### PR TITLE
feat(restore): parallel multi-job restore via restore run --all (spec 045 / PRD 31)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Each command file in `internal/cli/` exports a `*cobra.Command` and registers su
 Top-level commands: `backup`, `schedule`, `restore`, `monitor`, `retention`, `config`, `db`, `security`, `storage`, `version`.
 
 ### Package layout
-- `internal/cli/` — Cobra commands (one file per command group)
+- `internal/cli/` — Cobra commands (one file per command group). `restore run` accepts `--all` (run every enabled restore job concurrently, bounded by top-level `max_concurrent_restores`, default 1) + `--parallel N` override; `handleRestoreRunAll` fans out over a `chan struct{}` semaphore reusing `runOneRestoreJob` (spec 045 / PRD 31 — job axis; DB axis deferred, restore has no multi-DB auto-discovery).
 - `internal/config/` — `types.go` (YAML schema), `loader.go`, `validator.go`
 - `internal/adapters/monitor/` — SQLite execution history adapter implementing `ports.Recorder` (spec 032). `NewMonitor(dbPath) (*Monitor, error)`; always `defer .Close()`. Schema is version-gated via `BinarySchemaVersion`; migrations run under a file lock on every open and forward-incompat DBs are refused (`ErrForwardIncompatible`). Inspect with `sentinel monitor doctor [--repair]`.
 - `internal/scheduler/` — cron loop (`scheduler.go`), execution (`executor.go`), restore hook (`restore_integration.go`)
