### PR TITLE
ci(lint): enforce ADR 0001 hexagonal layering via golangci-lint depguard (spec 039 / PRD 25)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.24'
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v7   # v7 required for golangci-lint v2 (v6 only supports v1)
         with:
           version: v2.12.2   # golangci-lint v2 — required to parse the version:"2" .golangci.yml (was v1.61.0)
           args: --timeout=5m

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,13 +1,9 @@
 name: Lint
 on:
-  push:
-    branches:
-      - main
-      - 1.x
+  push: {}                # feature-branch feedback before a PR is opened (spec 039 FR-007/Q4)
   pull_request:
     branches:
-      - main
-      - 1.x
+      - develop           # gate merges into the active integration line (spec 039 FR-007)
   workflow_dispatch:
 jobs:
   lint:
@@ -19,5 +15,5 @@ jobs:
           go-version: '1.24'
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61.0
+          version: v2.12.2   # golangci-lint v2 — required to parse the version:"2" .golangci.yml (was v1.61.0)
           args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ output:
 linters:
   default: none
   enable:
+    - depguard
     - forbidigo
     - govet
   settings:
@@ -16,6 +17,92 @@ linters:
         - pattern: ^os\.Exit$
           msg: do not exit from command bodies; return an error and let main.go map it. See internal/cli/exit_codes.go.
       analyze-types: true
