### PR TITLE
refactor(dump): dedupe mysql/mariadb args builders via shared mysqlargs core (spec 044 / PRD 15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Top-level commands: `backup`, `schedule`, `restore`, `monitor`, `retention`, `co
 - `internal/adapters/restore/chain_assembler/` — `ports.ChainAssembler` adapter over `pg_combinebackup` (spec 038 FR-013); conformance assertion + `combinePostgresChain` test seam. Test fake: `internal/ports/chainassemblertesting.MockAssembler`.
 - `internal/utils/` — shared helpers (`file.go`, `time.go`, `scheduled_output.go`)
 - `internal/version/`
-- `internal/adapters/dump/{pg,mysql,mariadb,mongo}/` — engine-specific dump adapters (spec 035). Each package exposes a zero-field `Builder` satisfying `ports.DumpBuilder` and keeps its existing `Backup`/`BackupAll` entry points + `*DumpArgs` types. Compile-time port assertions in `conformance.go`. Port types `DumpBuilder`/`DumpCleanup`/`BuildContext`/`BuildResult` live in `internal/ports/dump.go`. (Mongo PEM lifecycle moved out to the neutral `internal/adapters/mongo_tls/` by spec 042 / PRD 29.)
+- `internal/adapters/dump/{pg,mysql,mariadb,mongo}/` — engine-specific dump adapters (spec 035). Each package exposes a zero-field `Builder` satisfying `ports.DumpBuilder` and keeps its existing `Backup`/`BackupAll` entry points + `*DumpArgs` types. Compile-time port assertions in `conformance.go`. Port types `DumpBuilder`/`DumpCleanup`/`BuildContext`/`BuildResult` live in `internal/ports/dump.go`. (Mongo PEM lifecycle moved out to the neutral `internal/adapters/mongo_tls/` by spec 042 / PRD 29. The mysql + mariadb args-builder body + validator are shared via `internal/adapters/mysqlargs.BuildArgs(Input, Flavor)` — a sibling outside `dump/` so the axis rule allows both engines to import it — by spec 044 / PRD 15; each engine's `argsBuilder` delegates with its `Flavor`. Dump builders are constructed via `internal/adapters/dump/registry.go::NewBuilder(engine, prober)` with an injected `ports.DBProber`, spec 043 / PRD 30.)
 - `internal/adapters/restore/incremental/{mysqlbinlog,pgcombine}/` — external-binary wrappers for incremental replay (spec 035). `pgcombine` is reached only through `internal/adapters/restore/chain_assembler/` (`ports.ChainAssembler`); `mysqlbinlog` is consumed by `internal/cli/backup_factory.go` (archive) and `internal/adapters/restore/runtime/` (replay).
 - `internal/adapters/restore/{pg,mysql,mariadb,mongo}/` — engine-specific restore adapters (spec 036). Each package exposes a zero-field `Builder` satisfying `ports.RestoreBuilder` and keeps its existing `Restore` entry point + `RestoreArgs` type (mongo additionally has `OplogReplayArgs` + `ReplayOplog`). Compile-time port assertions in `conformance.go`. Port types `RestoreBuilder`/`RestoreBuildContext`/`RestoreBuildResult`/`RestoreOptions` live in `internal/ports/restore.go`.
 
@@ -113,5 +113,5 @@ Every new feature MUST run these skills in this exact order — no skipping, no 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/043-dbprober-injection-dump-adapters/plan.md`
+`specs/044-dedupe-mysql-mariadb-args/plan.md`
 <!-- SPECKIT END -->

--- a/internal/adapters/dump/mariadb/args_builder.go
+++ b/internal/adapters/dump/mariadb/args_builder.go
@@ -1,13 +1,9 @@
 package mariadb
 
 import (
-	"fmt"
-
-	backup "github.com/denisakp/sentinel/internal/domain/backup"
+	"github.com/denisakp/sentinel/internal/adapters/mysqlargs"
 	"github.com/denisakp/sentinel/internal/adapters/storage"
-	internaltls "github.com/denisakp/sentinel/internal/adapters/tls"
 	"github.com/denisakp/sentinel/internal/ports"
-	"github.com/denisakp/sentinel/internal/utils"
 )
 
 type MariaDBDumpArgs struct {
@@ -24,35 +20,17 @@ type MariaDBDumpArgs struct {
 // engineOptions satisfies ports.EngineOptions.
 func (*MariaDBDumpArgs) IsEngineOptions() {}
 
-// ArgsBuilder builds the arguments for the mariadb_dump command
-func ArgsBuilder(mda *MariaDBDumpArgs) ([]string, error) {
-	if err := validateRequiredArgs(mda); err != nil {
-		return nil, err
-	}
-
-	// set the default host and port if not provided
-	mda.Host = utils.DefaultValue(mda.Host, "127.0.0.1")
-	mda.Port = utils.DefaultValue(mda.Port, "3306")
-
-	// build the required arguments
-	args := []string{
-		fmt.Sprintf("--host=%s", mda.Host),
-		fmt.Sprintf("--port=%s", mda.Port),
-		fmt.Sprintf("--user=%s", mda.Username),
-	}
-
-	if mda.AdditionalArgs != "" {
-		additionalArgs, err := backup.ParseAdditionalArgs(mda.AdditionalArgs)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse additional_args: %w", err)
-		}
-		args = append(args, additionalArgs...)
-	} // add additional arguments if provided
-
-	args = append(args, internaltls.BuildTLSArgs("mariadb", mda.TLS)...)
-
-	args = backup.RemoveArgsDuplicate(args) // remove duplicated arguments
-	args = append(args, mda.Database)       // add the database name to the arguments
-
-	return args, nil
+// argsBuilder builds the mariadb-dump arguments by delegating to the shared
+// MySQL-family core with the MariaDB flavor (spec 044 / PRD 15). MariaDB does
+// not emit --skip-password on an empty password.
+func argsBuilder(mda *MariaDBDumpArgs) ([]string, error) {
+	return mysqlargs.BuildArgs(mysqlargs.Input{
+		Host:           mda.Host,
+		Port:           mda.Port,
+		Username:       mda.Username,
+		Password:       mda.Password,
+		Database:       mda.Database,
+		AdditionalArgs: mda.AdditionalArgs,
+		TLS:            mda.TLS,
+	}, mysqlargs.FlavorMariaDB)
 }

--- a/internal/adapters/dump/mariadb/args_builder_test.go
+++ b/internal/adapters/dump/mariadb/args_builder_test.go
@@ -66,13 +66,13 @@ func TestArgsBuilder(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ArgsBuilder(tt.args)
+			got, err := argsBuilder(tt.args)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ArgsBuilder() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("argsBuilder() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ArgsBuilder() got = %v, want %v", got, tt.want)
+				t.Errorf("argsBuilder() got = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -86,7 +86,7 @@ func TestArgsBuilderNeverContainsPassword(t *testing.T) {
 		{Username: "root", Database: "test", Password: "secret", Host: "h", Port: "3306"},
 	}
 	for i, c := range cases {
-		got, err := ArgsBuilder(c)
+		got, err := argsBuilder(c)
 		if err != nil {
 			t.Fatalf("case %d: %v", i, err)
 		}

--- a/internal/adapters/dump/mariadb/env_injection_test.go
+++ b/internal/adapters/dump/mariadb/env_injection_test.go
@@ -10,7 +10,7 @@ import (
 // buildExecCmd mirrors the construction inside Backup so callers can assert env
 // shape without driving a real subprocess.
 func buildExecCmd(mda *MariaDBDumpArgs) (*exec.Cmd, error) {
-	args, err := ArgsBuilder(mda)
+	args, err := argsBuilder(mda)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapters/dump/mariadb/mariadb_dump.go
+++ b/internal/adapters/dump/mariadb/mariadb_dump.go
@@ -20,7 +20,7 @@ import (
 // probe uses the "mysql" scheme, as the prior checkConnectivity call did.
 func Backup(prober ports.DBProber, mda *MariaDBDumpArgs) (string, error) {
 	// Validate the required arguments
-	args, err := ArgsBuilder(mda)
+	args, err := argsBuilder(mda)
 	if err != nil {
 		return "", fmt.Errorf("failed to build arguments: %w", err)
 	}

--- a/internal/adapters/dump/mariadb/validator.go
+++ b/internal/adapters/dump/mariadb/validator.go
@@ -1,14 +1,9 @@
 package mariadb
 
-import "fmt"
+import "github.com/denisakp/sentinel/internal/adapters/mysqlargs"
 
+// validateRequiredArgs delegates to the shared MySQL-family validator
+// (spec 044 / PRD 15).
 func validateRequiredArgs(mda *MariaDBDumpArgs) error {
-	if mda.Database == "" {
-		return fmt.Errorf("database name is missing")
-	}
-
-	if mda.Username == "" {
-		return fmt.Errorf("username is missing")
-	}
-	return nil
+	return mysqlargs.ValidateRequired(mda.Username, mda.Database)
 }

--- a/internal/adapters/dump/mysql/args_builder.go
+++ b/internal/adapters/dump/mysql/args_builder.go
@@ -1,13 +1,9 @@
 package mysql
 
 import (
-	"fmt"
-
-	backup "github.com/denisakp/sentinel/internal/domain/backup"
+	"github.com/denisakp/sentinel/internal/adapters/mysqlargs"
 	"github.com/denisakp/sentinel/internal/adapters/storage"
-	internaltls "github.com/denisakp/sentinel/internal/adapters/tls"
 	"github.com/denisakp/sentinel/internal/ports"
-	"github.com/denisakp/sentinel/internal/utils"
 )
 
 type MySqlDumpArgs struct {
@@ -24,37 +20,17 @@ type MySqlDumpArgs struct {
 // engineOptions satisfies ports.EngineOptions.
 func (*MySqlDumpArgs) IsEngineOptions() {}
 
-// argsBuilder builds the arguments for the mysql_dump command
+// argsBuilder builds the mysqldump arguments by delegating to the shared
+// MySQL-family core with the MySQL flavor (spec 044 / PRD 15). MySQL emits
+// --skip-password on an empty password.
 func argsBuilder(mda *MySqlDumpArgs) ([]string, error) {
-	if err := validateRequiredArgs(mda); err != nil {
-		return nil, err
-	}
-
-	mda.Host = utils.DefaultValue(mda.Host, "127.0.0.1") // set the default host to 127.0.0.1 if not provided
-	mda.Port = utils.DefaultValue(mda.Port, "3306")      // set the default port to 3306 if not provided
-
-	args := []string{
-		fmt.Sprintf("--host=%s", mda.Host),
-		fmt.Sprintf("--port=%s", mda.Port),
-		fmt.Sprintf("--user=%s", mda.Username),
-	}
-
-	if mda.Password == "" {
-		args = append(args, "--skip-password")
-	} // skip password prompt if password is not provided
-
-	if mda.AdditionalArgs != "" {
-		additionalArgs, err := backup.ParseAdditionalArgs(mda.AdditionalArgs)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse additional_args: %w", err)
-		}
-		args = append(args, additionalArgs...)
-	} // handle additional arguments
-
-	args = append(args, internaltls.BuildTLSArgs("mysql", mda.TLS)...)
-
-	args = backup.RemoveArgsDuplicate(args) // remove duplicate arguments
-	args = append(args, mda.Database)       // add database name
-
-	return args, nil
+	return mysqlargs.BuildArgs(mysqlargs.Input{
+		Host:           mda.Host,
+		Port:           mda.Port,
+		Username:       mda.Username,
+		Password:       mda.Password,
+		Database:       mda.Database,
+		AdditionalArgs: mda.AdditionalArgs,
+		TLS:            mda.TLS,
+	}, mysqlargs.FlavorMySQL)
 }

--- a/internal/adapters/dump/mysql/validator.go
+++ b/internal/adapters/dump/mysql/validator.go
@@ -1,16 +1,9 @@
 package mysql
 
-import "fmt"
+import "github.com/denisakp/sentinel/internal/adapters/mysqlargs"
 
-// validateRequiredArgs validates required arguments for MySQL dump
+// validateRequiredArgs delegates to the shared MySQL-family validator
+// (spec 044 / PRD 15).
 func validateRequiredArgs(mda *MySqlDumpArgs) error {
-	if mda.Database == "" {
-		return fmt.Errorf("database name is missing")
-	}
-
-	if mda.Username == "" {
-		return fmt.Errorf("username is missing")
-	}
-
-	return nil
+	return mysqlargs.ValidateRequired(mda.Username, mda.Database)
 }

--- a/internal/adapters/mysqlargs/core.go
+++ b/internal/adapters/mysqlargs/core.go
@@ -1,0 +1,86 @@
+// Package mysqlargs holds the shared MySQL-family dump-argument core used by the
+// mysql and mariadb dump adapters (spec 044 / PRD 15). It lives outside
+// internal/adapters/dump/ because the adapter-dump-axis lint rule forbids the
+// engine sub-packages from importing the internal/adapters/dump prefix.
+package mysqlargs
+
+import (
+	"fmt"
+
+	backup "github.com/denisakp/sentinel/internal/domain/backup"
+	internaltls "github.com/denisakp/sentinel/internal/adapters/tls"
+	"github.com/denisakp/sentinel/internal/ports"
+	"github.com/denisakp/sentinel/internal/utils"
+)
+
+// Flavor selects the engine-specific knobs of the shared arg builder: whether an
+// empty password emits --skip-password (MySQL only) and the TLS engine string.
+type Flavor int
+
+const (
+	FlavorMySQL Flavor = iota
+	FlavorMariaDB
+)
+
+// Input carries the engine-agnostic fields the shared core needs, copied from
+// the caller's *DumpArgs.
+type Input struct {
+	Host, Port, Username, Password, Database, AdditionalArgs string
+	TLS                                                      *ports.Config
+}
+
+// ValidateRequired enforces the shared required-field checks (spec 044).
+func ValidateRequired(username, database string) error {
+	if database == "" {
+		return fmt.Errorf("database name is missing")
+	}
+	if username == "" {
+		return fmt.Errorf("username is missing")
+	}
+	return nil
+}
+
+func tlsEngine(f Flavor) string {
+	if f == FlavorMariaDB {
+		return "mariadb"
+	}
+	return "mysql"
+}
+
+// BuildArgs builds the mysqldump/mariadb-dump argument list shared by both
+// engines. The argument order is preserved exactly from the pre-dedupe builders:
+// [--host,--port,--user] -> (MySQL-only --skip-password on empty password) ->
+// additional-args -> TLS args -> de-dup -> database.
+func BuildArgs(in Input, flavor Flavor) ([]string, error) {
+	if err := ValidateRequired(in.Username, in.Database); err != nil {
+		return nil, err
+	}
+
+	host := utils.DefaultValue(in.Host, "127.0.0.1")
+	port := utils.DefaultValue(in.Port, "3306")
+
+	args := []string{
+		fmt.Sprintf("--host=%s", host),
+		fmt.Sprintf("--port=%s", port),
+		fmt.Sprintf("--user=%s", in.Username),
+	}
+
+	if flavor == FlavorMySQL && in.Password == "" {
+		args = append(args, "--skip-password")
+	}
+
+	if in.AdditionalArgs != "" {
+		parsed, err := backup.ParseAdditionalArgs(in.AdditionalArgs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse additional_args: %w", err)
+		}
+		args = append(args, parsed...)
+	}
+
+	args = append(args, internaltls.BuildTLSArgs(tlsEngine(flavor), in.TLS)...)
+
+	args = backup.RemoveArgsDuplicate(args)
+	args = append(args, in.Database)
+
+	return args, nil
+}

--- a/internal/adapters/mysqlargs/core_test.go
+++ b/internal/adapters/mysqlargs/core_test.go
@@ -1,0 +1,78 @@
+package mysqlargs
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/denisakp/sentinel/internal/ports"
+)
+
+func TestBuildArgs_MySQLEmptyPasswordEmitsSkipPassword(t *testing.T) {
+	got, err := BuildArgs(Input{Username: "u", Database: "db"}, FlavorMySQL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"--host=127.0.0.1", "--port=3306", "--user=u", "--skip-password", "db"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("mismatch:\n got  %v\n want %v", got, want)
+	}
+}
+
+func TestBuildArgs_MariaDBEmptyPasswordNoSkipPassword(t *testing.T) {
+	got, err := BuildArgs(Input{Username: "u", Database: "db"}, FlavorMariaDB)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"--host=127.0.0.1", "--port=3306", "--user=u", "db"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("mismatch:\n got  %v\n want %v", got, want)
+	}
+}
+
+func TestBuildArgs_NonEmptyPasswordNoSkip(t *testing.T) {
+	got, _ := BuildArgs(Input{Host: "h", Port: "3307", Username: "u", Password: "p", Database: "db"}, FlavorMySQL)
+	want := []string{"--host=h", "--port=3307", "--user=u", "db"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("mismatch:\n got  %v\n want %v", got, want)
+	}
+}
+
+func TestBuildArgs_AdditionalArgs(t *testing.T) {
+	got, err := BuildArgs(Input{Username: "u", Password: "p", Database: "db", AdditionalArgs: "--single-transaction"}, FlavorMariaDB)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// order: host/port/user, additional-args, database
+	want := []string{"--host=127.0.0.1", "--port=3306", "--user=u", "--single-transaction", "db"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("mismatch:\n got  %v\n want %v", got, want)
+	}
+}
+
+func TestBuildArgs_TLSEngineString(t *testing.T) {
+	tls := &ports.Config{Enabled: true, CACertPath: "/ca.pem"}
+	mysqlArgs, _ := BuildArgs(Input{Username: "u", Password: "p", Database: "db", TLS: tls}, FlavorMySQL)
+	mariaArgs, _ := BuildArgs(Input{Username: "u", Password: "p", Database: "db", TLS: tls}, FlavorMariaDB)
+	// The two flavors must differ only in the TLS flags produced by the engine string.
+	if reflect.DeepEqual(mysqlArgs, mariaArgs) {
+		t.Errorf("expected differing TLS args between mysql and mariadb flavors")
+	}
+}
+
+func TestValidateRequired(t *testing.T) {
+	if err := ValidateRequired("u", "db"); err != nil {
+		t.Errorf("valid input errored: %v", err)
+	}
+	if err := ValidateRequired("u", ""); err == nil {
+		t.Error("missing database should error")
+	}
+	if err := ValidateRequired("", "db"); err == nil {
+		t.Error("missing username should error")
+	}
+}
+
+func TestBuildArgs_ValidationPropagates(t *testing.T) {
+	if _, err := BuildArgs(Input{Username: "u"}, FlavorMySQL); err == nil {
+		t.Error("missing database should error from BuildArgs")
+	}
+}


### PR DESCRIPTION
Closes #73. Delivers **PRD 15** — the **last Phase D item** (maintainability; the architectural cleanups PRDs 27–30 already landed).

## What

The mysql and mariadb dump args builders + validators were near-clones. Collapse the shared body into one place.

**Option A** (clarify): a functional shared core in the new sibling package **`internal/adapters/mysqlargs`** — `BuildArgs(Input, Flavor)` + `ValidateRequired`. Both `*DumpArgs` structs stay unchanged; each engine's `argsBuilder` delegates with its `Flavor`. mariadb's `ArgsBuilder` (no external callers) is unexported to `argsBuilder` to match mysql.

| Area | Change |
|------|--------|
| `internal/adapters/mysqlargs/core.go` (+ test) | NEW shared `BuildArgs`/`ValidateRequired`/`Flavor` |
| `dump/mysql/{args_builder,validator}.go` | delegate to `mysqlargs` |
| `dump/mariadb/{args_builder,validator}.go` + `mariadb_dump.go` | delegate; `ArgsBuilder`→`argsBuilder` |
| `CLAUDE.md` | note the shared `mysqlargs` core |

## PRD correction

The PRD suggested `internal/adapters/dump/mysqlproto/`, but the spec-039 `adapter-dump-axis` depguard rule denies the `internal/adapters/dump` prefix for the engine sub-packages — a shared package there would fail `make lint`. `mysqlargs` is a **sibling outside `dump/`** (like `mongo_tls`); it is not an engine adapter, so both engines importing it adds no adapter→adapter cross-import.

## Behaviour preserved

- Exact arg order: `[--host,--port,--user]` → (mysql-only `--skip-password` on empty password) → additional-args → TLS → dedup → database.
- Per-engine TLS engine string (`mysql`/`mariadb`) preserved.
- The two `argsBuilder` bodies now differ by **4** lines; the validator two-check logic lives **once**.
- Existing golden `args_builder_test.go` + `validator_test.go` in both engines stay green (mariadb tests updated only for the `ArgsBuilder`→`argsBuilder` rename).

## Verification

- `go build/vet/test ./...` green; **`go vet -tags=integration ./...` clean**; `make lint` 0.
- `make e2e` → **32 PASS / 0 FAIL** (mysql + mariadb dumps byte-identical).

**This closes Phase D** — the ADR 0001 architectural cleanups (27–30) plus this maintainability dedupe are all done.