@@ -113,5 +113,5 @@ Every new feature MUST run these skills in this exact order — no skipping, no 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/044-dedupe-mysql-mariadb-args/plan.md`
+`specs/045-parallel-multi-job-restore/plan.md`
 <!-- SPECKIT END -->

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -7,6 +7,7 @@ Operational procedures for running, recovering, and maintaining Sentinel in prod
 - [Start the scheduler](./start-scheduler.md)
 - [Inspect monitor history](./inspect-monitor-history.md)
 - [Apply retention](./apply-retention.md)
+- [Parallel multi-job restore](./parallel-restore.md)
 - [Check storage backend](./check-storage-backend.md)
 
 ## Setup

--- a/docs/runbooks/parallel-restore.md
+++ b/docs/runbooks/parallel-restore.md
@@ -1,0 +1,82 @@
+# Parallel Multi-Job Restore
+
+`sentinel restore run --all` runs every **enabled** configured restore job at once, bounded by a concurrency limit. It turns a disaster-recovery drill across N services (one restore job per service) from a serial sum-of-times into a parallel run.
+
+> Scope: this parallelises **jobs** (the job axis). It does not restore multiple databases within a single job — a restore job targets exactly one database.
+
+## Quick start
+
+```bash
+# Serial (default — behaviour unchanged):
+sentinel restore run --all --config sentinel.yaml
+
+# Parallel — raise the config limit, or override per-invocation:
+sentinel restore run --all --parallel 5 --config sentinel.yaml
+```
+
+Single-job runs are unchanged:
+
+```bash
+sentinel restore run svc-a-restore --config sentinel.yaml
+```
+
+## Configuration
+
+```yaml
+# Global concurrency limit for `restore run --all`. Default 1 (serial).
+# Parallelism is opt-in: raise this and/or pass --parallel.
+max_concurrent_restores: 4
+
+restores:
+  svc-a-restore:
+    type: postgres
+    database: svc_a
+    backup_source: { ... }
+    # ...
+  svc-b-restore:
+    type: mysql
+    database: svc_b
+    backup_source: { ... }
+  # ...one job per service
+```
+
+- **Default `max_concurrent_restores: 1`** preserves today's serial behaviour for anyone who does not opt in.
+- Valid range: `1`–`100` (rejected at config load otherwise).
+
+## Concurrency precedence
+
+```
+--parallel N   (if > 0)   >   max_concurrent_restores (config)   >   1 (default)
+```
+
+## Failure isolation
+
+A run-all is a **drill**: one failing service must not stop the others.
+
+- A job that fails does **not** abort or cancel the sibling jobs — they run to completion.
+- Each job's outcome is reported individually:
+
+  ```
+    svc-a-restore                  OK      Restore job "svc-a-restore" completed successfully
+    svc-b-restore                  FAILED  restore source not found: ...
+    svc-c-restore                  OK      Restore job "svc-c-restore" completed successfully
+  Restore run-all: 2/3 succeeded (concurrency=4)
+  ```
+
+- The command exits **non-zero** if any job failed, and zero if all succeeded — so a drill in CI/cron fails loudly when a service can't be restored.
+
+## DR drill workflow
+
+1. Configure one restore job per service (each pointing at that service's backup source and target database).
+2. Set `max_concurrent_restores` to a value your hardware can sustain (each concurrent PostgreSQL PITR / `pg_combinebackup`, `mysql`, or `mongorestore` is a separate process — size CPU/RAM accordingly).
+3. Run `sentinel restore run --all` on a drill schedule (or in CI).
+4. Read the per-job summary; investigate any `FAILED` service; the non-zero exit flags the drill as failed.
+
+## Multi-tenant restore
+
+Model each tenant as a restore job (same backup source, different target database) and run `--all --parallel N` to restore many tenants concurrently instead of a shell loop.
+
+## Notes
+
+- Execution history is recorded per job and is safe under concurrency.
+- One notification per job (unchanged) — there is no aggregate "drill summary" notification.

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -83,10 +84,10 @@ var (
 	}
 
 	restoreRunCmd = &cobra.Command{
-		Use:   "run <job-name>",
-		Short: "Execute a restore job now",
-		Long:  `Run a configured restore job immediately (including staged backup download for supported sources).`,
-		Args:  cobra.ExactArgs(1),
+		Use:   "run [job-name]",
+		Short: "Execute a restore job now (or --all for every enabled job)",
+		Long:  `Run a configured restore job immediately (including staged backup download for supported sources). Use --all to run every enabled restore job concurrently up to max_concurrent_restores.`,
+		Args:  cobra.MaximumNArgs(1),
 		RunE:  handleRestoreRun,
 	}
 
@@ -126,6 +127,10 @@ var (
 	restoreLogLevel            string
 	restoreAllowLegacyEnvelope bool
 
+	// Run-all flags (spec 045 / PRD 31).
+	restoreRunAll   bool
+	restoreParallel int
+
 	// One-off restore override flags.
 	restoreGCSBucket          string
 	restoreGCSProjectID       string
@@ -156,6 +161,8 @@ func init() {
 	restoreRunCmd.Flags().StringVar(&restoreGCSProjectID, "gcs-project-id", "", "Google Cloud project ID (optional)")
 	restoreRunCmd.Flags().StringVar(&restoreGCSCredentialsFile, "gcs-credentials-file", "", "Google Cloud service account key file")
 	restoreRunCmd.Flags().BoolVar(&restoreKeepFile, "keep-file", false, "Keep staged restore artifact after run for debugging")
+	restoreRunCmd.Flags().BoolVar(&restoreRunAll, "all", false, "Run all enabled restore jobs concurrently (up to max_concurrent_restores)")
+	restoreRunCmd.Flags().IntVar(&restoreParallel, "parallel", 0, "Max concurrent restore jobs for --all (0 = use max_concurrent_restores)")
 }
 
 var restoreCmd = &cobra.Command{
@@ -301,13 +308,39 @@ func handleRestoreDryRun(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func handleRestoreRun(cmd *cobra.Command, args []string) error {
-	jobName := args[0]
+// jobOutcome is the result of running one restore job: OK plus the stdout to
+// print (Msg) and the error to surface (Err). Used by both the single-job and
+// the --all (run-all) paths so they share identical execution + result handling
+// (spec 045 / PRD 31).
+type jobOutcome struct {
+	Name string
+	OK   bool
+	Msg  string
+	Err  error
+}
 
+func handleRestoreRun(cmd *cobra.Command, args []string) error {
 	cfg, err := loadRestoreConfig()
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
+
+	ctx := context.Background()
+	if cmd != nil {
+		ctx = cmd.Context()
+	}
+
+	if restoreRunAll {
+		if len(args) > 0 {
+			return fmt.Errorf("cannot combine --all with a job name")
+		}
+		return handleRestoreRunAll(ctx, cfg)
+	}
+
+	if len(args) == 0 {
+		return fmt.Errorf("a restore job name is required (or use --all to run every enabled job)")
+	}
+	jobName := args[0]
 
 	job, ok := cfg.Restores[jobName]
 	if !ok {
@@ -322,11 +355,17 @@ func handleRestoreRun(cmd *cobra.Command, args []string) error {
 	}
 	defer mon.Close()
 
-	ctx := context.Background()
-	if cmd != nil {
-		ctx = cmd.Context()
+	outcome := runOneRestoreJob(ctx, cfg, mon, jobName, job)
+	if outcome.Msg != "" {
+		fmt.Print(outcome.Msg)
 	}
+	return outcome.Err
+}
 
+// runOneRestoreJob executes a single restore job and returns its outcome without
+// printing or returning early, so it can be composed into the run-all fan-out
+// (failure is captured, never propagated to abort siblings).
+func runOneRestoreJob(ctx context.Context, cfg *config.Configuration, mon *monitor.Monitor, jobName string, job config.RestoreJob) jobOutcome {
 	result, err := runRestoreExecution(ctx, &internalrestore.ExecutionRequest{
 		JobName:             jobName,
 		Job:                 job,
@@ -338,29 +377,105 @@ func handleRestoreRun(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		notifyRestoreResult(ctx, jobName, job, result, err)
 		if result != nil && result.PlanningStatus == string(domainrestore.PlanStatusConfirmationRequired) {
-			return fmt.Errorf("restore execution requires explicit fallback confirmation; set confirm_full_fallback: true for job %q", jobName)
+			return jobOutcome{Name: jobName, OK: false, Err: fmt.Errorf("restore execution requires explicit fallback confirmation; set confirm_full_fallback: true for job %q", jobName)}
 		}
 		if result != nil && result.Status == ports.StatusSkipped {
-			return fmt.Errorf("restore execution skipped: %s", result.Reason)
+			return jobOutcome{Name: jobName, OK: false, Err: fmt.Errorf("restore execution skipped: %s", result.Reason)}
 		}
-		return mapRestoreSourceError(job, err)
+		return jobOutcome{Name: jobName, OK: false, Err: mapRestoreSourceError(job, err)}
 	}
 
 	notifyRestoreResult(ctx, jobName, job, result, nil)
 
+	var b strings.Builder
+	if result != nil && result.FallbackDecision == string(domainrestore.FallbackCandidateFullRestore) {
+		fmt.Fprintf(&b, "WARNING: incremental restore fell back to full restore (reason=%s, fallback_backup_id=%s)\n", result.FallbackReason, result.FallbackBackupID)
+	}
 	if result != nil && result.StagedFileRetained {
-		if result.FallbackDecision == string(domainrestore.FallbackCandidateFullRestore) {
-			fmt.Printf("WARNING: incremental restore fell back to full restore (reason=%s, fallback_backup_id=%s)\n", result.FallbackReason, result.FallbackBackupID)
+		fmt.Fprintf(&b, "Restore job %q completed. Staged file retained at: %s\n", jobName, result.StagedFilePath)
+	} else {
+		fmt.Fprintf(&b, "Restore job %q completed successfully\n", jobName)
+	}
+	return jobOutcome{Name: jobName, OK: true, Msg: b.String()}
+}
+
+// effectiveRestoreConcurrency resolves the run-all concurrency: the --parallel
+// override (if > 0), else max_concurrent_restores, else 1.
+func effectiveRestoreConcurrency(cfg *config.Configuration, parallelFlag int) int {
+	if parallelFlag > 0 {
+		return parallelFlag
+	}
+	if cfg.MaxConcurrentRestores > 0 {
+		return cfg.MaxConcurrentRestores
+	}
+	return 1
+}
+
+// handleRestoreRunAll runs every enabled restore job concurrently, bounded by
+// the effective concurrency limit, isolating per-job failures and reporting a
+// per-job aggregate (spec 045 / PRD 31).
+func handleRestoreRunAll(ctx context.Context, cfg *config.Configuration) error {
+	mon, err := monitor.NewMonitor(cfg.HistoryDBPath)
+	if err != nil {
+		return fmt.Errorf("failed to initialize restore monitor: %w", err)
+	}
+	defer mon.Close()
+
+	type namedJob struct {
+		name string
+		job  config.RestoreJob
+	}
+	var enabled []namedJob
+	for name, job := range cfg.Restores {
+		if job.Enabled == nil || *job.Enabled {
+			enabled = append(enabled, namedJob{name: name, job: job})
 		}
-		fmt.Printf("Restore job %q completed. Staged file retained at: %s\n", jobName, result.StagedFilePath)
+	}
+	if len(enabled) == 0 {
+		fmt.Println("No enabled restore jobs to run.")
 		return nil
 	}
 
-	if result != nil && result.FallbackDecision == string(domainrestore.FallbackCandidateFullRestore) {
-		fmt.Printf("WARNING: incremental restore fell back to full restore (reason=%s, fallback_backup_id=%s)\n", result.FallbackReason, result.FallbackBackupID)
-	}
+	limit := effectiveRestoreConcurrency(cfg, restoreParallel)
+	sem := make(chan struct{}, limit)
+	var wg sync.WaitGroup
+	outcomes := make([]jobOutcome, len(enabled))
 
-	fmt.Printf("Restore job %q completed successfully\n", jobName)
+	for i, e := range enabled {
+		wg.Add(1)
+		go func(i int, name string, job config.RestoreJob) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			// Contain any per-job panic so one bad job never aborts the batch.
+			defer func() {
+				if r := recover(); r != nil {
+					outcomes[i] = jobOutcome{Name: name, OK: false, Err: fmt.Errorf("restore job %q panicked: %v", name, r)}
+				}
+			}()
+			applyRestoreRunOverrides(&job)
+			outcomes[i] = runOneRestoreJob(ctx, cfg, mon, name, job)
+		}(i, e.name, e.job)
+	}
+	wg.Wait()
+
+	failed := 0
+	for _, o := range outcomes {
+		status := "OK"
+		if !o.OK {
+			status = "FAILED"
+			failed++
+		}
+		detail := strings.TrimSpace(o.Msg)
+		if o.Err != nil {
+			detail = o.Err.Error()
+		}
+		fmt.Printf("  %-30s %-7s %s\n", o.Name, status, detail)
+	}
+	fmt.Printf("Restore run-all: %d/%d succeeded (concurrency=%d)\n", len(outcomes)-failed, len(outcomes), limit)
+	if failed > 0 {
+		return fmt.Errorf("%d of %d restore jobs failed", failed, len(outcomes))
+	}
 	return nil
 }
 

--- a/internal/cli/restore_runall_test.go
+++ b/internal/cli/restore_runall_test.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/denisakp/sentinel/internal/config"
+	internalrestore "github.com/denisakp/sentinel/internal/adapters/restore/runtime"
+	"github.com/denisakp/sentinel/internal/ports"
+)
+
+// TestHandleRestoreRunAll_FailureIsolationAndConcurrency verifies that --all
+// runs every enabled job, one failure does not abort siblings, concurrency is
+// bounded, and the overall result is non-nil when any job fails (spec 045).
+func TestHandleRestoreRunAll_FailureIsolationAndConcurrency(t *testing.T) {
+	prevExecutor := runRestoreExecution
+	prevParallel := restoreParallel
+	t.Cleanup(func() {
+		runRestoreExecution = prevExecutor
+		restoreParallel = prevParallel
+	})
+
+	enabled := true
+	cfg := &config.Configuration{
+		HistoryDBPath:         filepath.Join(t.TempDir(), "history.db"),
+		MaxConcurrentRestores: 2,
+		Restores: map[string]config.RestoreJob{
+			"job-a":    {Name: "job-a", Type: "postgres", Enabled: &enabled, Database: "a"},
+			"job-b":    {Name: "job-b", Type: "postgres", Enabled: &enabled, Database: "b"},
+			"job-fail": {Name: "job-fail", Type: "postgres", Enabled: &enabled, Database: "f"},
+		},
+	}
+	restoreParallel = 2
+
+	var (
+		mu       sync.Mutex
+		invoked  = map[string]bool{}
+		inFlight int32
+		maxSeen  int32
+	)
+	runRestoreExecution = func(_ context.Context, req *internalrestore.ExecutionRequest) (*internalrestore.ExecutionResult, error) {
+		n := atomic.AddInt32(&inFlight, 1)
+		for {
+			old := atomic.LoadInt32(&maxSeen)
+			if n <= old || atomic.CompareAndSwapInt32(&maxSeen, old, n) {
+				break
+			}
+		}
+		defer atomic.AddInt32(&inFlight, -1)
+
+		mu.Lock()
+		invoked[req.JobName] = true
+		mu.Unlock()
+
+		if req.JobName == "job-fail" {
+			return nil, fmt.Errorf("boom")
+		}
+		return &internalrestore.ExecutionResult{Status: ports.StatusSuccess}, nil
+	}
+
+	err := handleRestoreRunAll(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected non-nil error when a job fails")
+	}
+
+	// all three jobs invoked (failure isolation: the failing one did not abort others)
+	for _, name := range []string{"job-a", "job-b", "job-fail"} {
+		if !invoked[name] {
+			t.Errorf("job %q was not invoked", name)
+		}
+	}
+	// concurrency never exceeded the limit
+	if maxSeen > 2 {
+		t.Errorf("observed concurrency %d exceeds limit 2", maxSeen)
+	}
+}
+
+func TestEffectiveRestoreConcurrency(t *testing.T) {
+	cfg := &config.Configuration{MaxConcurrentRestores: 3}
+	if got := effectiveRestoreConcurrency(cfg, 5); got != 5 {
+		t.Errorf("--parallel override: got %d want 5", got)
+	}
+	if got := effectiveRestoreConcurrency(cfg, 0); got != 3 {
+		t.Errorf("config value: got %d want 3", got)
+	}
+	if got := effectiveRestoreConcurrency(&config.Configuration{}, 0); got != 1 {
+		t.Errorf("default: got %d want 1", got)
+	}
+}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -55,6 +55,9 @@ func applyDefaults(cfg *Configuration) {
 	if cfg.MaxConcurrentBackups == 0 {
 		cfg.MaxConcurrentBackups = defaultMaxConcurrentJobs
 	}
+	if cfg.MaxConcurrentRestores == 0 {
+		cfg.MaxConcurrentRestores = defaultMaxConcurrentRestores
+	}
 	if cfg.LogFormat == "" {
 		cfg.LogFormat = defaultLogFormat
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -134,6 +134,10 @@ type Configuration struct {
 	// Global concurrency limit (default: 3) — kept for backward compatibility
 	MaxConcurrentBackups int `yaml:"max_concurrent_backups"`
 
+	// Global concurrency limit for `restore run --all` (default: 1 — serial;
+	// parallelism is opt-in). Spec 045 / PRD 31.
+	MaxConcurrentRestores int `yaml:"max_concurrent_restores"`
+
 	// Scheduler holds advanced concurrency and timeout settings
 	Scheduler SchedulerConfig `yaml:"scheduler,omitempty"`
 

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -48,6 +48,11 @@ func ValidateConfig(cfg *Configuration) error {
 	if cfg.MaxConcurrentBackups < 1 || cfg.MaxConcurrentBackups > 100 {
 		return fmt.Errorf("max_concurrent_backups must be between 1 and 100")
 	}
+	// 0 means "unset" (LoadConfig defaults it to 1 before validation); reject
+	// only a genuinely out-of-range value (negative or > 100). Spec 045 / PRD 31.
+	if cfg.MaxConcurrentRestores != 0 && (cfg.MaxConcurrentRestores < 1 || cfg.MaxConcurrentRestores > 100) {
+		return fmt.Errorf("max_concurrent_restores must be between 1 and 100")
+	}
 
 	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
 

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -313,3 +313,28 @@ func baseConfigWithRestore() *Configuration {
 		},
 	}
 }
+
+func TestValidateConfig_MaxConcurrentRestoresRange(t *testing.T) {
+	base := func(v int) *Configuration {
+		return &Configuration{
+			Version:               "1.0",
+			MaxConcurrentBackups:  1,
+			MaxConcurrentRestores: v,
+			Databases: map[string]BackupJob{
+				"db": {Type: "postgres", Host: "h", Username: "u", PasswordEnv: "PW", Database: "d", Schedule: "0 2 * * *", Storage: StorageConfig{Type: "local", LocalPath: "/tmp"}},
+			},
+		}
+	}
+	if err := ValidateConfig(base(-1)); err == nil {
+		t.Error("negative max_concurrent_restores must be rejected")
+	}
+	if err := ValidateConfig(base(101)); err == nil {
+		t.Error("max_concurrent_restores > 100 must be rejected")
+	}
+	if err := ValidateConfig(base(4)); err != nil {
+		t.Errorf("valid max_concurrent_restores rejected: %v", err)
+	}
+	if err := ValidateConfig(base(0)); err != nil {
+		t.Errorf("unset (0) max_concurrent_restores must pass (loader defaults it): %v", err)
+	}
+}


### PR DESCRIPTION
Closes #75. Delivers **PRD 31** — first **Phase E** user-facing feature (DR-drill acceleration).

## What

`sentinel restore run <job>` runs one job. Add `sentinel restore run --all` to run every **enabled** configured restore job concurrently, bounded by `max_concurrent_restores` (default 1; `--parallel N` override) — an N-service DR drill goes from sum-of-times to a parallel run.

| Area | Change |
|------|--------|
| `internal/config/{types,loader,validator}.go` | NEW top-level `Configuration.MaxConcurrentRestores` (default 1, validated) |
| `internal/cli/restore.go` | `--all` + `--parallel` flags; `Args` relaxed; `runOneRestoreJob` extraction; `handleRestoreRunAll` semaphore fan-out |
| tests | run-all failure-isolation + concurrency-bound + precedence; config range |
| `docs/runbooks/parallel-restore.md` | NEW runbook |

## Design

- **Failure isolation**: each job runs in a goroutine with per-job `recover()`; a failure is captured in its outcome and never aborts siblings. Per-job aggregate summary; non-zero exit iff any failed.
- **Concurrency**: `chan struct{}` semaphore (same pattern as the scheduler), sharing one concurrency-safe `*Monitor` (`*sql.DB` pool + `busy_timeout`). Precedence `--parallel > max_concurrent_restores > 1`.
- **Behaviour-preserving**: single-job `restore run <job>` unchanged; default limit 1 ⇒ serial. No new ports, no domain Executor signature change.

## Scope correction (clarify)

The PRD's "DB axis" (parallel restore of auto-discovered databases within one job) rests on a **false premise** — a `RestoreJob` targets a single `Database`; restore has no multi-DB auto-discovery. **Job axis only**; the DB axis is deferred to a future "restore auto-discovery" feature. Also: the top-level `MaxConcurrentRestores` field didn't exist (only `SchedulerConfig` had one) — this feature creates it, symmetric to `MaxConcurrentBackups`.

## Verification

- `go build/vet/test ./...` + **`go vet -tags=integration ./...`** + `make lint` green.
- `make e2e` → **32 PASS / 0 FAIL** (incl. single-job `restore run` unchanged after the arg relaxation).
- Unit tests prove: all enabled jobs invoked, one failure doesn't abort siblings, observed concurrency ≤ limit, overall exit non-zero on failure, precedence.