+    # ADR 0001 hexagonal layering (adapters -> ports <- domain), enforced per spec 039 / PRD 25.
+    # Each documented exception carries a `# spec NNN` / `desc` provenance note (FR-012).
+    depguard:
+      rules:
+        # internal/domain is pure. Applies to production AND test files (spec 039 Q1):
+        # the `internal/ports` prefix covers the *testing fakes domain tests use.
+        domain-pure:
+          list-mode: strict
+          files:
+            - "**/internal/domain/**"
+          allow:
+            - $gostd
+            - github.com/denisakp/sentinel/internal/ports        # subtree: ports/*testing fakes (spec 038)
+            - github.com/denisakp/sentinel/internal/sanitize
+            - github.com/denisakp/sentinel/internal/domain
+            - github.com/google/shlex                             # spec 037 pure-tokenizer precedent
+        # Ports declare interfaces; only the documented ports -> domain/retention exception is allowed.
+        # Top-level *.go only: conformance_test.go imports every adapter by design, and the *testing
+        # helper sub-packages import third-party test libs (testcontainers) — both excluded.
+        ports-mostly-pure:
+          list-mode: strict
+          files:
+            - "**/internal/ports/*.go"
+            - "!**/*_test.go"
+          allow:
+            - $gostd
+            - github.com/denisakp/sentinel/internal/ports
+            - github.com/denisakp/sentinel/internal/domain/retention  # spec 038 Q2 (Recorder retention methods)
+        # Sibling dump adapters must not import each other. dump/* -> db_probe (spec 037) is outside
+        # the deny prefix, so it stays allowed under lax.
+        adapter-dump-axis:
+          list-mode: lax
+          files:
+            - "**/internal/adapters/dump/pg/**"
+            - "**/internal/adapters/dump/mysql/**"
+            - "**/internal/adapters/dump/mariadb/**"
+            - "**/internal/adapters/dump/mongo/**"
+            - "!**/*_test.go"
+          deny:
+            - pkg: github.com/denisakp/sentinel/internal/adapters/dump
+              desc: "sibling dump adapters must not import each other (ADR 0001 axis isolation)"
+        # Sibling restore adapters must not import each other. restore/mongo -> dump/mongo (Mongo PEM,
+        # spec 036) is cross-axis, outside this deny prefix -> allowed.
+        adapter-restore-axis:
+          list-mode: lax
+          files:
+            - "**/internal/adapters/restore/pg/**"
+            - "**/internal/adapters/restore/mysql/**"
+            - "**/internal/adapters/restore/mariadb/**"
+            - "**/internal/adapters/restore/mongo/**"
+            - "!**/*_test.go"
+          deny:
+            - pkg: github.com/denisakp/sentinel/internal/adapters/restore
+              desc: "sibling restore adapters must not import each other (ADR 0001 axis isolation)"
+        # Sibling storage adapters must not import each other. registry.go (spec 029) is at the storage
+        # package root, outside these engine-dir globs -> not linted.
+        adapter-storage-axis:
+          list-mode: lax
+          files:
+            - "**/internal/adapters/storage/local/**"
+            - "**/internal/adapters/storage/s3/**"
+            - "**/internal/adapters/storage/gcs/**"
+            - "**/internal/adapters/storage/gdrive/**"
+            - "**/internal/adapters/storage/azure/**"
+            - "!**/*_test.go"
+          deny:
+            - pkg: github.com/denisakp/sentinel/internal/adapters/storage
+              desc: "sibling storage adapters must not import each other (ADR 0001 axis isolation)"
+        # config/marshal.go may import ONLY the enumerated dump/restore/storage adapters (spec 035/036
+        # Q1). strict => a new un-listed adapter import fails visibly (FR-004).
+        config-marshal:
+          list-mode: strict
+          files:
+            - "**/internal/config/marshal.go"
+          allow:
+            - $gostd
+            - github.com/denisakp/sentinel/internal/adapters/dump/pg
+            - github.com/denisakp/sentinel/internal/adapters/dump/mysql
+            - github.com/denisakp/sentinel/internal/adapters/dump/mariadb
+            - github.com/denisakp/sentinel/internal/adapters/dump/mongo
+            - github.com/denisakp/sentinel/internal/adapters/restore/pg
+            - github.com/denisakp/sentinel/internal/adapters/restore/mysql
+            - github.com/denisakp/sentinel/internal/adapters/restore/mariadb
+            - github.com/denisakp/sentinel/internal/adapters/restore/mongo
+            - github.com/denisakp/sentinel/internal/adapters/restore/incremental/mysqlbinlog
+            - github.com/denisakp/sentinel/internal/adapters/storage
   exclusions:
     generated: lax
     presets:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Top-level commands: `backup`, `schedule`, `restore`, `monitor`, `retention`, `co
 - `internal/adapters/restore/{pg,mysql,mariadb,mongo}/` — engine-specific restore adapters (spec 036). Each package exposes a zero-field `Builder` satisfying `ports.RestoreBuilder` and keeps its existing `Restore` entry point + `RestoreArgs` type (mongo additionally has `OplogReplayArgs` + `ReplayOplog`). Compile-time port assertions in `conformance.go`. Port types `RestoreBuilder`/`RestoreBuildContext`/`RestoreBuildResult`/`RestoreOptions` live in `internal/ports/restore.go`.
 
 ### Import-cycle rule
-Hexagonal layering per ADR 0001: **`adapters → ports ← domain`**. Adapter sub-packages under `internal/adapters/storage/{local,s3,gcs,gdrive,azure}/`, `internal/adapters/dump/{pg,mysql,mariadb,mongo}/`, and `internal/adapters/restore/{pg,mysql,mariadb,mongo}/` MUST NOT import each other. Storage registry imports every storage sibling. Dump and restore adapters don't import sibling adapters within their axis. Domain code reaches concrete storage backends only through `storage.NewBackend(...)` returning `ports.StorageBackend`. Domain code reaches dumps through `ports.DumpBuilder` and restores through `ports.RestoreBuilder` (each engine adapter exposes a `Builder` value).
+**Enforced in CI via `.golangci.yml` (depguard rule groups: `domain-pure`, `ports-mostly-pure`, `adapter-{dump,restore,storage}-axis`, `config-marshal`); see spec 039 / PRD 25. Run locally with `make lint`.** Hexagonal layering per ADR 0001: **`adapters → ports ← domain`**. Adapter sub-packages under `internal/adapters/storage/{local,s3,gcs,gdrive,azure}/`, `internal/adapters/dump/{pg,mysql,mariadb,mongo}/`, and `internal/adapters/restore/{pg,mysql,mariadb,mongo}/` MUST NOT import each other. Storage registry imports every storage sibling. Dump and restore adapters don't import sibling adapters within their axis. Domain code reaches concrete storage backends only through `storage.NewBackend(...)` returning `ports.StorageBackend`. Domain code reaches dumps through `ports.DumpBuilder` and restores through `ports.RestoreBuilder` (each engine adapter exposes a `Builder` value).
 
 **Known narrow exceptions** (pre-existing; called out so they aren't flagged as new debt):
 - `internal/config/marshal.go` imports the four dump adapter packages for `*DumpArgs` type names referenced in `Build*DumpArgs` return types (spec 035 clarification Q1) and the four restore adapter packages for `RestoreArgs`/`OplogReplayArgs` type names referenced in `Build*RestoreArgs`/`BuildMongoOplogReplayArgs` return types (spec 036 clarification Q1). Future spec may introduce `ports.DumpArgsFactory`/`RestoreArgsFactory` to remove the direction.
@@ -113,5 +113,5 @@ Every new feature MUST run these skills in this exact order — no skipping, no 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/038-domain-extraction-phase2/plan.md`
+`specs/039-hexagonal-lint-enforcement/plan.md`
 <!-- SPECKIT END -->

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ NETWORK     := sentinel
 IMAGE       := sentinel-dev:local
 MONGO_NAME  := sentinel-mongo
 
