### PR TITLE
feat(restore): --skip-hash-verify escape hatch for benign manifest mismatch (PRD 39)

### DIFF
--- a/internal/adapters/restore/runtime/executor.go
+++ b/internal/adapters/restore/runtime/executor.go
@@ -62,6 +62,10 @@ type ExecutionRequest struct {
 	ConflictEvaluator func(context.Context, config.RestoreJob, string) error
 	// AllowLegacyEnvelope opt-in for decrypting pre-v2 artifacts. Off by default.
 	AllowLegacyEnvelope bool
+	// SkipHashVerify downgrades a manifest hash mismatch from a hard abort to a
+	// logged WARNING. Off by default; set only by the per-invocation
+	// --skip-hash-verify restore flag (never env-defaulted).
+	SkipHashVerify bool
 }
 
 // ExecutionResult preserves the pre-carve result shape (now the domain
@@ -190,7 +194,7 @@ func NewRestoreExecutorFromConfig(req *ExecutionRequest, job config.RestoreJob) 
 		LoadPlanManifest: manifest.LoadRestoreManifest,
 		ReadManifest:     manifest.ReadManifest,
 		Preflight: func(ctx context.Context, artifact *domainrestore.StagedArtifact) (string, error) {
-			return applyRestorePreflight(ctx, req.Config, artifact, req.AllowLegacyEnvelope)
+			return applyRestorePreflight(ctx, req.Config, artifact, req.AllowLegacyEnvelope, req.SkipHashVerify)
 		},
 		RestoreOptions: func(stagedPath string) (ports.RestoreOptions, error) {
 			return stagedPathOptions{path: stagedPath}, nil
@@ -295,7 +299,7 @@ func executePostgresPITR(ctx context.Context, job config.RestoreJob, password, s
 
 // applyPreflight verifies integrity and decrypts the staged artifact in
 // place. Relocated verbatim from internal/restore/executor.go.
-func applyPreflight(ctx context.Context, cfg *config.Configuration, artifact *StagedArtifact, allowLegacyEnvelope bool) (string, error) {
+func applyPreflight(ctx context.Context, cfg *config.Configuration, artifact *StagedArtifact, allowLegacyEnvelope, skipHashVerify bool) (string, error) {
 	if artifact == nil {
 		return "", fmt.Errorf("staged artifact is required")
 	}
@@ -317,9 +321,10 @@ func applyPreflight(ctx context.Context, cfg *config.Configuration, artifact *St
 	}
 
 	reader, err := PreRestoreVerifyAndDecryptWithOptions(ctx, m, artifact.Path, keyProvider, ports.DecryptOptions{
-		AllowLegacy: allowLegacyEnvelope,
-		Source:      artifact.Path,
-		BackupID:    m.BackupID,
+		AllowLegacy:    allowLegacyEnvelope,
+		SkipHashVerify: skipHashVerify,
+		Source:         artifact.Path,
+		BackupID:       m.BackupID,
 	})
 	if err != nil {
 		if errors.Is(err, ErrHashMismatch) {

--- a/internal/adapters/restore/runtime/executor_test.go
+++ b/internal/adapters/restore/runtime/executor_test.go
@@ -143,7 +143,7 @@ func TestExecuteRestoreRequiresVerificationForPITR(t *testing.T) {
 	stageRestoreSource = func(ctx context.Context, job config.RestoreJob) (*StagedArtifact, error) {
 		return &StagedArtifact{Path: backupPath, ManifestPath: manifestPath, SourcePath: "backup.sql", SizeBytes: 6}, nil
 	}
-	applyRestorePreflight = func(ctx context.Context, cfg *config.Configuration, artifact *StagedArtifact, _ bool) (string, error) {
+	applyRestorePreflight = func(ctx context.Context, cfg *config.Configuration, artifact *StagedArtifact, _, _ bool) (string, error) {
 		return artifact.Path, nil
 	}
 	executeRestoreEngine = func(ctx context.Context, job config.RestoreJob, stagedPath string) error {
@@ -226,7 +226,7 @@ func TestExecuteRestoreFallbackConfirmationRequired(t *testing.T) {
 	stageRestoreSource = func(ctx context.Context, job config.RestoreJob) (*StagedArtifact, error) {
 		return &StagedArtifact{Path: backupPath, ManifestPath: manifestPath, SourcePath: "backup.sql", SizeBytes: 6}, nil
 	}
-	applyRestorePreflight = func(ctx context.Context, cfg *config.Configuration, artifact *StagedArtifact, _ bool) (string, error) {
+	applyRestorePreflight = func(ctx context.Context, cfg *config.Configuration, artifact *StagedArtifact, _, _ bool) (string, error) {
 		return artifact.Path, nil
 	}
 	executeRestoreEngine = func(ctx context.Context, job config.RestoreJob, stagedPath string) error {
@@ -315,7 +315,7 @@ func TestExecuteRestore_CleansAssembledArtifactsOnEngineFailure(t *testing.T) {
 	stageRestoreSource = func(ctx context.Context, job config.RestoreJob) (*StagedArtifact, error) {
 		return &StagedArtifact{Path: backupPath, ManifestPath: manifestPath, SourcePath: "incremental.dump", SizeBytes: 6}, nil
 	}
-	applyRestorePreflight = func(ctx context.Context, cfg *config.Configuration, artifact *StagedArtifact, _ bool) (string, error) {
+	applyRestorePreflight = func(ctx context.Context, cfg *config.Configuration, artifact *StagedArtifact, _, _ bool) (string, error) {
 		return artifact.Path, nil
 	}
 	var chainPaths []string

--- a/internal/adapters/restore/runtime/preflight.go
+++ b/internal/adapters/restore/runtime/preflight.go
@@ -24,6 +24,15 @@ import (
 // domain sentinel.
 var ErrHashMismatch = domainrestore.ErrHashMismatch
 
+// SkipHashVerifyWarnMsg is the prominent, unmissable WARNING line written to
+// stderr when a manifest hash mismatch is bypassed via the per-invocation
+// --skip-hash-verify restore flag. Mirrors the operator-facing shape of the
+// CLI's LegacyEnvelopeOptInWarnMsg, but lives driving-side beside its single
+// emission point (preflight): the CLI package imports runtime, not the
+// reverse, so the constant cannot live in internal/cli. Takes the backup ID
+// and the artifact path.
+const SkipHashVerifyWarnMsg = "WARNING: restoring backup %q from %q with --skip-hash-verify — the manifest SHA-256 does NOT match the artifact; integrity is unverified and you are proceeding at your own risk\n"
+
 // PreRestoreVerifyAndDecrypt is the single entry point for restore pre-flight:
 //
 //  1. Reads the backup file at filePath
@@ -59,13 +68,29 @@ func PreRestoreVerifyAndDecryptWithOptions(
 	}
 
 	if computed != m.Hash.Value {
-		return nil, fmt.Errorf("%w: stored=%s computed=%s file=%q",
-			ErrHashMismatch, m.Hash.Value, computed, filePath)
+		if !decryptOpts.SkipHashVerify {
+			return nil, fmt.Errorf("%w: stored=%s computed=%s file=%q",
+				ErrHashMismatch, m.Hash.Value, computed, filePath)
+		}
+		// Explicit, per-invocation operator override via --skip-hash-verify.
+		// Never silent: emit both a structured security event and a prominent
+		// stderr line. For encrypted artifacts this only silences the SHA-256
+		// compare — AES-256-GCM auth-tag verification below is an independent
+		// integrity gate this flag does NOT bypass, so a truly corrupt
+		// ciphertext still fails to decrypt.
+		slog.WarnContext(ctx, "SECURITY WARNING: manifest hash mismatch bypassed via --skip-hash-verify",
+			"event", "skip_hash_verify",
+			"backup_id", m.BackupID,
+			"stored", m.Hash.Value,
+			"computed", computed,
+			"file", filePath,
+			"encrypted", m.Encryption != nil)
+		fmt.Fprintf(os.Stderr, SkipHashVerifyWarnMsg, m.BackupID, filePath)
+	} else {
+		slog.InfoContext(ctx, "hash verification passed",
+			"backup_id", m.BackupID,
+			"hash", computed)
 	}
-
-	slog.InfoContext(ctx, "hash verification passed",
-		"backup_id", m.BackupID,
-		"hash", computed)
 
 	// Open the file for reading (plaintext or ciphertext)
 	f, err := os.Open(filePath)

--- a/internal/adapters/restore/runtime/preflight_test.go
+++ b/internal/adapters/restore/runtime/preflight_test.go
@@ -1,12 +1,16 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -159,5 +163,181 @@ func TestPreRestoreVerifyAndDecrypt_EncryptedWithoutKeyProviderFails(t *testing.
 	_, err := PreRestoreVerifyAndDecrypt(context.Background(), m, filePath, nil)
 	if err == nil {
 		t.Fatal("expected error when key provider is missing for encrypted backup")
+	}
+}
+
+// runPreflightCapturing runs PreRestoreVerifyAndDecryptWithOptions while
+// capturing the default slog output and os.Stderr, so tests can assert the
+// --skip-hash-verify WARNING is loud and unmissable (PRD 39).
+func runPreflightCapturing(t *testing.T, m *ports.BackupManifest, filePath string, kp ports.KeyProvider, opts ports.DecryptOptions) (io.Reader, error, string, string) {
+	t.Helper()
+
+	var logBuf bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prevLogger)
+
+	oldStderr := os.Stderr
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe(): %v", err)
+	}
+	os.Stderr = pw
+
+	r, runErr := PreRestoreVerifyAndDecryptWithOptions(context.Background(), m, filePath, kp, opts)
+
+	_ = pw.Close()
+	os.Stderr = oldStderr
+	stderrBytes, _ := io.ReadAll(pr)
+
+	return r, runErr, logBuf.String(), string(stderrBytes)
+}
+
+// mismatchManifest builds a plaintext-artifact manifest whose stored hash is
+// deliberately wrong, so the preflight hash compare fails.
+func mismatchManifest(backupID string) *ports.BackupManifest {
+	return &ports.BackupManifest{
+		BackupID: backupID,
+		Hash: ports.HashInfo{
+			Algorithm: "sha256",
+			Value:     strings.Repeat("0", 64), // never equals a real content hash
+		},
+	}
+}
+
+// (a) Default (flag off): a hash mismatch still aborts hard with ErrHashMismatch
+// and returns no reader — the pre-PRD-39 behaviour is unchanged.
+func TestPreRestoreVerifyAndDecrypt_HashMismatchAbortsByDefault(t *testing.T) {
+	filePath := writePlainBackup(t, []byte("payload the manifest disagrees with"))
+	m := mismatchManifest("mismatch-off")
+
+	r, err, logs, stderr := runPreflightCapturing(t, m, filePath, nil, ports.DecryptOptions{})
+	if err == nil {
+		t.Fatal("expected ErrHashMismatch when --skip-hash-verify is off, got nil")
+	}
+	if !errors.Is(err, ErrHashMismatch) {
+		t.Fatalf("err = %v, want ErrHashMismatch", err)
+	}
+	if r != nil {
+		t.Fatalf("expected nil reader on abort, got %T", r)
+	}
+	if strings.Contains(logs, "skip_hash_verify") {
+		t.Fatalf("unexpected skip_hash_verify event when flag off: %s", logs)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr WARNING when flag off, got %q", stderr)
+	}
+}
+
+// (b) Flag on: a hash mismatch is downgraded to a proceed, emitting the
+// structured skip_hash_verify WARNING event AND the stderr WARNING line, and
+// the plaintext artifact is still readable.
+func TestPreRestoreVerifyAndDecrypt_SkipHashVerifyProceedsWithWarning(t *testing.T) {
+	content := []byte("payload the manifest disagrees with")
+	filePath := writePlainBackup(t, content)
+	m := mismatchManifest("mismatch-on")
+
+	r, err, logs, stderr := runPreflightCapturing(t, m, filePath, nil, ports.DecryptOptions{SkipHashVerify: true})
+	if err != nil {
+		t.Fatalf("expected proceed with --skip-hash-verify, got err = %v", err)
+	}
+	if r == nil {
+		t.Fatal("expected a reader when bypassing, got nil")
+	}
+	got, readErr := io.ReadAll(r)
+	if readErr != nil {
+		t.Fatalf("ReadAll() error = %v", readErr)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("bypassed plaintext mismatch: got %q want %q", string(got), string(content))
+	}
+
+	// Structured WARNING event, at WARN level, carrying the bypass marker.
+	if !strings.Contains(logs, "skip_hash_verify") {
+		t.Fatalf("missing structured skip_hash_verify event: %s", logs)
+	}
+	if !strings.Contains(logs, `"level":"WARN"`) {
+		t.Fatalf("skip_hash_verify event not emitted at WARN level: %s", logs)
+	}
+	// The match-path info log must NOT claim verification passed on a bypass.
+	if strings.Contains(logs, "hash verification passed") {
+		t.Fatalf("bypass wrongly logged 'hash verification passed': %s", logs)
+	}
+	// Prominent stderr line for interactive operators.
+	if !strings.Contains(stderr, "skip-hash-verify") || !strings.Contains(stderr, "WARNING") {
+		t.Fatalf("missing/weak stderr WARNING line: %q", stderr)
+	}
+}
+
+// (c) Flag on but hashes match: identical to today — no warning, normal info
+// log, and the flag is a no-op.
+func TestPreRestoreVerifyAndDecrypt_SkipHashVerifyNoOpOnMatch(t *testing.T) {
+	content := []byte("payload that matches its manifest")
+	filePath := writePlainBackup(t, content)
+	hash, err := computeHash(filePath)
+	if err != nil {
+		t.Fatalf("computeHash() error = %v", err)
+	}
+	m := &ports.BackupManifest{
+		BackupID: "match-flag-on",
+		Hash:     ports.HashInfo{Algorithm: "sha256", Value: hash},
+	}
+
+	r, err, logs, stderr := runPreflightCapturing(t, m, filePath, nil, ports.DecryptOptions{SkipHashVerify: true})
+	if err != nil {
+		t.Fatalf("unexpected error on matching hash: %v", err)
+	}
+	got, readErr := io.ReadAll(r)
+	if readErr != nil {
+		t.Fatalf("ReadAll() error = %v", readErr)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("payload mismatch: got %q want %q", string(got), string(content))
+	}
+	if strings.Contains(logs, "skip_hash_verify") || stderr != "" {
+		t.Fatalf("flag should be a no-op on a matching hash; logs=%s stderr=%q", logs, stderr)
+	}
+	if !strings.Contains(logs, "hash verification passed") {
+		t.Fatalf("expected normal 'hash verification passed' info log: %s", logs)
+	}
+}
+
+// (d) Second gate intact: for an encrypted artifact, --skip-hash-verify silences
+// the SHA-256 compare but a corrupt ciphertext still fails AES-256-GCM auth-tag
+// verification during decryption.
+func TestPreRestoreVerifyAndDecrypt_SkipHashVerifyStillEnforcesAuthTag(t *testing.T) {
+	masterKey := testMasterKey()
+	t.Setenv("TEST_RESTORE_MASTER_KEY", base64.StdEncoding.EncodeToString(masterKey))
+
+	filePath := writePlainBackup(t, []byte("encrypted backup payload to corrupt"))
+	m := createEncryptedBackup(t, filePath, "enc-corrupt-1", masterKey)
+
+	// Corrupt the final byte of the ciphertext (part of the last chunk's auth
+	// tag). This also changes the file's SHA-256, so the hash gate would abort
+	// were it not bypassed.
+	raw, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("read encrypted file: %v", err)
+	}
+	raw[len(raw)-1] ^= 0xFF
+	if err := os.WriteFile(filePath, raw, 0o644); err != nil {
+		t.Fatalf("write corrupted file: %v", err)
+	}
+
+	kp := &crypto.FileKeyProvider{EnvVar: "TEST_RESTORE_MASTER_KEY"}
+	r, err, logs, _ := runPreflightCapturing(t, m, filePath, kp, ports.DecryptOptions{SkipHashVerify: true})
+	if err != nil {
+		t.Fatalf("hash gate should be bypassed; got err = %v", err)
+	}
+	if !strings.Contains(logs, "skip_hash_verify") {
+		t.Fatalf("expected skip_hash_verify bypass event: %s", logs)
+	}
+	// The auth-tag failure surfaces while streaming the plaintext out.
+	_, readErr := io.ReadAll(r)
+	if readErr == nil {
+		t.Fatal("expected AES-GCM auth-tag failure on corrupt ciphertext, got nil")
+	}
+	if !errors.Is(readErr, ports.ErrAuthTagFailed) {
+		t.Fatalf("read error = %v, want ErrAuthTagFailed", readErr)
 	}
 }

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -127,6 +127,10 @@ var (
 	restoreLogLevel            string
 	restoreAllowLegacyEnvelope bool
 
+	// Run-only integrity escape hatch (PRD 39). Per-invocation, flag-only,
+	// off by default — never env-defaulted or config-driven.
+	restoreSkipHashVerify bool
+
 	// Run-all flags (spec 045 / PRD 31).
 	restoreRunAll   bool
 	restoreParallel int
@@ -163,6 +167,14 @@ func init() {
 	restoreRunCmd.Flags().BoolVar(&restoreKeepFile, "keep-file", false, "Keep staged restore artifact after run for debugging")
 	restoreRunCmd.Flags().BoolVar(&restoreRunAll, "all", false, "Run all enabled restore jobs concurrently (up to max_concurrent_restores)")
 	restoreRunCmd.Flags().IntVar(&restoreParallel, "parallel", 0, "Max concurrent restore jobs for --all (0 = use max_concurrent_restores)")
+	// Registered on the run command only (not persistently) so it cannot leak
+	// onto list/status/dry-run. Flag-only, off by default — no env default (an
+	// env default would silently defeat integrity checking across every restore
+	// on a host). PRD 39.
+	restoreRunCmd.Flags().BoolVar(&restoreSkipHashVerify, "skip-hash-verify", false,
+		"UNSAFE: proceed even if the artifact's SHA-256 does not match the manifest. "+
+			"Downgrades the integrity abort to a logged WARNING. Use only for a manifest/artifact "+
+			"you have independently verified, or last-copy disaster recovery.")
 }
 
 var restoreCmd = &cobra.Command{
@@ -373,6 +385,7 @@ func runOneRestoreJob(ctx context.Context, cfg *config.Configuration, mon *monit
 		LockDir:             cfg.Scheduler.LockDir,
 		Monitor:             mon,
 		AllowLegacyEnvelope: restoreAllowLegacyEnvelope,
+		SkipHashVerify:      restoreSkipHashVerify,
 	})
 	if err != nil {
 		notifyRestoreResult(ctx, jobName, job, result, err)

--- a/internal/ports/encryption.go
+++ b/internal/ports/encryption.go
@@ -31,6 +31,11 @@ type DecryptReader interface {
 type DecryptOptions struct {
 	// AllowLegacy permits decrypting pre-v2 (unversioned) artifacts. Off by default.
 	AllowLegacy bool
+	// SkipHashVerify downgrades a manifest hash mismatch from a hard abort to a
+	// logged WARNING. Off by default; set only by the per-invocation
+	// --skip-hash-verify restore flag. Never env-defaulted. It bypasses only the
+	// manifest SHA-256 compare — AES-256-GCM auth-tag verification stays enforced.
+	SkipHashVerify bool
 	// Source is a human-readable path/URI identifying the artifact (for log lines).
 	Source string
 	// BackupID is the AAD used during encryption.


### PR DESCRIPTION
## Recovered PRD 39 — `--skip-hash-verify` restore escape hatch

Recovers roadmap **M3 (v1.2.0)** minor integrity feature. Gives operators a **supported** recovery path past a *benign* manifest hash mismatch, instead of an unrecoverable hard abort.

- New per-invocation `--skip-hash-verify` flag on `restore run` (mirrors `--allow-legacy-envelope` plumbing: CLI flag → `ExecutionRequest.SkipHashVerify` → `applyPreflight` → `ports.DecryptOptions.SkipHashVerify` → preflight gate).
- **Safety**: default behaviour is UNCHANGED (verify on; a mismatch aborts with `ErrHashMismatch`). The flag is **flag-only** — never an env var / config default — and registered on `restoreRunCmd` only (can't leak onto list/status). On bypass it emits a structured `skip_hash_verify` WARN event **and** a prominent stderr WARNING (`SkipHashVerifyWarnMsg`); the "hash verification passed" log is now guarded to the true-match path.
- Encrypted artifacts keep their **independent AES-256-GCM auth-tag** integrity gate — the flag only silences the manifest SHA-256 compare, so a truly corrupt ciphertext still fails to decrypt (`ErrAuthTagFailed`). `backup verify` is untouched.

4 new preflight tests (mismatch off→abort, mismatch on→proceed+warn+no false "passed", match on→no-op, encrypted+corrupt→auth-tag still fails). `go build/vet/test` green. Release-notes in the consolidated follow-up.
