### PR TITLE
 implement local storage backups

### DIFF
--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -156,7 +156,7 @@ func init() {
 	// postgresql flags
 	BackupCmd.Flags().StringVar(&pgOutFormat, "pg-out-format", "", "PostgresSQL output format [p (plain), c (custom), d (directory), t (tar)] ")
 	BackupCmd.Flags().StringVar(&pgCompressionAlgo, "pg-compression-algo", "", "PostgresSQL compression algorithm [gzip, lz4, zstd, none]")
-	BackupCmd.Flags().IntVar(&pgCompressionLevel, "pg-compression-level", 0, "PostgresSQL compression level [0-9]")
+	BackupCmd.Flags().IntVar(&pgCompressionLevel, "pg-compression-level", 1, "PostgresSQL compression level [1-9]")
 
 	// mongodb flags
 	BackupCmd.Flags().StringVarP(&uri, "uri", "", "mongodb://localhost:27017", "MongoDB URI")

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -68,6 +68,8 @@ var BackupCmd = &cobra.Command{
 				CompressionAlgorithm: pgCompressionAlgo,
 				CompressionLevel:     pgCompressionLevel,
 				AdditionalArgs:       additionalArgs,
+				StorageType:          storageType,
+				StoragePath:          localPath,
 			}
 
 			err = pg_dump.Backup(pda)
@@ -86,6 +88,8 @@ var BackupCmd = &cobra.Command{
 				Database:       database,
 				OutName:        output,
 				AdditionalArgs: additionalArgs,
+				StorageType:    storageType,
+				StoragePath:    localPath,
 			}
 
 			err = mysql_dump.Backup(mda)
@@ -104,6 +108,8 @@ var BackupCmd = &cobra.Command{
 				Database:       database,
 				OutName:        output,
 				AdditionalArgs: additionalArgs,
+				StorageType:    storageType,
+				StoragePath:    localPath,
 			}
 
 			err = mariadb_dump.Backup(mda)
@@ -122,6 +128,8 @@ var BackupCmd = &cobra.Command{
 				AdditionalArgs: additionalArgs,
 				OutName:        output,
 				Uri:            uri,
+				StorageType:    storageType,
+				StoragePath:    localPath,
 			}
 
 			err = mongo_dump.Backup(da)
@@ -136,9 +144,9 @@ var BackupCmd = &cobra.Command{
 func init() {
 	BackupCmd.Flags().StringVarP(&dbType, "type", "t", "", "Database type (mysql, postgres, mariadb, mongodb)")
 
-	BackupCmd.Flags().StringVarP(&host, "host", "H", "", "Database host")
+	BackupCmd.Flags().StringVarP(&host, "host", "H", "127.0.0.1", "Database host")
 	BackupCmd.Flags().StringVarP(&port, "port", "P", "", "Database port")
-	BackupCmd.Flags().StringVarP(&user, "user", "u", "", "Database user")
+	BackupCmd.Flags().StringVarP(&user, "user", "u", "root", "Database user")
 	BackupCmd.Flags().StringVarP(&password, "password", "p", "", "Database password")
 	BackupCmd.Flags().StringVarP(&database, "database", "d", "", "Database name")
 
@@ -155,8 +163,8 @@ func init() {
 
 	// storage flags
 	BackupCmd.Flags().StringVarP(&storageType, "storage", "s", "local", "storage type (local, s3, gcs, google-drive)")
-	BackupCmd.Flags().StringVarP(&output, "local-path", "", "", "Local path to store the backup")
-	BackupCmd.Flags().StringVarP(&localPath, "output", "o", "", "Output name")
+	BackupCmd.Flags().StringVarP(&localPath, "local-path", "", "", "Local path to store the backup")
+	BackupCmd.Flags().StringVarP(&output, "output", "o", "", "Output name")
 
 	// required args
 	err := BackupCmd.MarkFlagRequired("type")

--- a/internal/backup/sql/connectivity.go
+++ b/internal/backup/sql/connectivity.go
@@ -19,11 +19,12 @@ func CheckConnectivity(dbType, host, port, user, password, database string) (boo
 	switch scheme {
 	case "mysql":
 		cfg := (&mysql.Config{
-			User:   user,
-			Passwd: password,
-			Net:    "tcp",
-			Addr:   fmt.Sprintf("%s:%s", host, port),
-			DBName: database,
+			User:                 user,
+			Passwd:               password,
+			Net:                  "tcp",
+			Addr:                 fmt.Sprintf("%s:%s", host, port),
+			DBName:               database,
+			AllowNativePasswords: true,
 		}).FormatDSN()
 
 		if err := PingSqlDatabase("mysql", cfg); err != nil {

--- a/internal/storage/local/folder.go
+++ b/internal/storage/local/folder.go
@@ -6,7 +6,13 @@ import (
 	"path/filepath"
 )
 
-// determineLocalBackupPath returns an absolute path for the local backup directory.
+// determineLocalBackupPath determines the local backup directory path.
+// If the provided path is empty, it checks the environment variable
+// BACKUP_DIRECTORY. If that is also not set, it defaults to a directory
+// named "sentinel" in the user's home directory. The function returns
+// the absolute path of the determined backup directory.
+// Returns an error if the home directory cannot be retrieved
+// or if converting to an absolute path fails.
 func determineLocalBackupPath(path string) (string, error) {
 	if path == "" {
 		if envDir := os.Getenv("BACKUP_DIRECTORY"); envDir != "" {
@@ -20,7 +26,6 @@ func determineLocalBackupPath(path string) (string, error) {
 		}
 	}
 
-	// convert the path to an absolute path
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return "", fmt.Errorf("failed to get absolute path: %w", err)
@@ -29,7 +34,10 @@ func determineLocalBackupPath(path string) (string, error) {
 	return absPath, err
 }
 
-// createDirIfNotExists checks if the directory exists and creates it if it doesn't.
+// createDirIfNotExists checks if the specified directory exists and creates it
+// if it does not. This function ensures that the necessary directory structure
+// is available for storing backups. Returns an error if there is an issue
+// checking the directory's existence or if creating the directory fails.
 func createDirIfNotExists(path string) error {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		if err := os.MkdirAll(path, os.ModePerm); err != nil {

--- a/internal/storage/local/local.go
+++ b/internal/storage/local/local.go
@@ -7,10 +7,15 @@ import (
 	"path/filepath"
 )
 
-// LocalStorage is a struct that implements the Storage interface
+// LocalStorage is a struct that implements the Storage interface.
 type LocalStorage struct{}
 
-// GetBackupPath returns the path to the local backup directory
+// GetBackupPath returns the path where the backup will be stored.
+// This implementation is part of the LocalStorage struct, which
+// manages local backup paths. The function determines the local backup
+// directory path and ensures that the directory exists, creating it if necessary.
+// Returns the determined backup path or an error if path determination
+// or directory creation fails.
 func (ls *LocalStorage) GetBackupPath(path string) (string, error) {
 	// Determine the local backup directory path, using default if necessary
 	localBackupPath, err := determineLocalBackupPath(path)
@@ -26,6 +31,14 @@ func (ls *LocalStorage) GetBackupPath(path string) (string, error) {
 	return localBackupPath, err
 }
 
+// WriteBackup writes the backup data to a specified path.
+// This implementation is part of the LocalStorage struct, which contains
+// the logic for managing backups on the local file system.
+// If the provided path is a directory, the function will copy the
+// contents of the backup data (as multiple files) into that directory.
+// If the path is a file, it creates the file and writes the backup data to it.
+// Returns an error if the path is invalid, if the directory cannot be
+// accessed, or if file operations fail.
 func (ls *LocalStorage) WriteBackup(data []byte, path string) error {
 	if isDirectory(path) {
 		tmpDir := path
@@ -39,9 +52,16 @@ func (ls *LocalStorage) WriteBackup(data []byte, path string) error {
 			srcPath := filepath.Join(tmpDir, file.Name())
 			destPath := filepath.Join(path, file.Name())
 
-			if err := copyFile(srcPath, destPath); err != nil {
-				return fmt.Errorf("failed to copy file %s: %w", file.Name(), err)
+			if file.IsDir() {
+				err = copyDir(srcPath, destPath)
+			} else {
+				err = copyFile(srcPath, destPath)
 			}
+
+			if err != nil {
+				return fmt.Errorf("failed to copy file: %w", err)
+			}
+
 		}
 
 		fmt.Printf("Backup successfully written to %s\n", path)
@@ -49,7 +69,7 @@ func (ls *LocalStorage) WriteBackup(data []byte, path string) error {
 		return nil
 	}
 
-	file, err := os.Create(path) // create the file
+	file, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)
 	}
@@ -65,6 +85,10 @@ func (ls *LocalStorage) WriteBackup(data []byte, path string) error {
 	return nil
 }
 
+// isDirectory checks if a given path points to a directory.
+// It returns true if the path is a directory, false otherwise.
+// This function is useful to determine whether a path should be
+// treated as a directory (for copying multiple files) or as a file.
 func isDirectory(path string) bool {
 	info, err := os.Stat(path)
 	if err != nil {
@@ -73,6 +97,10 @@ func isDirectory(path string) bool {
 	return info.IsDir()
 }
 
+// copyFile copies a file from the source to the destination.
+// This function is useful to copy backup files for Postgres databases
+// when the output format is a directory. Each file is copied individually
+// to the destination directory.
 func copyFile(src, dest string) error {
 	srcFile, err := os.Open(src)
 	if err != nil {
@@ -89,6 +117,38 @@ func copyFile(src, dest string) error {
 	_, err = io.Copy(destFile, srcFile)
 	if err != nil {
 		return fmt.Errorf("failed to copy file: %w", err)
+	}
+
+	return nil
+}
+
+// copyDir recursively copies a directory from the source to the destination.
+// This function is useful when performing MongoDump backup of all databases,
+// as Mongo exports each database to a separate directory.
+func copyDir(srcDir, destDir string) error {
+	err := os.MkdirAll(destDir, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("failed to create destination directory: %w", err)
+	}
+
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return fmt.Errorf("failed to read source directory %s:  %w", srcDir, err)
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(srcDir, entry.Name())
+		destPath := filepath.Join(destDir, entry.Name())
+
+		if entry.IsDir() {
+			if err := copyDir(srcPath, destPath); err != nil {
+				return err
+			}
+		} else {
+			if err := copyFile(srcPath, destPath); err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil

--- a/internal/utils/default.go
+++ b/internal/utils/default.go
@@ -21,9 +21,13 @@ func DefaultBackupOutName() string {
 }
 
 func FinalOutName(outName string) string {
-	ext := DefaultValue(filepath.Ext(outName), ".sql")
+	ext := filepath.Ext(outName)
 
-	return DefaultValue(outName, DefaultBackupOutName()) + ext
+	if ext == "" {
+		return DefaultValue(outName, DefaultBackupOutName()) + ".sql"
+	}
+
+	return outName
 }
 
 func FullPath(path, fileName string) string {

--- a/internal/utils/default.go
+++ b/internal/utils/default.go
@@ -16,8 +16,7 @@ func DefaultValue(value, defaultValue string) string {
 
 // DefaultBackupOutName returns the default backup output name
 func DefaultBackupOutName() string {
-	timestamp := time.Now().Format("2006-01-02T15-04-05") // format the current time
-	return fmt.Sprintf("SENTINEL_%s", timestamp)
+	return fmt.Sprintf("SENTINEL_%s", time.Now().Format("2006-01-02T15-04-05"))
 }
 
 func FinalOutName(outName string) string {

--- a/pkg/backup/mariadb_dump/args_builder.go
+++ b/pkg/backup/mariadb_dump/args_builder.go
@@ -23,8 +23,9 @@ func ArgsBuilder(mda *MariaDBDumpArgs) ([]string, error) {
 		return nil, err
 	}
 
-	mda.Host = utils.DefaultValue(mda.Host, "127.0.0.1") // set the default host to 127.0.0.1 if not provided
-	mda.Port = utils.DefaultValue(mda.Port, "3306")      // set the default port to 3306 if not provided
+	// set the default host and port if not provided
+	mda.Host = utils.DefaultValue(mda.Host, "127.0.0.1")
+	mda.Port = utils.DefaultValue(mda.Port, "3306")
 
 	args := []string{
 		"--host=" + mda.Host,

--- a/pkg/backup/mariadb_dump/mariadb_dump.go
+++ b/pkg/backup/mariadb_dump/mariadb_dump.go
@@ -53,10 +53,10 @@ func Backup(mda *MariaDBDumpArgs) error {
 	fullPath := utils.FullPath(backupPath, mda.OutName)
 
 	if err := storageHandler.WriteBackup(stdOut.Bytes(), fullPath); err != nil {
-		return err
+		return fmt.Errorf("failed to write backup to storage - %w", err)
 	}
 
-	fmt.Printf("Backup file created at %s\n", fullPath)
+	fmt.Printf("Backup complete !\n")
 
 	return nil
 }

--- a/pkg/backup/mongo_dump/args_builder.go
+++ b/pkg/backup/mongo_dump/args_builder.go
@@ -14,9 +14,13 @@ type DumpMongoArgs struct {
 	StoragePath    string // Storage path for the backup file
 }
 
-func argsBuilder(da *DumpMongoArgs) ([]string, error) {
+func argsBuilder(da *DumpMongoArgs, backupPath string) ([]string, error) {
 	// set default values
 	da.Uri = utils.DefaultValue(da.Uri, "mongodb://localhost:27017")
+
+	// handle output name
+	outName := utils.DefaultValue(da.OutName, utils.DefaultBackupOutName())
+	da.OutName = utils.FullPath(backupPath, outName)
 
 	args := []string{
 		"--uri=" + da.Uri,

--- a/pkg/backup/mongo_dump/mongo_dump.go
+++ b/pkg/backup/mongo_dump/mongo_dump.go
@@ -5,41 +5,32 @@ import (
 	"fmt"
 	"github.com/denisakp/sentinel/internal/backup/mongo"
 	"github.com/denisakp/sentinel/internal/storage"
-	"github.com/denisakp/sentinel/internal/utils"
 	"os/exec"
-	"time"
 )
 
 // Backup backs up a MongoDB database using mongo_dump
 func Backup(da *DumpMongoArgs) error {
-	args, err := argsBuilder(da) // build mongo_dump arguments
-	if err != nil {
-		return fmt.Errorf("failed to build arguments: %w", err)
-	}
-
-	if err := validateRequiredArgs(da); err != nil {
-		return err
-	}
-
-	// check connectivity
-	if err := mongo.CheckConnectivity(da.Uri); err != nil {
-		return fmt.Errorf("failed to check connectivity: %w", err)
-	}
-
 	// get the storage handler
 	storageHandler, err := storage.NewStorage(da.StorageType)
 	if err != nil {
 		return err
 	}
 
+	// get the backup path
 	backupPath, err := storageHandler.GetBackupPath(da.StoragePath)
 	if err != nil {
 		return err
 	}
 
-	da.OutName = utils.DefaultValue(da.OutName, fmt.Sprintf("SENTINEL_%s", time.Now().Format("2006-01-02-15-04-05"))) // set default output name
+	args, err := argsBuilder(da, backupPath) // build mongo_dump arguments
+	if err != nil {
+		return fmt.Errorf("failed to build mongo_dump arguments: %w", err)
+	}
 
-	da.OutName = utils.FullPath(backupPath, da.OutName) // set the backup file path
+	// check connectivity
+	if err := mongo.CheckConnectivity(da.Uri); err != nil {
+		return err
+	}
 
 	cmd := exec.Command("mongodump", args...) // run mongo_dump command
 
@@ -58,10 +49,10 @@ func Backup(da *DumpMongoArgs) error {
 	}
 
 	if err := storageHandler.WriteBackup(stdOut.Bytes(), da.OutName); err != nil {
-		return err
+		return fmt.Errorf("failed to write backup to storage: %w", err)
 	}
 
-	fmt.Printf("Backup completed successfully %s \n", da.OutName)
+	fmt.Printf("Backup complete !\n")
 
 	return nil
 }

--- a/pkg/backup/mysql_dump/mysql_dump.go
+++ b/pkg/backup/mysql_dump/mysql_dump.go
@@ -57,7 +57,7 @@ func Backup(mda *MySqlDumpArgs) error {
 
 	// write backup to storage
 	if err := storageHandler.WriteBackup(stdOut.Bytes(), fullPath); err != nil {
-		return err
+		return fmt.Errorf("failed to write backup to storage - %w", err)
 	}
 
 	fmt.Printf("Backup file created at %s\n", fullPath)

--- a/pkg/backup/mysql_dump/mysql_dump.go
+++ b/pkg/backup/mysql_dump/mysql_dump.go
@@ -60,7 +60,7 @@ func Backup(mda *MySqlDumpArgs) error {
 		return fmt.Errorf("failed to write backup to storage - %w", err)
 	}
 
-	fmt.Printf("Backup file created at %s\n", fullPath)
+	fmt.Printf("Backup complete !\n")
 
 	return nil
 }

--- a/pkg/backup/pg_dump/validator.go
+++ b/pkg/backup/pg_dump/validator.go
@@ -35,7 +35,7 @@ func validatePgCompressionAlgorithm(algorithm string) error {
 }
 
 func validatePgCompressionLevel(level int) error {
-	if level < 0 || level > 9 {
+	if level != -1 && (level < 1 || level > 9) {
 		return fmt.Errorf("invalid compression level: %d", level)
 	}
 


### PR DESCRIPTION
resolve #11 

- [x] add a flag in the CLI for specifying the local storage path (e.g., --storage /home/user/backups)
- [x] implement functionality to save backup files to the specified local directory
- [x] insure that the file naming and compression options are applied

- [x] users can specify a local directory for backups via CLI
- [x] backups are successfully saved in the correct format with the appropriate compression (if any)
- [x] clear error handling for invalid paths or permissions issues.