-.PHONY: e2e e2e-quick infra-up infra-down build-image clean help lint-redact-stderr
+.PHONY: e2e e2e-quick infra-up infra-down build-image clean help lint-redact-stderr lint
 
 help:
 	@echo "Targets:"
@@ -61,6 +61,12 @@ lint-redact-stderr:
 		exit 1; \
 	fi; \
 	echo "[lint-redact-stderr] OK"
+
+## Run golangci-lint (ADR 0001 hexagonal depguard rules + forbidigo + govet) — same config CI uses.
+## Spec 039 / PRD 25. In the Claude Code dev shell a bare `golangci-lint` is rewritten by the rtk
+## hook (injects --out-format, rejected by v2); make runs it as a subprocess so it is unaffected.
+lint:
+	golangci-lint run --timeout 5m
 
 # ---------------------------------------------------------------------------
 # Internal targets


### PR DESCRIPTION
Closes #63. Delivers **PRD 25** — closes the ADR 0001 hexagonal-migration lineage (deferred by spec 037 FR-020 + spec 038 FR-018).

## What

Makes the hexagonal layering rule (`adapters → ports ← domain`) a machine-checked CI gate instead of CLAUDE.md prose + a manual grep audit.

| File | Change |
|------|--------|
| `.golangci.yml` | Add `depguard` with 6 rule groups — `domain-pure`, `ports-mostly-pure`, `adapter-{dump,restore,storage}-axis`, `config-marshal` — each documented import exception carrying a `# spec NNN` provenance comment. `forbidigo` + `govet` + exclusions unchanged. |
| `.github/workflows/lint.yml` | **Fix the broken workflow**: triggers `main`/`1.x` → `develop` (PR gate) + `push` (feature-branch feedback); `golangci-lint-action` `v1.61.0` → `v2.12.2` (v1 could not parse the `version:"2"` config). |
| `Makefile` | Add `make lint` (same config as CI). |
| `CLAUDE.md` | Note CI enforcement in the Import-cycle rule section. |

**No `.go` files change.**

## Rule groups

- **domain-pure** (strict): `internal/domain/**` may import only stdlib, `internal/ports` (subtree — covers `*testing` fakes), `internal/sanitize`, sibling `internal/domain/*`, `google/shlex`.
- **ports-mostly-pure** (strict, top-level `*.go` non-test): stdlib + `internal/domain/retention` only. Excludes `conformance_test.go` and the `*testing` fakes by design.
- **adapter-{dump,restore,storage}-axis** (lax): sibling engine adapters can't import each other; documented cross-axis / db_probe / registry / runtime exceptions stay legal.
- **config-marshal** (strict): only the 10 enumerated dump/restore/storage adapters — a new un-listed adapter import fails visibly.

## Verification

- `golangci-lint run` → **0 issues** at branch tip (no baseline / grandfathering).
- Deliberate violations in domain-pure, adapter-dump-axis, and config-marshal are each caught with a clear message (reverted).
- `go build ./...` Success · `go vet ./...` clean · `go test ./...` green · `make lint` 0 issues.
- Existing `forbidigo` (`log.Fatal`/`os.Exit`) + `govet` still fire.

> This PR also un-breaks the pre-existing Lint CI, which was pinned to golangci-lint v1 against a v2 config and triggered only on the dead `main` branch.
