### PR TITLE
feat(release): cross-platform binary distribution via GoReleaser (PRD 38)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,27 +2,27 @@ name: Release
 on:
   push:
     tags:
-      - "v1.*"
+      # Widened from 'v1.*' so future v2.x tags also release (PRD 38 Q3).
+      - "v*"
+permissions:
+  contents: write
 jobs:
-  release:
+  goreleaser:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          # GoReleaser needs full history + tags for changelog/version resolution.
+          fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
           go-version: '1.24'
-      - name: build binary
-        run: |
-          go build \
-            -ldflags "-X github.com/denisakp/sentinel/internal/version.Version=${{ github.ref_name }} -X github.com/denisakp/sentinel/internal/version.Commit=${{ github.sha }} -X github.com/denisakp/sentinel/internal/version.BuildDate=${{ github.event.repository.updated_at }}" \
-            -o sentinel
-          tar -czvf sentinel-${{ github.ref_name }}-linux-amd64.tar.gz sentinel
-      - name: Release
-        uses: softprops/action-gh-release@v2
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          files: sentinel-*.tar.gz
-          body: |
-            See `release-notes.md` for changes summary.
-          draft: false
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,78 @@
+# GoReleaser configuration — cross-platform binary distribution (PRD 38).
+#
+# Sentinel is pure Go (no cgo — the SQLite monitor uses the pure-Go
+# modernc.org/sqlite driver), so every target cross-compiles with
+# CGO_ENABLED=0 and no cross-toolchain. Matches the flags used by
+# infra/docker/Dockerfile (CGO_ENABLED=0, -trimpath, -ldflags "-s -w").
+#
+# Validate locally with: goreleaser release --snapshot --clean
+# (produces all 5 binaries + archives + checksums.txt under dist/).
+#
+# TODO(v2): supply-chain signing — cosign keyless (GitHub OIDC, `--yes`)
+# plus SLSA build provenance attestations. Deferred out of v1 per PRD 38
+# Q1 (checksums-only for v1; signing/provenance a fast-follow).
+version: 2
+
+project_name: sentinel
+
+builds:
+  - id: sentinel
+    main: .                  # main.go lives at the repo root
+    binary: sentinel
+    env:
+      - CGO_ENABLED=0        # pure Go — matches infra/docker/Dockerfile
+    flags:
+      - -trimpath
+    ldflags:
+      # Stamp the real internal/version vars. GoVersion is NOT stamped —
+      # internal/version.Get() sources it from runtime.Version() at runtime.
+      - -s -w
+      - -X github.com/denisakp/sentinel/internal/version.Version={{ .Version }}
+      - -X github.com/denisakp/sentinel/internal/version.Commit={{ .FullCommit }}
+      - -X github.com/denisakp/sentinel/internal/version.BuildDate={{ .CommitDate }}
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      # 5-target matrix per roadmap M4 / F-01: linux/{amd64,arm64},
+      # darwin/{amd64,arm64}, windows/amd64. windows/arm64 excluded
+      # (PRD 38 Q2 — one-line add if ever wanted).
+      - goos: windows
+        goarch: arm64
+
+archives:
+  - id: default
+    ids:
+      - sentinel
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    files:
+      - README.md
+      - LICENSE
+      - release-notes.md
+
+checksum:
+  name_template: checksums.txt
+  algorithm: sha256
+
+release:
+  github:
+    owner: denisakp
+    name: sentinel
+  draft: false
+  # Keep pointing operators at the consolidated changelog (PRD 38 Q6).
+  footer: |
+    ---
+    See `release-notes.md` for the full changes summary. Each release ships
+    prebuilt binaries for linux/darwin/windows (amd64 + arm64, minus
+    windows/arm64) plus a SHA-256 `checksums.txt`; verify downloads with
+    `sha256sum -c checksums.txt`.

--- a/README.md
+++ b/README.md
@@ -23,20 +23,62 @@ It supports PostgreSQL, MySQL, MariaDB, and MongoDB — with cloud storage, sche
 
 ## Installation
 
+### Download a prebuilt binary (recommended)
+
+No Go toolchain required. Prebuilt binaries are published on every release for
+**linux**, **macOS**, and **Windows** (amd64 + arm64, except windows/arm64),
+each with a SHA-256 `checksums.txt`.
+
+1. Grab the asset for your OS/arch from the
+   [latest release](https://github.com/denisakp/sentinel/releases/latest) —
+   e.g. `sentinel-<version>-linux-amd64.tar.gz` (Windows ships `.zip`).
+2. Download and verify the integrity of your download:
+
+   ```bash
+   VERSION=<version>          # e.g. 1.3.0 (no leading "v")
+   OS=linux                   # linux | darwin | windows
+   ARCH=amd64                 # amd64 | arm64
+   BASE=https://github.com/denisakp/sentinel/releases/latest/download
+
+   curl -LO "$BASE/sentinel-$VERSION-$OS-$ARCH.tar.gz"
+   curl -LO "$BASE/checksums.txt"
+   sha256sum -c checksums.txt --ignore-missing
+   ```
+3. Extract and put it on your `PATH`:
+
+   ```bash
+   tar -xzf "sentinel-$VERSION-$OS-$ARCH.tar.gz"   # unzip on Windows
+   sudo mv sentinel /usr/local/bin/
+   sentinel version
+   sentinel version --tools   # check pg_dump, mysqldump, mongodump versions
+   ```
+
+Prebuilt binaries still expect the relevant DB client tools (`pg_dump`,
+`mysqldump`, `mongodump`, …) on your `PATH`.
+
+### Install with `go install`
+
+If you already have Go 1.24+:
+
+```bash
+go install github.com/denisakp/sentinel@latest
+```
+
+> **Note:** a `go install` build is compiled without release ldflags, so
+> `sentinel version` reports the `dev / unknown / unknown` development
+> fallback rather than a stamped version. Use a prebuilt release binary if you
+> need `sentinel version` to report the real version/commit/build date.
+
+### Build from source (dev only)
+
 Requires Go 1.24+.
 
 ```bash
-git clone https://github.com/denis-yaovi/sentinel.git
+git clone https://github.com/denisakp/sentinel.git
 cd sentinel
 go mod download
-go build -o sentinel
-```
-
-Verify:
-
-```bash
+go build -o sentinel ./...
 ./sentinel version
-./sentinel version --tools   # check pg_dump, mysqldump, mongodump versions
 ```
 
 ---


### PR DESCRIPTION
## Recovered PRD 38 — cross-platform binary distribution via GoReleaser

Recovers roadmap **M4 — Deploy (v1.2.1)** / backlog F-01. Removes the "requires Go" adoption blocker: prebuilt binaries + `go install`, replacing the hand-rolled single linux/amd64 tarball.

- **`.goreleaser.yaml`** (v2): builds linux/darwin/windows × amd64/arm64 (windows/arm64 excluded → 5 targets), `CGO_ENABLED=0` + `-trimpath` (pure Go, matches Dockerfile), tar.gz (+ zip for windows), `checksums.txt` (SHA-256), ldflags stamping `internal/version.{Version,Commit,BuildDate}`.
- **`.github/workflows/release.yml`**: trigger `v1.*`→`v*`, `contents: write`, `fetch-depth: 0`, `goreleaser-action@v6` (`release --clean`); hand-rolled build/tar/upload steps removed.
- **`README.md`**: prebuilt binary primary + `sha256sum -c`; `go install github.com/denisakp/sentinel@latest` secondary (with the `dev/unknown` version-stamp caveat); git-clone/build demoted to "from source"; fixed clone URL owner `denis-yaovi`→`denisakp`.

Signing (cosign/SLSA) deferred to v2 (checksums-only for v1) — `TODO(v2)` in the config. No `internal/**` change. `go build ./...` green; `goreleaser check` passed. Release-notes entry lands in a consolidated follow-up (parallel-worktree batch).
