### PR TITLE
feat(backup): pipeline compression (gzip/zstd) for all engines (PRD 33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,29 @@ Plaintext is the default when no encryption config is present. See [docs/runbook
 
 ---
 
+## Compression
+
+Pipeline compression is opt-in and engine-agnostic — it primarily closes the gap
+for **MySQL / MariaDB**, whose dumps are otherwise raw SQL text (PostgreSQL and
+MongoDB already compress natively). The stage runs `dump → compress → hash →
+encrypt → upload`, and restore auto-detects the algorithm from the manifest (no
+operator flag).
+
+```yaml
+defaults:
+  compression:
+    enabled: true
+    algorithm: zstd      # gzip | zstd | none  (default: zstd)
+    level: 6             # gzip 1–9, zstd 1–19  (0/omitted = per-algorithm default)
+```
+
+Enabling pipeline compression alongside engine-native compression
+(`pg_dump --compress` / `mongodump --gzip`) on the same job is rejected to
+prevent double-compression. Default is off (no behaviour change until enabled).
+See [docs/runbooks/backup-compression.md](docs/runbooks/backup-compression.md).
+
+---
+
 ## Contributing
 
 - [CONTRIBUTING.md](CONTRIBUTING.md) — setup, coding standards, PR process

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -14,6 +14,7 @@ Operational procedures for running, recovering, and maintaining Sentinel in prod
 ## Setup
 - [Environment setup](./environment-setup.md)
 - [Enable encryption](./enable-encryption.md)
+- [Backup compression (gzip/zstd)](./backup-compression.md)
 - [Database credentials](./credentials.md)
 - [Alerting setup](./alerting-setup.md)
 - [DB migration status](./db-migration-status.md)

--- a/docs/runbooks/backup-compression.md
+++ b/docs/runbooks/backup-compression.md
@@ -1,0 +1,173 @@
+# Runbook — Backup compression (gzip / zstd)
+
+- **Audience**: ops / SRE
+- **Last reviewed**: 2026-08-02
+- **Related**: PRD 33 / spec 049 (pipeline compression), [enable-encryption](./enable-encryption.md), [verify-backup-integrity](./verify-backup-integrity.md), [restore-from-backup](./restore-from-backup.md), [check-storage-backend](./check-storage-backend.md)
+
+## When to use
+
+You want to shrink backup artifacts (storage-at-rest + upload/download bandwidth)
+for the engines that do **not** compress natively — **MySQL** and **MariaDB**,
+whose dumps stream to storage as raw SQL text. SQL data typically compresses
+~80–90%.
+
+PostgreSQL (`pg_dump --compress`) and MongoDB (`mongodump --gzip`) already
+compress natively; pipeline compression is available for them too, but you must
+not enable both at once (see the double-compress guard below).
+
+## How it works
+
+Compression is an **engine-agnostic streaming pipeline stage**, a sibling of the
+AES-256-GCM encryption stage. The order is load-bearing:
+
+```
+dump → compress → SHA-256 hash → encrypt → upload
+```
+
+- **Compress before encrypt** — ciphertext is incompressible, so compressing
+  after encryption would achieve ~0%.
+- The recorded manifest hash covers the **compressed** bytes (the artifact that
+  lands in storage), consistent with the encrypted-path precedent.
+- The artifact keeps its configured filename (no `.gz` / `.zst` suffix is added);
+  the manifest records the algorithm + level, and restore reads it back
+  automatically.
+
+Restore is fully automatic: `download → decrypt → decompress → feed to the
+restore tool`, with the algorithm read from the manifest — **no operator flag**.
+
+## Preconditions
+
+- Sentinel binary present (compression is pure-Go: stdlib gzip +
+  `github.com/klauspost/compress/zstd`, no external tools).
+- Opt-in: nothing changes until you set `compression.enabled: true`.
+
+## Configuration
+
+`CompressionConfig` can be set per job (`databases.<job>.compression`) or as a
+global default (`defaults.compression`); a job without its own block inherits the
+default (same inheritance rule as retention).
+
+```yaml
+defaults:
+  compression:
+    enabled: true
+    algorithm: zstd      # gzip | zstd | none  (default: zstd)
+    level: 6             # gzip 1–9, zstd 1–19  (0/omitted = per-algorithm default)
+
+databases:
+  prod-mysql:
+    type: mysql
+    host: host.docker.internal
+    port: 3306
+    username: sentinel
+    password_env: DEV_MYSQL_PASSWORD
+    database: app
+    output: prod-mysql.sql
+    compression:
+      enabled: true
+      algorithm: gzip     # override the default for this job
+```
+
+Fields:
+
+- `enabled` — turns pipeline compression on. Default `false` (opt-in; zero
+  behaviour change until set).
+- `algorithm` — `gzip`, `zstd`, or `none`. Omitted → `zstd` (best ratio/speed,
+  pure Go). `none` means "no pipeline compression" even if `enabled: true`.
+- `level` — codec level. gzip `1`–`9`, zstd `1`–`19`. `0` / omitted selects the
+  per-algorithm default (gzip 6, zstd 3).
+
+### Double-compress guard (Option A)
+
+Pipeline compression may **not** be enabled on a job that also uses
+engine-native compression. Validation fails with:
+
+```
+backup '<job>': compression cannot be enabled together with engine-native
+compression (postgres compress/pg_compression_* or mongodb gzip); disable one
+to avoid double-compression
+```
+
+Native compression means, for PostgreSQL, any of the `compress`,
+`pg_compression_algo` (≠ `none`), or `pg_compression_level` database options; for
+MongoDB, `gzip: true`. Choose one mechanism per job.
+
+## Steps
+
+### Enable and run
+
+```bash
+export DEV_MYSQL_PASSWORD=sentinel
+sentinel config validate --config /workspace/infra/dataset/local.yaml
+sentinel backup --config /workspace/infra/dataset/local.yaml
+```
+
+### Confirm the artifact shrank
+
+Compare against an uncompressed baseline of the same database:
+
+```bash
+ls -l /workspace/backups/prod-mysql.sql
+```
+
+Expect a materially smaller file (target ≥ 80% reduction on SQL data).
+
+### Inspect the manifest
+
+```bash
+cat /workspace/backups/prod-mysql.sql.manifest.json
+```
+
+```json
+{
+  "hash": { "algorithm": "sha256", "value": "<hash-of-compressed-bytes>" },
+  "compression": { "algorithm": "gzip", "level": 6 }
+}
+```
+
+The `compression` block is what restore auto-detects. A backup **without** a
+`compression` block (legacy backups, or natively-compressed PG/Mongo dumps) is
+restored unchanged — no decompress stage is attempted.
+
+## Restore
+
+No extra flags. Point the restore job at the artifact as usual; Sentinel reads
+`compression.algorithm` from the manifest and inserts the decompress stage after
+decryption:
+
+```bash
+sentinel restore run <job> --config /workspace/infra/dataset/local.yaml
+```
+
+If the artifact is also encrypted, the order is decrypt → decompress → restore,
+handled automatically.
+
+## Compression + encryption
+
+Both can be enabled on the same job. The pipeline compresses first, then
+encrypts (ciphertext is incompressible, so this order is mandatory). The manifest
+carries both a `compression` block and an `encryption` block; the `hash.value`
+covers the final stored (compressed-then-encrypted) bytes.
+
+## Rollback / recovery
+
+To stop compressing new backups, set `compression.enabled: false` (or remove the
+block) and re-run. Existing compressed artifacts remain restorable — the manifest
+records how to decompress them.
+
+## Choosing an algorithm
+
+- **zstd** (default) — best ratio-for-speed; recommended for most workloads.
+- **gzip** — ubiquitous, slightly lower ratio; use when downstream tooling must
+  read the raw stream with standard `gzip`.
+
+lz4 / snappy are intentionally out of scope for v1.
+
+## References
+
+- `internal/adapters/compress/` — gzip + zstd codecs (`ports.CompressWriter` /
+  `ports.DecompressReader`)
+- `internal/domain/backup/pipeline.go` — `ApplyArtifactSecurity` (compress stage)
+- `internal/cli/backup_factory.go` — `compressBackupFile` (hook wiring)
+- `internal/adapters/restore/runtime/executor.go` — `applyPreflight` (decompress)
+- `internal/config/{types,validator,loader}.go` — `CompressionConfig`

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/smithy-go v1.22.0
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+	github.com/klauspost/compress v1.18.0
 	github.com/lib/pq v1.12.3
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.8.1
@@ -80,7 +81,6 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.13.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect

--- a/internal/adapters/compress/compress.go
+++ b/internal/adapters/compress/compress.go
@@ -1,0 +1,131 @@
+// Package compress is the driving adapter for pipeline backup compression
+// (PRD 33 / spec 049). It implements ports.CompressWriter / DecompressReader
+// over two pure-Go codecs:
+//
+//   - gzip  — stdlib compress/gzip
+//   - zstd  — github.com/klauspost/compress/zstd (no cgo)
+//
+// The stage is engine-agnostic: it mirrors the AES-256-GCM streaming stage in
+// internal/adapters/crypto. Domain code never imports this package — the
+// backup Executor reaches compression through a Job hook wired by
+// internal/cli/backup_factory.go, and the restore runtime (a composition
+// root) constructs the decompressor directly. The algorithm/level are carried
+// in the backup manifest (ports.CompressionInfo).
+package compress
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+
+	"github.com/klauspost/compress/zstd"
+
+	"github.com/denisakp/sentinel/internal/ports"
+)
+
+// Supported pipeline compression algorithms.
+const (
+	AlgorithmGzip = "gzip"
+	AlgorithmZstd = "zstd"
+	// AlgorithmNone is a valid config value meaning "no pipeline compression".
+	AlgorithmNone = "none"
+)
+
+// Default per-algorithm compression levels applied when the config omits a
+// level (level == 0). gzip default mirrors the classic level 6; zstd default
+// (3) maps to klauspost's SpeedDefault.
+const (
+	DefaultGzipLevel = 6
+	DefaultZstdLevel = 3
+)
+
+// Inclusive per-algorithm level bounds. gzip: 1..9 (compress/gzip). zstd:
+// 1..19 (the conventional zstd CLI range; klauspost clamps to its four
+// internal speed tiers).
+const (
+	MinGzipLevel = 1
+	MaxGzipLevel = 9
+	MinZstdLevel = 1
+	MaxZstdLevel = 19
+)
+
+// IsSupportedAlgorithm reports whether algorithm is one this adapter can build
+// a codec for (gzip or zstd). "none" and "" are NOT supported codecs — callers
+// treat those as "compression disabled" before reaching here.
+func IsSupportedAlgorithm(algorithm string) bool {
+	return algorithm == AlgorithmGzip || algorithm == AlgorithmZstd
+}
+
+// DefaultLevel returns the per-algorithm default level (used when config
+// omits level). Returns 0 for unknown algorithms.
+func DefaultLevel(algorithm string) int {
+	switch algorithm {
+	case AlgorithmGzip:
+		return DefaultGzipLevel
+	case AlgorithmZstd:
+		return DefaultZstdLevel
+	default:
+		return 0
+	}
+}
+
+// NewCompressWriter returns a streaming compressor for algorithm writing the
+// compressed stream to w. A zero level selects the per-algorithm default.
+func NewCompressWriter(w io.Writer, algorithm string, level int) (ports.CompressWriter, error) {
+	switch algorithm {
+	case AlgorithmGzip:
+		if level == 0 {
+			level = DefaultGzipLevel
+		}
+		gw, err := gzip.NewWriterLevel(w, level)
+		if err != nil {
+			return nil, fmt.Errorf("compress: invalid gzip level %d: %w", level, err)
+		}
+		return gw, nil
+	case AlgorithmZstd:
+		if level == 0 {
+			level = DefaultZstdLevel
+		}
+		zw, err := zstd.NewWriter(w, zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(level)))
+		if err != nil {
+			return nil, fmt.Errorf("compress: failed to initialise zstd writer: %w", err)
+		}
+		return zw, nil
+	default:
+		return nil, fmt.Errorf("compress: unsupported algorithm %q (want gzip or zstd)", algorithm)
+	}
+}
+
+// NewDecompressReader returns a streaming decompressor for algorithm reading
+// the compressed stream from r. The restore runtime selects the algorithm
+// from the backup manifest.
+func NewDecompressReader(r io.Reader, algorithm string) (ports.DecompressReader, error) {
+	switch algorithm {
+	case AlgorithmGzip:
+		gr, err := gzip.NewReader(r)
+		if err != nil {
+			return nil, fmt.Errorf("compress: failed to initialise gzip reader: %w", err)
+		}
+		return gr, nil
+	case AlgorithmZstd:
+		zr, err := zstd.NewReader(r)
+		if err != nil {
+			return nil, fmt.Errorf("compress: failed to initialise zstd reader: %w", err)
+		}
+		return &zstdReadCloser{Decoder: zr}, nil
+	default:
+		return nil, fmt.Errorf("compress: unsupported algorithm %q (want gzip or zstd)", algorithm)
+	}
+}
+
+// zstdReadCloser adapts *zstd.Decoder (whose Close() returns nothing) to
+// ports.DecompressReader (Close() error).
+type zstdReadCloser struct {
+	*zstd.Decoder
+}
+
+// Close releases the decoder. *zstd.Decoder.Close never reports an error.
+func (z *zstdReadCloser) Close() error {
+	z.Decoder.Close()
+	return nil
+}

--- a/internal/adapters/compress/compress_test.go
+++ b/internal/adapters/compress/compress_test.go
@@ -1,0 +1,134 @@
+package compress
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+// sampleData returns a compressible payload (repetitive SQL-like text).
+func sampleData() []byte {
+	var b strings.Builder
+	for i := 0; i < 2000; i++ {
+		b.WriteString("INSERT INTO t (a, b, c) VALUES (1, 'hello world', 'compress me');\n")
+	}
+	return []byte(b.String())
+}
+
+func TestRoundTrip(t *testing.T) {
+	cases := []struct {
+		algorithm string
+		level     int
+	}{
+		{AlgorithmGzip, 0}, // default
+		{AlgorithmGzip, 1},
+		{AlgorithmGzip, 9},
+		{AlgorithmZstd, 0}, // default
+		{AlgorithmZstd, 1},
+		{AlgorithmZstd, 19},
+	}
+
+	original := sampleData()
+	for _, tc := range cases {
+		t.Run(tc.algorithm, func(t *testing.T) {
+			var compressed bytes.Buffer
+			cw, err := NewCompressWriter(&compressed, tc.algorithm, tc.level)
+			if err != nil {
+				t.Fatalf("NewCompressWriter() error = %v", err)
+			}
+			if _, err := cw.Write(original); err != nil {
+				t.Fatalf("Write() error = %v", err)
+			}
+			if err := cw.Close(); err != nil {
+				t.Fatalf("Close() error = %v", err)
+			}
+
+			if compressed.Len() >= len(original) {
+				t.Fatalf("compressed size %d not smaller than original %d", compressed.Len(), len(original))
+			}
+
+			dr, err := NewDecompressReader(bytes.NewReader(compressed.Bytes()), tc.algorithm)
+			if err != nil {
+				t.Fatalf("NewDecompressReader() error = %v", err)
+			}
+			defer dr.Close()
+
+			got, err := io.ReadAll(dr)
+			if err != nil {
+				t.Fatalf("ReadAll() error = %v", err)
+			}
+			if !bytes.Equal(got, original) {
+				t.Fatalf("round-trip mismatch: got %d bytes, want %d", len(got), len(original))
+			}
+		})
+	}
+}
+
+func TestNewCompressWriterUnsupportedAlgorithm(t *testing.T) {
+	if _, err := NewCompressWriter(&bytes.Buffer{}, "lz4", 0); err == nil {
+		t.Fatal("expected error for unsupported compress algorithm")
+	}
+	if _, err := NewCompressWriter(&bytes.Buffer{}, AlgorithmNone, 0); err == nil {
+		t.Fatal("expected error for 'none' algorithm (callers must gate this out)")
+	}
+}
+
+func TestNewDecompressReaderUnsupportedAlgorithm(t *testing.T) {
+	if _, err := NewDecompressReader(bytes.NewReader(nil), "lz4"); err == nil {
+		t.Fatal("expected error for unsupported decompress algorithm")
+	}
+}
+
+func TestNewCompressWriterInvalidGzipLevel(t *testing.T) {
+	// gzip level 42 is out of the stdlib range; the writer constructor rejects it.
+	if _, err := NewCompressWriter(&bytes.Buffer{}, AlgorithmGzip, 42); err == nil {
+		t.Fatal("expected error for out-of-range gzip level")
+	}
+}
+
+func TestIsSupportedAlgorithm(t *testing.T) {
+	for _, a := range []string{AlgorithmGzip, AlgorithmZstd} {
+		if !IsSupportedAlgorithm(a) {
+			t.Errorf("IsSupportedAlgorithm(%q) = false, want true", a)
+		}
+	}
+	for _, a := range []string{AlgorithmNone, "", "lz4"} {
+		if IsSupportedAlgorithm(a) {
+			t.Errorf("IsSupportedAlgorithm(%q) = true, want false", a)
+		}
+	}
+}
+
+func TestDefaultLevel(t *testing.T) {
+	if got := DefaultLevel(AlgorithmGzip); got != DefaultGzipLevel {
+		t.Errorf("DefaultLevel(gzip) = %d, want %d", got, DefaultGzipLevel)
+	}
+	if got := DefaultLevel(AlgorithmZstd); got != DefaultZstdLevel {
+		t.Errorf("DefaultLevel(zstd) = %d, want %d", got, DefaultZstdLevel)
+	}
+	if got := DefaultLevel("none"); got != 0 {
+		t.Errorf("DefaultLevel(none) = %d, want 0", got)
+	}
+}
+
+// TestCrossAlgorithmMismatchFails ensures a zstd stream cannot be decoded as
+// gzip (and gives a clear error rather than silent corruption).
+func TestCrossAlgorithmMismatchFails(t *testing.T) {
+	var compressed bytes.Buffer
+	cw, err := NewCompressWriter(&compressed, AlgorithmZstd, 0)
+	if err != nil {
+		t.Fatalf("NewCompressWriter() error = %v", err)
+	}
+	if _, err := cw.Write(sampleData()); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if err := cw.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	// gzip reader construction reads/validates the header eagerly and should fail.
+	if _, err := NewDecompressReader(bytes.NewReader(compressed.Bytes()), AlgorithmGzip); err == nil {
+		t.Fatal("expected error decoding a zstd stream as gzip")
+	}
+}

--- a/internal/adapters/compress/conformance.go
+++ b/internal/adapters/compress/conformance.go
@@ -1,0 +1,19 @@
+package compress
+
+import (
+	"compress/gzip"
+
+	"github.com/klauspost/compress/zstd"
+
+	"github.com/denisakp/sentinel/internal/ports"
+)
+
+// Compile-time assertions that the concrete codec types satisfy their declared
+// ports. A signature drift on either side breaks the build here rather than at
+// distant call sites (mirrors internal/adapters/crypto/conformance.go).
+var (
+	_ ports.CompressWriter   = (*gzip.Writer)(nil)
+	_ ports.CompressWriter   = (*zstd.Encoder)(nil)
+	_ ports.DecompressReader = (*gzip.Reader)(nil)
+	_ ports.DecompressReader = (*zstdReadCloser)(nil)
+)

--- a/internal/adapters/restore/runtime/compress_decompress_test.go
+++ b/internal/adapters/restore/runtime/compress_decompress_test.go
@@ -1,0 +1,140 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/denisakp/sentinel/internal/adapters/compress"
+	"github.com/denisakp/sentinel/internal/adapters/crypto"
+	manifest "github.com/denisakp/sentinel/internal/adapters/manifest_store"
+	"github.com/denisakp/sentinel/internal/config"
+	"github.com/denisakp/sentinel/internal/ports"
+)
+
+// writeCompressedBackup compresses plaintext into path with the given algorithm
+// and returns the SHA-256 hex digest of the compressed (stored) bytes.
+func writeCompressedBackup(t *testing.T, path string, plaintext []byte, algorithm string) string {
+	t.Helper()
+	out, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create compressed backup: %v", err)
+	}
+	hw := crypto.NewHashingWriter(out)
+	cw, err := compress.NewCompressWriter(hw, algorithm, 0)
+	if err != nil {
+		t.Fatalf("NewCompressWriter(): %v", err)
+	}
+	if _, err := cw.Write(plaintext); err != nil {
+		t.Fatalf("compress write: %v", err)
+	}
+	if err := cw.Close(); err != nil {
+		t.Fatalf("compress close: %v", err)
+	}
+	hash := hw.Sum()
+	if err := out.Close(); err != nil {
+		t.Fatalf("close compressed backup: %v", err)
+	}
+	return hash
+}
+
+// TestApplyPreflight_DecompressesFromManifest asserts restore auto-detects
+// pipeline compression from the manifest (no operator flag) and decompresses
+// the staged artifact back to the original plaintext dump.
+func TestApplyPreflight_DecompressesFromManifest(t *testing.T) {
+	for _, algorithm := range []string{compress.AlgorithmGzip, compress.AlgorithmZstd} {
+		t.Run(algorithm, func(t *testing.T) {
+			dir := t.TempDir()
+			stagedPath := filepath.Join(dir, "backup.sql")
+			plaintext := bytes.Repeat([]byte("-- restore me, decompressed --\n"), 200)
+
+			hash := writeCompressedBackup(t, stagedPath, plaintext, algorithm)
+
+			manifestPath := stagedPath + ".manifest.json"
+			m := &ports.BackupManifest{
+				BackupID:     "cmp-1",
+				Database:     "db",
+				DatabaseType: "postgres",
+				CreatedAt:    time.Now().UTC(),
+				Hash:         ports.HashInfo{Algorithm: "sha256", Value: hash},
+				Compression:  &ports.CompressionInfo{Algorithm: algorithm, Level: 0},
+			}
+			if err := manifest.WriteManifest(manifestPath, m); err != nil {
+				t.Fatalf("WriteManifest(): %v", err)
+			}
+
+			artifact := &StagedArtifact{Path: stagedPath, ManifestPath: manifestPath}
+			outPath, err := applyPreflight(context.Background(), &config.Configuration{}, artifact, false, false)
+			if err != nil {
+				t.Fatalf("applyPreflight() error = %v", err)
+			}
+
+			got, err := os.ReadFile(outPath)
+			if err != nil {
+				t.Fatalf("read decompressed output: %v", err)
+			}
+			if !bytes.Equal(got, plaintext) {
+				t.Fatalf("decompressed payload mismatch: got %d bytes, want %d", len(got), len(plaintext))
+			}
+		})
+	}
+}
+
+// TestApplyPreflight_NoCompressionBlockUnchanged asserts a manifest WITHOUT a
+// compression block leaves a plaintext staged artifact byte-for-byte unchanged
+// (legacy backup backward-compat: no decompress attempted).
+func TestApplyPreflight_NoCompressionBlockUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	stagedPath := filepath.Join(dir, "backup.sql")
+	plaintext := []byte("-- an uncompressed, unencrypted dump --\n")
+	if err := os.WriteFile(stagedPath, plaintext, 0o600); err != nil {
+		t.Fatalf("write staged artifact: %v", err)
+	}
+
+	// Hash of the plaintext (stored) bytes.
+	hash := hashFile(t, stagedPath)
+
+	manifestPath := stagedPath + ".manifest.json"
+	m := &ports.BackupManifest{
+		BackupID:     "plain-1",
+		Database:     "db",
+		DatabaseType: "postgres",
+		CreatedAt:    time.Now().UTC(),
+		Hash:         ports.HashInfo{Algorithm: "sha256", Value: hash},
+	}
+	if err := manifest.WriteManifest(manifestPath, m); err != nil {
+		t.Fatalf("WriteManifest(): %v", err)
+	}
+
+	artifact := &StagedArtifact{Path: stagedPath, ManifestPath: manifestPath}
+	outPath, err := applyPreflight(context.Background(), &config.Configuration{}, artifact, false, false)
+	if err != nil {
+		t.Fatalf("applyPreflight() error = %v", err)
+	}
+
+	got, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("payload changed: got %q want %q", got, plaintext)
+	}
+}
+
+// hashFile computes the SHA-256 hex digest of the file at path.
+func hashFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read for hash: %v", err)
+	}
+	hw := crypto.NewHashingWriter(io.Discard)
+	if _, err := hw.Write(data); err != nil {
+		t.Fatalf("hash write: %v", err)
+	}
+	return hw.Sum()
+}

--- a/internal/adapters/restore/runtime/executor.go
+++ b/internal/adapters/restore/runtime/executor.go
@@ -14,6 +14,7 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/denisakp/sentinel/internal/adapters/compress"
 	"github.com/denisakp/sentinel/internal/adapters/crypto"
 	"github.com/denisakp/sentinel/internal/adapters/lock"
 	manifest "github.com/denisakp/sentinel/internal/adapters/manifest_store"
@@ -331,6 +332,19 @@ func applyPreflight(ctx context.Context, cfg *config.Configuration, artifact *St
 			return "", fmt.Errorf("integrity_check_failed: %w", err)
 		}
 		return "", err
+	}
+
+	// Decompress stage (spec 049 / PRD 33): inserted AFTER decrypt, driven by
+	// the manifest (no operator flag). A manifest without a compression block
+	// (legacy backups, native-compressed PG/Mongo dumps) skips this entirely,
+	// so existing backups restore byte-for-byte unchanged.
+	if m.Compression != nil && m.Compression.Algorithm != "" && m.Compression.Algorithm != "none" {
+		dr, derr := compress.NewDecompressReader(reader, m.Compression.Algorithm)
+		if derr != nil {
+			return "", fmt.Errorf("failed to initialise decompressor for %q: %w", artifact.Path, derr)
+		}
+		defer dr.Close()
+		reader = dr
 	}
 
 	decryptedPath := artifact.Path + ".plaintext"

--- a/internal/cli/backup_factory.go
+++ b/internal/cli/backup_factory.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	compresspkg "github.com/denisakp/sentinel/internal/adapters/compress"
 	"github.com/denisakp/sentinel/internal/adapters/crypto"
 	dbprobe "github.com/denisakp/sentinel/internal/adapters/db_probe"
 	dumpmariadb "github.com/denisakp/sentinel/internal/adapters/dump/mariadb"
@@ -285,6 +286,17 @@ func buildDomainBackupJob(
 		djob.GCSBucket = storageParams.GCSBucket
 	}
 
+	// Pipeline compression (spec 049 / PRD 33): wired only when the effective
+	// (post-inheritance) job config enables it with a real codec. The validator
+	// has already rejected enabling this alongside engine-native compression.
+	if cc := job.Compression; cc != nil && cc.Enabled && cc.Algorithm != "" && cc.Algorithm != "none" {
+		algorithm := cc.Algorithm
+		level := cc.Level
+		djob.CompressArtifact = func(path string) (bool, *ports.CompressionInfo, string, error) {
+			return compressBackupFile(algorithm, level, path)
+		}
+	}
+
 	if encryptionConfigured(cfg) {
 		djob.EncryptionKeyHint = cfg.EncryptionKeyEnv
 		djob.EncryptArtifact = func(path, backupID string) (bool, *ports.EncryptionInfo, string, error) {
@@ -366,6 +378,63 @@ func archiveMongoOplogArtifacts(ctx context.Context, job config.BackupJob, backu
 	return backup.IncrementalArtifacts{
 		OplogArtifactPath: archiveResult.ArchivePath,
 	}, nil
+}
+
+// compressBackupFile compresses filePath in place using the pipeline codec
+// (gzip/zstd) and returns (compressed, compression info, sha256 of the
+// compressed bytes). It mirrors encryptBackupFile: stream source → codec →
+// HashingWriter → temp file, then atomically replace the original. The
+// compressed digest is the stored-artifact hash when the backup is not
+// subsequently encrypted (spec 049 / PRD 33).
+func compressBackupFile(algorithm string, level int, filePath string) (bool, *ports.CompressionInfo, string, error) {
+	in, err := os.Open(filePath)
+	if err != nil {
+		return false, nil, "", fmt.Errorf("failed to open file for compression: %w", err)
+	}
+
+	cmpPath := filePath + ".cmp"
+	out, err := os.Create(cmpPath)
+	if err != nil {
+		in.Close()
+		return false, nil, "", fmt.Errorf("failed to create compressed output: %w", err)
+	}
+
+	hw := crypto.NewHashingWriter(out)
+	cw, err := compresspkg.NewCompressWriter(hw, algorithm, level)
+	if err != nil {
+		in.Close()
+		out.Close()
+		os.Remove(cmpPath)
+		return false, nil, "", err
+	}
+
+	if _, copyErr := io.Copy(cw, in); copyErr != nil {
+		in.Close()
+		cw.Close()
+		out.Close()
+		os.Remove(cmpPath)
+		return false, nil, "", fmt.Errorf("failed during compression: %w", copyErr)
+	}
+	in.Close()
+
+	if closeErr := cw.Close(); closeErr != nil {
+		out.Close()
+		os.Remove(cmpPath)
+		return false, nil, "", fmt.Errorf("failed to finalize compressed data: %w", closeErr)
+	}
+
+	compressedHash := hw.Sum()
+	if closeErr := out.Close(); closeErr != nil {
+		os.Remove(cmpPath)
+		return false, nil, "", fmt.Errorf("failed to close compressed output: %w", closeErr)
+	}
+
+	if renameErr := os.Rename(cmpPath, filePath); renameErr != nil {
+		os.Remove(cmpPath)
+		return false, nil, "", fmt.Errorf("failed to replace file with compressed version: %w", renameErr)
+	}
+
+	return true, &ports.CompressionInfo{Algorithm: algorithm, Level: level}, compressedHash, nil
 }
 
 // encryptBackupFile encrypts filePath in-place using AES-256-GCM via

--- a/internal/config/compression_loader_test.go
+++ b/internal/config/compression_loader_test.go
@@ -1,0 +1,75 @@
+package config
+
+import "testing"
+
+func TestApplyCompressionDefaults(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        *CompressionConfig
+		wantAlgo  string
+		wantLevel int
+	}{
+		{"nil untouched", nil, "", 0},
+		{"disabled untouched", &CompressionConfig{Enabled: false}, "", 0},
+		{"enabled empty -> zstd default", &CompressionConfig{Enabled: true}, "zstd", 3},
+		{"enabled gzip default level", &CompressionConfig{Enabled: true, Algorithm: "gzip"}, "gzip", 6},
+		{"explicit level preserved", &CompressionConfig{Enabled: true, Algorithm: "gzip", Level: 2}, "gzip", 2},
+		{"explicit zstd level preserved", &CompressionConfig{Enabled: true, Algorithm: "zstd", Level: 12}, "zstd", 12},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			applyCompressionDefaults(tc.in)
+			if tc.in == nil {
+				return
+			}
+			if tc.in.Algorithm != tc.wantAlgo {
+				t.Errorf("Algorithm = %q, want %q", tc.in.Algorithm, tc.wantAlgo)
+			}
+			if tc.in.Level != tc.wantLevel {
+				t.Errorf("Level = %d, want %d", tc.in.Level, tc.wantLevel)
+			}
+		})
+	}
+}
+
+// TestCompressionInheritance verifies a job without its own compression block
+// inherits (a copy of) defaults.compression, while a job with its own block
+// does not — mirroring the retention inheritance contract.
+func TestCompressionInheritance(t *testing.T) {
+	enabled := true
+	cfg := &Configuration{
+		MaxConcurrentBackups: 1,
+		Defaults: GlobalDefaults{
+			Compression: &CompressionConfig{Enabled: true, Algorithm: "gzip", Level: 4},
+		},
+		Databases: map[string]BackupJob{
+			"inherits": {Type: "postgres", Enabled: &enabled},
+			"overrides": {
+				Type:        "postgres",
+				Enabled:     &enabled,
+				Compression: &CompressionConfig{Enabled: false},
+			},
+		},
+	}
+
+	applyDefaults(cfg)
+
+	inherits := cfg.Databases["inherits"]
+	if inherits.Compression == nil {
+		t.Fatal("inherits.Compression = nil, want inherited defaults")
+	}
+	if !inherits.Compression.Enabled || inherits.Compression.Algorithm != "gzip" || inherits.Compression.Level != 4 {
+		t.Fatalf("inherited compression = %#v", inherits.Compression)
+	}
+
+	// Inheritance must be a copy: mutating the job must not touch defaults.
+	inherits.Compression.Level = 9
+	if cfg.Defaults.Compression.Level != 4 {
+		t.Fatalf("defaults mutated via inherited copy: level = %d", cfg.Defaults.Compression.Level)
+	}
+
+	overrides := cfg.Databases["overrides"]
+	if overrides.Compression == nil || overrides.Compression.Enabled {
+		t.Fatalf("overrides.Compression = %#v, want explicit disabled block", overrides.Compression)
+	}
+}

--- a/internal/config/compression_validator_test.go
+++ b/internal/config/compression_validator_test.go
@@ -1,0 +1,128 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// compressionJob returns a minimal valid postgres job with the given
+// compression + database options applied, wrapped in a Configuration.
+func compressionJob(t *testing.T, compression *CompressionConfig, dbOpts map[string]interface{}, engine string) *Configuration {
+	t.Helper()
+	enabled := true
+	job := BackupJob{
+		Name:            "job",
+		Type:            engine,
+		Enabled:         &enabled,
+		Host:            "localhost",
+		Username:        "sentinel",
+		PasswordEnv:     "TEST_PASSWORD",
+		Database:        "app",
+		Storage:         StorageConfig{Type: "local", LocalPath: "/tmp"},
+		DatabaseOptions: dbOpts,
+		Compression:     compression,
+	}
+	if engine == "mongodb" {
+		job.URI = "mongodb://localhost:27017"
+		job.Host = ""
+		job.Username = ""
+		job.PasswordEnv = ""
+	}
+	return &Configuration{
+		Version:              "1.0",
+		MaxConcurrentBackups: 1,
+		Databases:            map[string]BackupJob{"job": job},
+	}
+}
+
+func TestValidateCompression_Valid(t *testing.T) {
+	cases := []struct {
+		name string
+		c    *CompressionConfig
+	}{
+		{"nil", nil},
+		{"disabled", &CompressionConfig{Enabled: false, Algorithm: "gzip"}},
+		{"zstd default level", &CompressionConfig{Enabled: true, Algorithm: "zstd"}},
+		{"gzip level 9", &CompressionConfig{Enabled: true, Algorithm: "gzip", Level: 9}},
+		{"zstd level 19", &CompressionConfig{Enabled: true, Algorithm: "zstd", Level: 19}},
+		{"algorithm none allowed when present", &CompressionConfig{Enabled: false, Algorithm: "none"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := compressionJob(t, tc.c, nil, "postgres")
+			if err := ValidateConfig(cfg); err != nil {
+				t.Fatalf("ValidateConfig() unexpected error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateCompression_Invalid(t *testing.T) {
+	cases := []struct {
+		name    string
+		c       *CompressionConfig
+		wantErr string
+	}{
+		{"bad algorithm", &CompressionConfig{Enabled: true, Algorithm: "lz4"}, "must be one of: gzip, zstd, none"},
+		{"gzip level too high", &CompressionConfig{Enabled: true, Algorithm: "gzip", Level: 10}, "gzip must be between 1 and 9"},
+		{"gzip level negative", &CompressionConfig{Enabled: true, Algorithm: "gzip", Level: -1}, "gzip must be between 1 and 9"},
+		{"zstd level too high", &CompressionConfig{Enabled: true, Algorithm: "zstd", Level: 20}, "zstd must be between 1 and 19"},
+		{"enabled with none", &CompressionConfig{Enabled: true, Algorithm: "none"}, "algorithm is 'none'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := compressionJob(t, tc.c, nil, "postgres")
+			err := ValidateConfig(cfg)
+			if err == nil {
+				t.Fatalf("ValidateConfig() error = nil, want error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("ValidateConfig() error = %v, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidateCompression_RejectsDoubleCompress covers the Option A guard: a
+// job may not enable pipeline compression AND engine-native compression.
+func TestValidateCompression_RejectsDoubleCompress(t *testing.T) {
+	cases := []struct {
+		name   string
+		engine string
+		dbOpts map[string]interface{}
+	}{
+		{"pg compress level", "postgres", map[string]interface{}{"compress": 6}},
+		{"pg compression algo", "postgres", map[string]interface{}{"pg_compression_algo": "zstd"}},
+		{"pg compression level", "postgres", map[string]interface{}{"pg_compression_level": 5}},
+		{"mongo gzip", "mongodb", map[string]interface{}{"gzip": true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := compressionJob(t, &CompressionConfig{Enabled: true, Algorithm: "zstd"}, tc.dbOpts, tc.engine)
+			err := ValidateConfig(cfg)
+			if err == nil {
+				t.Fatal("ValidateConfig() error = nil, want double-compress rejection")
+			}
+			if !strings.Contains(err.Error(), "engine-native compression") {
+				t.Fatalf("ValidateConfig() error = %v, want double-compress error", err)
+			}
+		})
+	}
+}
+
+// TestValidateCompression_NativeWithoutPipelineAllowed ensures native
+// compression alone (no pipeline compression) still validates — the guard only
+// fires when BOTH are set.
+func TestValidateCompression_NativeWithoutPipelineAllowed(t *testing.T) {
+	cfg := compressionJob(t, nil, map[string]interface{}{"compress": 6}, "postgres")
+	if err := ValidateConfig(cfg); err != nil {
+		t.Fatalf("ValidateConfig() unexpected error = %v", err)
+	}
+
+	// pipeline compression on a PG job with pg_compression_algo=none is fine.
+	cfg2 := compressionJob(t, &CompressionConfig{Enabled: true, Algorithm: "zstd"},
+		map[string]interface{}{"pg_compression_algo": "none"}, "postgres")
+	if err := ValidateConfig(cfg2); err != nil {
+		t.Fatalf("ValidateConfig() unexpected error = %v", err)
+	}
+}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -100,6 +100,11 @@ func applyDefaults(cfg *Configuration) {
 		if !hasRetention(job.Retention) && hasRetention(cfg.Defaults.Retention) {
 			job.Retention = cfg.Defaults.Retention
 		}
+		if job.Compression == nil && cfg.Defaults.Compression != nil {
+			inherited := *cfg.Defaults.Compression
+			job.Compression = &inherited
+		}
+		applyCompressionDefaults(job.Compression)
 		if job.Notifications == nil && len(cfg.Defaults.Notifications) > 0 {
 			job.Notifications = cfg.Defaults.Notifications
 		}
@@ -154,6 +159,27 @@ func applyNotificationDefaults(channels []NotificationChannel) {
 
 func hasRetention(policy RetentionPolicy) bool {
 	return policy.KeepLast > 0 || policy.KeepDays > 0 || policy.DryRun || gfsConfigured(policy.GFS)
+}
+
+// applyCompressionDefaults normalizes an enabled compression block in place:
+// an omitted algorithm becomes zstd (the recommended default), and an omitted
+// level (0) becomes the per-algorithm default. Disabled or nil blocks are left
+// untouched. Spec 049 / PRD 33.
+func applyCompressionDefaults(c *CompressionConfig) {
+	if c == nil || !c.Enabled {
+		return
+	}
+	if c.Algorithm == "" {
+		c.Algorithm = "zstd"
+	}
+	if c.Level == 0 {
+		switch c.Algorithm {
+		case "gzip":
+			c.Level = 6
+		case "zstd":
+			c.Level = 3
+		}
+	}
 }
 
 func boolPtr(v bool) *bool {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -78,6 +78,25 @@ type MySQLConfig struct {
 	BinlogPath string `yaml:"binlog_path,omitempty"`
 }
 
+// CompressionConfig holds engine-agnostic pipeline compression settings
+// (PRD 33 / spec 049). Compression is an opt-in streaming stage inserted
+// between the dump and the hash/encrypt steps; it primarily targets the
+// uncompressed engines (MySQL/MariaDB). Its presence is a pointer on BackupJob
+// and GlobalDefaults so a job can be distinguished from "unset" (inherit
+// defaults) — mirroring the RetentionPolicy inheritance pattern.
+type CompressionConfig struct {
+	// Enabled turns pipeline compression on. Default false (opt-in): no
+	// behaviour change unless explicitly enabled.
+	Enabled bool `yaml:"enabled"`
+
+	// Algorithm is one of: gzip, zstd, none (default: zstd when enabled and
+	// omitted). "none" means no pipeline compression even when enabled.
+	Algorithm string `yaml:"algorithm,omitempty"`
+
+	// Level is the codec level: gzip 1–9, zstd 1–19 (0 = per-algorithm default).
+	Level int `yaml:"level,omitempty"`
+}
+
 // AzureAuthConfig specifies authentication method for Azure Blob Storage.
 type AzureAuthConfig struct {
 	// Type is one of: managed_identity, connection_string, sas_token
@@ -167,6 +186,10 @@ type GlobalDefaults struct {
 	// Default retention policy
 	Retention RetentionPolicy `yaml:"retention"`
 
+	// Default pipeline compression settings (inherited by jobs without their
+	// own compression: block). Spec 049 / PRD 33.
+	Compression *CompressionConfig `yaml:"compression,omitempty"`
+
 	// Default notification channels
 	Notifications []NotificationChannel `yaml:"notifications"`
 }
@@ -234,6 +257,10 @@ type BackupJob struct {
 
 	// MySQL holds MySQL/MariaDB engine-specific options.
 	MySQL MySQLConfig `yaml:"mysql,omitempty"`
+
+	// Compression holds engine-agnostic pipeline compression settings. When
+	// nil the job inherits defaults.compression (spec 049 / PRD 33).
+	Compression *CompressionConfig `yaml:"compression,omitempty"`
 
 	// Cron expression for scheduling (5-field format)
 	Schedule string `yaml:"schedule,omitempty"`

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -93,6 +93,9 @@ func ValidateConfig(cfg *Configuration) error {
 		if err := validateDatabaseOptions(job); err != nil {
 			return fmt.Errorf("backup '%s': %w", name, err)
 		}
+		if err := validateCompression(job); err != nil {
+			return fmt.Errorf("backup '%s': %w", name, err)
+		}
 		if err := validateNotifications(job); err != nil {
 			return fmt.Errorf("backup '%s': %w", name, err)
 		}
@@ -439,6 +442,87 @@ func gfsConfigured(gfs *GFSPolicy) bool {
 		return false
 	}
 	return gfs.KeepDaily > 0 || gfs.KeepWeekly > 0 || gfs.KeepMonthly > 0 || gfs.KeepYearly > 0
+}
+
+// validateCompression validates a job's pipeline compression block (spec 049 /
+// PRD 33). Algorithm must be gzip/zstd/none; when enabled the level must fall
+// within the per-algorithm range; and — per the Option A resolution — pipeline
+// compression may NOT coexist with engine-native compression (double-compress
+// guard).
+func validateCompression(job BackupJob) error {
+	c := job.Compression
+	if c == nil {
+		return nil
+	}
+
+	switch c.Algorithm {
+	case "", "none", "gzip", "zstd":
+		// ok
+	default:
+		return fmt.Errorf("compression.algorithm must be one of: gzip, zstd, none")
+	}
+
+	if !c.Enabled {
+		return nil
+	}
+
+	// After loader normalization an enabled block always carries a concrete
+	// algorithm; resolve defensively for callers validating a raw config.
+	algorithm := c.Algorithm
+	if algorithm == "" {
+		algorithm = "zstd"
+	}
+	if algorithm == "none" {
+		return fmt.Errorf("compression.enabled is true but algorithm is 'none'; set algorithm to gzip or zstd, or disable compression")
+	}
+
+	if c.Level != 0 {
+		switch algorithm {
+		case "gzip":
+			if c.Level < 1 || c.Level > 9 {
+				return fmt.Errorf("compression.level for gzip must be between 1 and 9")
+			}
+		case "zstd":
+			if c.Level < 1 || c.Level > 19 {
+				return fmt.Errorf("compression.level for zstd must be between 1 and 19")
+			}
+		}
+	}
+
+	if hasNativeCompression(job) {
+		return fmt.Errorf("compression cannot be enabled together with engine-native compression (postgres compress/pg_compression_* or mongodb gzip); disable one to avoid double-compression")
+	}
+
+	return nil
+}
+
+// hasNativeCompression reports whether the job configures dump-tool-native
+// compression: postgres pg_dump --compress / --compression (compress,
+// pg_compression_algo, pg_compression_level) or mongodump --gzip.
+func hasNativeCompression(job BackupJob) bool {
+	switch job.Type {
+	case "postgres":
+		if v, ok := job.DatabaseOptions["compress"]; ok {
+			if lvl, ok2 := asInt(v); ok2 && lvl > 0 {
+				return true
+			}
+		}
+		if v, ok := job.DatabaseOptions["pg_compression_algo"]; ok {
+			if s, ok2 := v.(string); ok2 && s != "" && s != "none" {
+				return true
+			}
+		}
+		if _, ok := job.DatabaseOptions["pg_compression_level"]; ok {
+			return true
+		}
+	case "mongodb":
+		if v, ok := job.DatabaseOptions["gzip"]; ok {
+			if b, ok2 := v.(bool); ok2 && b {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func validateDatabaseOptions(job BackupJob) error {

--- a/internal/domain/backup/job.go
+++ b/internal/domain/backup/job.go
@@ -59,6 +59,12 @@ type Job struct {
 	// (the env var name, never the key).
 	EncryptionKeyHint string
 
+	// CompressArtifact compresses the artifact at path in place and returns
+	// (compressed, compression info, compressed-bytes hash). Runs BEFORE
+	// hash/encrypt in the pipeline (dump → compress → hash → encrypt). nil =
+	// compression disabled/unconfigured. Spec 049 / PRD 33.
+	CompressArtifact CompressArtifactFunc
+
 	// EncryptArtifact encrypts the artifact at path in place and returns
 	// (encrypted, envelope info, ciphertext hash). nil = plaintext config.
 	EncryptArtifact EncryptArtifactFunc
@@ -75,6 +81,11 @@ type Job struct {
 
 // EncryptArtifactFunc is the in-place artifact encryption hook.
 type EncryptArtifactFunc func(path, backupID string) (encrypted bool, info *ports.EncryptionInfo, encryptedHash string, err error)
+
+// CompressArtifactFunc is the in-place artifact compression hook. It returns
+// whether compression fired, the manifest metadata to record, and the SHA-256
+// digest of the compressed bytes (the stored artifact when not encrypted).
+type CompressArtifactFunc func(path string) (compressed bool, info *ports.CompressionInfo, compressedHash string, err error)
 
 // ArchiveFunc captures incremental side artifacts for the given dump path.
 type ArchiveFunc func(ctx context.Context, artifactPath string) (IncrementalArtifacts, error)

--- a/internal/domain/backup/pipeline.go
+++ b/internal/domain/backup/pipeline.go
@@ -132,6 +132,28 @@ func (e *Executor) ApplyArtifactSecurity(ctx context.Context, job Job, plaintext
 		HashValue:     plaintextDigest,
 	}
 
+	// Compression is opt-in and runs first — before hash/encrypt (pipeline
+	// order: dump → compress → hash → encrypt). The artifact is compressed in
+	// place so every downstream step (incremental size math, encryption,
+	// manifest SizeBytes) operates on the compressed bytes. The compressed
+	// digest becomes the stored-artifact hash (Q3); encryption, when
+	// configured, overrides it with the ciphertext digest below. Spec 049 /
+	// PRD 33.
+	var compInfo *ports.CompressionInfo
+	if job.CompressArtifact != nil && filePath != "" {
+		compressed, cmeta, compHash, compErr := job.CompressArtifact(filePath)
+		if compErr != nil {
+			return nil, nil, fmt.Errorf("failed to compress backup: %w", compErr)
+		}
+		if compressed {
+			compInfo = cmeta
+			result.HashValue = compHash
+			if info, statErr := os.Stat(filePath); statErr == nil && !info.IsDir() {
+				fileSize = info.Size()
+			}
+		}
+	}
+
 	meta := DeriveIncrementalContext(ctx, e.rec, job, fileSize)
 	if meta.BackupType == "incremental" && (job.Engine == "mysql" || job.Engine == "mariadb") {
 		if job.ArchiveBinlogs == nil {
@@ -201,7 +223,8 @@ func (e *Executor) ApplyArtifactSecurity(ctx context.Context, job Job, plaintext
 			Value:          result.HashValue,
 			PlaintextValue: plaintextHash,
 		},
-		Encryption: encInfo,
+		Compression: compInfo,
+		Encryption:  encInfo,
 		AdvancedRestore: &ports.AdvancedRestoreMetadata{
 			Capabilities: []string{"full", "incremental"},
 			IncrementalLineage: &ports.IncrementalLineageMetadata{

--- a/internal/domain/backup/pipeline_compress_test.go
+++ b/internal/domain/backup/pipeline_compress_test.go
@@ -1,0 +1,173 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/denisakp/sentinel/internal/ports"
+)
+
+// localCompressionJob builds a local-storage job whose artifact already exists
+// on disk, ready for ApplyArtifactSecurity.
+func localCompressionJob(t *testing.T, content []byte) (Job, string) {
+	t.Helper()
+	dir := t.TempDir()
+	artifact := filepath.Join(dir, "out.sql")
+	if err := os.WriteFile(artifact, content, 0o644); err != nil {
+		t.Fatalf("seed artifact: %v", err)
+	}
+	return Job{
+		Name:        "job-c",
+		Engine:      "postgres",
+		Database:    "app",
+		Options:     fakeOptions{},
+		StorageType: "local",
+		OutName:     artifact,
+	}, artifact
+}
+
+// TestApplyArtifactSecurity_CompressBeforeEncrypt asserts the pipeline ordering
+// (dump → compress → hash → encrypt): the compress hook runs first, the encrypt
+// hook observes the COMPRESSED bytes, and the manifest records the ciphertext
+// digest as Hash.Value with the plaintext dump digest preserved.
+func TestApplyArtifactSecurity_CompressBeforeEncrypt(t *testing.T) {
+	job, artifact := localCompressionJob(t, []byte("-- plaintext dump payload\n"))
+
+	var order []string
+	compressedMarker := []byte("COMPRESSED-BYTES")
+
+	job.CompressArtifact = func(path string) (bool, *ports.CompressionInfo, string, error) {
+		order = append(order, "compress")
+		if err := os.WriteFile(path, compressedMarker, 0o644); err != nil {
+			return false, nil, "", err
+		}
+		return true, &ports.CompressionInfo{Algorithm: "zstd", Level: 3}, "comp-hash", nil
+	}
+	job.EncryptArtifact = func(path, _ string) (bool, *ports.EncryptionInfo, string, error) {
+		order = append(order, "encrypt")
+		got, _ := os.ReadFile(path)
+		if !bytes.Equal(got, compressedMarker) {
+			t.Errorf("encrypt hook saw %q, want compressed bytes %q", got, compressedMarker)
+		}
+		return true, &ports.EncryptionInfo{Algorithm: "AES-256-GCM"}, "enc-hash", nil
+	}
+
+	manifests := &stubManifestStore{}
+	e := NewExecutor(nil, nil, nil, nil, &stubRecorder{}, nil, nil, nil, manifests)
+
+	outcome, _, err := e.ApplyArtifactSecurity(context.Background(), job, "plain-digest", "")
+	if err != nil {
+		t.Fatalf("ApplyArtifactSecurity() error = %v", err)
+	}
+
+	if len(order) != 2 || order[0] != "compress" || order[1] != "encrypt" {
+		t.Fatalf("stage order = %v, want [compress encrypt]", order)
+	}
+	if outcome.HashValue != "enc-hash" {
+		t.Fatalf("outcome.HashValue = %q, want enc-hash", outcome.HashValue)
+	}
+
+	m := manifests.written[artifact+".manifest.json"]
+	if m == nil {
+		t.Fatal("manifest not written")
+	}
+	if m.Compression == nil || m.Compression.Algorithm != "zstd" || m.Compression.Level != 3 {
+		t.Fatalf("manifest.Compression = %#v, want zstd/3", m.Compression)
+	}
+	if m.Hash.Value != "enc-hash" {
+		t.Fatalf("manifest.Hash.Value = %q, want enc-hash", m.Hash.Value)
+	}
+	if m.Hash.PlaintextValue != "plain-digest" {
+		t.Fatalf("manifest.Hash.PlaintextValue = %q, want plain-digest", m.Hash.PlaintextValue)
+	}
+	if m.Encryption == nil {
+		t.Fatal("manifest.Encryption = nil, want encryption info")
+	}
+}
+
+// TestApplyArtifactSecurity_CompressionOnlyManifest asserts compression without
+// encryption records the compressed-bytes digest as the stored-artifact hash
+// (Q3) and stamps the manifest compression block.
+func TestApplyArtifactSecurity_CompressionOnlyManifest(t *testing.T) {
+	job, artifact := localCompressionJob(t, []byte("-- plaintext dump payload\n"))
+
+	compressedMarker := []byte("GZIP-BYTES")
+	job.CompressArtifact = func(path string) (bool, *ports.CompressionInfo, string, error) {
+		if err := os.WriteFile(path, compressedMarker, 0o644); err != nil {
+			return false, nil, "", err
+		}
+		return true, &ports.CompressionInfo{Algorithm: "gzip", Level: 6}, "comp-hash", nil
+	}
+
+	manifests := &stubManifestStore{}
+	e := NewExecutor(nil, nil, nil, nil, &stubRecorder{}, nil, nil, nil, manifests)
+
+	outcome, _, err := e.ApplyArtifactSecurity(context.Background(), job, "plain-digest", "")
+	if err != nil {
+		t.Fatalf("ApplyArtifactSecurity() error = %v", err)
+	}
+	if outcome.HashValue != "comp-hash" {
+		t.Fatalf("outcome.HashValue = %q, want comp-hash (compressed bytes)", outcome.HashValue)
+	}
+	if outcome.Encrypted {
+		t.Fatal("outcome.Encrypted = true, want false")
+	}
+
+	m := manifests.written[artifact+".manifest.json"]
+	if m == nil {
+		t.Fatal("manifest not written")
+	}
+	if m.Compression == nil || m.Compression.Algorithm != "gzip" || m.Compression.Level != 6 {
+		t.Fatalf("manifest.Compression = %#v, want gzip/6", m.Compression)
+	}
+	if m.Hash.Value != "comp-hash" || m.Hash.PlaintextValue != "plain-digest" {
+		t.Fatalf("manifest.Hash = %#v", m.Hash)
+	}
+	if m.Encryption != nil {
+		t.Fatalf("manifest.Encryption = %#v, want nil", m.Encryption)
+	}
+
+	// The on-disk artifact holds the compressed bytes.
+	got, _ := os.ReadFile(artifact)
+	if !bytes.Equal(got, compressedMarker) {
+		t.Fatalf("artifact bytes = %q, want compressed bytes", got)
+	}
+}
+
+// TestApplyArtifactSecurity_NoCompressionByteForByte asserts that with no
+// compression hook wired, the artifact bytes and manifest are unchanged from
+// the pre-compression behaviour (opt-in default OFF; byte-for-byte parity).
+func TestApplyArtifactSecurity_NoCompressionByteForByte(t *testing.T) {
+	original := []byte("-- plaintext dump payload, do not touch\n")
+	job, artifact := localCompressionJob(t, original)
+
+	manifests := &stubManifestStore{}
+	e := NewExecutor(nil, nil, nil, nil, &stubRecorder{}, nil, nil, nil, manifests)
+
+	outcome, _, err := e.ApplyArtifactSecurity(context.Background(), job, "plain-digest", "")
+	if err != nil {
+		t.Fatalf("ApplyArtifactSecurity() error = %v", err)
+	}
+
+	got, _ := os.ReadFile(artifact)
+	if !bytes.Equal(got, original) {
+		t.Fatalf("artifact bytes changed: got %q want %q", got, original)
+	}
+	if outcome.HashValue != "plain-digest" {
+		t.Fatalf("outcome.HashValue = %q, want plain-digest", outcome.HashValue)
+	}
+
+	m := manifests.written[artifact+".manifest.json"]
+	if m == nil {
+		t.Fatal("manifest not written")
+	}
+	if m.Compression != nil {
+		t.Fatalf("manifest.Compression = %#v, want nil (no compression configured)", m.Compression)
+	}
+	if m.Hash.Value != "plain-digest" {
+		t.Fatalf("manifest.Hash.Value = %q, want plain-digest", m.Hash.Value)
+	}
+}

--- a/internal/ports/compress.go
+++ b/internal/ports/compress.go
@@ -1,0 +1,29 @@
+package ports
+
+import "io"
+
+// CompressWriter abstracts *internal/adapters/compress streaming compressors
+// (gzip / zstd). It is the sibling of EncryptWriter: a streaming pipeline
+// stage the backup Executor reaches through a Job hook wired by the driving
+// factory (PRD 33 / spec 049).
+//
+// Implementations consume plaintext dump bytes via io.Writer and emit the
+// compressed stream to the wrapped writer. Close finalizes the stream
+// (flushes the compressor's buffered data + trailer); callers MUST Close
+// before reading the produced artifact's final bytes/size.
+type CompressWriter interface {
+	io.Writer
+	// Close flushes any buffered data and writes the compression trailer.
+	Close() error
+}
+
+// DecompressReader abstracts *internal/adapters/compress streaming
+// decompressors (gzip / zstd). It is the sibling of DecryptReader: the
+// restore runtime inserts it AFTER decryption, reading the compressed
+// artifact and yielding the plaintext dump. The algorithm is read from the
+// backup manifest (no operator flag).
+type DecompressReader interface {
+	io.Reader
+	// Close releases decompressor resources.
+	Close() error
+}

--- a/internal/ports/manifest.go
+++ b/internal/ports/manifest.go
@@ -41,8 +41,20 @@ type BackupManifest struct {
 	CreatedAt       time.Time                `json:"created_at"`
 	SizeBytes       int64                    `json:"size_bytes"`
 	Hash            HashInfo                 `json:"hash"`
+	Compression     *CompressionInfo         `json:"compression,omitempty"`
 	Encryption      *EncryptionInfo          `json:"encryption,omitempty"`
 	AdvancedRestore *AdvancedRestoreMetadata `json:"advanced_restore,omitempty"`
+}
+
+// CompressionInfo records the pipeline compression applied to a backup
+// artifact (PRD 33 / spec 049). Present only when pipeline compression fired;
+// a manifest without this block ⇒ the artifact is uncompressed (or compressed
+// natively by the dump tool, e.g. pg_dump --compress / mongodump --gzip),
+// and restore performs no decompress stage. Restore reads Algorithm to select
+// the decompressor — no operator flag.
+type CompressionInfo struct {
+	Algorithm string `json:"algorithm"`
+	Level     int    `json:"level,omitempty"`
 }
 
 // HashInfo holds the integrity fingerprint for a backup file.

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -504,6 +504,140 @@ EOF
     restore dry-run pg-e2e-restore --config /configs/restore.yaml
 }
 
+# test_compression proves the spec 049 / PRD 33 pipeline compression end-to-end:
+# a config-driven LOCAL backup with compression enabled must produce a
+# COMPRESSED artifact (zstd magic, not plaintext SQL) + a manifest recording the
+# algorithm, and restore must auto-decompress (no operator flag) and round-trip.
+test_compression() {
+  log ""
+  log "=== Suite: compression — local, zstd [spec 049] ==="
+
+  local art="$BACKUPS_DIR/postgres-comp.sql"
+  local manifest="${art}.manifest.json"
+  rm -f "$art" "$manifest"
+
+  cat > "$CONFIGS_DIR/compression.yaml" <<EOF
+version: "1.0"
+log_format: text
+history_db_path: /workspace/.sentinel/history.db
+
+defaults:
+  storage:
+    type: local
+    local_path: /workspace/backups
+
+databases:
+  postgres-comp:
+    type: postgres
+    host: pgsql
+    port: 5432
+    username: sentinel
+    password_env: DEV_POSTGRES_PASSWORD
+    database: sentinel
+    output: postgres-comp.sql
+    compression:
+      enabled: true
+      algorithm: zstd
+EOF
+
+  # Seed a probe row so the restore below proves a real round-trip.
+  local seeded=false
+  if docker compose -f "$INFRA_DIR/docker-compose.yml" exec -T pgsql \
+      psql -U sentinel -d sentinel -c \
+      "DROP TABLE IF EXISTS e2e_comp_probe; CREATE TABLE e2e_comp_probe(id int primary key, note text); INSERT INTO e2e_comp_probe VALUES (1,'spec-049-compression');" >/dev/null 2>&1; then
+    seeded=true
+  fi
+
+  assert_exit_ok "compression: backup local (zstd)" backup --config /configs/compression.yaml
+
+  # Core assertion: the stored artifact is zstd-compressed (magic 28 b5 2f fd),
+  # NOT plaintext SQL.
+  if [[ -s "$art" ]]; then
+    local magic
+    magic=$(head -c4 "$art" | od -An -tx1 | tr -d ' \n')
+    if [[ "$magic" == "28b52ffd" ]]; then
+      ok "compression: artifact carries zstd magic (compressed, not plaintext)"
+    else
+      fail "compression: artifact magic=$magic, expected zstd 28b52ffd (not compressed?)"
+    fi
+    if grep -qa "PostgreSQL database dump" "$art"; then
+      fail "compression: artifact contains plaintext SQL header — not compressed"
+    else
+      ok "compression: no plaintext SQL header in artifact"
+    fi
+  else
+    fail "compression: artifact missing ($art)"
+  fi
+
+  # Manifest records the compression algorithm.
+  if [[ -s "$manifest" ]] && grep -qa '"compression"' "$manifest" && grep -qa 'zstd' "$manifest"; then
+    ok "compression: manifest records algorithm (zstd)"
+  else
+    fail "compression: manifest missing compression block"
+  fi
+
+  # Restore auto-decompresses (no operator flag) and round-trips the data.
+  if [[ "$seeded" == true ]]; then
+    docker compose -f "$INFRA_DIR/docker-compose.yml" exec -T pgsql \
+      psql -U sentinel -c "DROP DATABASE IF EXISTS sentinel_restore_comp;" >/dev/null 2>&1 || true
+    if docker compose -f "$INFRA_DIR/docker-compose.yml" exec -T pgsql \
+        psql -U sentinel -c "CREATE DATABASE sentinel_restore_comp;" >/dev/null 2>&1; then
+      cat > "$CONFIGS_DIR/compression-restore.yaml" <<EOF
+version: "1.0"
+log_format: text
+history_db_path: /workspace/.sentinel/history.db
+
+defaults:
+  storage:
+    type: local
+    local_path: /workspace/backups
+
+databases:
+  postgres-comp:
+    type: postgres
+    host: pgsql
+    port: 5432
+    username: sentinel
+    password_env: DEV_POSTGRES_PASSWORD
+    database: sentinel
+    output: postgres-comp.sql
+
+restores:
+  pg-comp-restore:
+    type: postgres
+    enabled: true
+    schedule: "0 3 * * *"
+    host: pgsql
+    port: 5432
+    username: sentinel
+    password_env: DEV_POSTGRES_PASSWORD
+    database: sentinel_restore_comp
+    staging_dir: /workspace/staging
+    backup_source:
+      type: local
+      local_path: /workspace/backups
+      backup_path: postgres-comp.sql
+EOF
+      assert_exit_ok "compression: restore run (auto-decompress)" \
+        restore run pg-comp-restore --config /configs/compression-restore.yaml
+      local got
+      got=$(docker compose -f "$INFRA_DIR/docker-compose.yml" exec -T pgsql \
+        psql -U sentinel -d sentinel_restore_comp -t -c "SELECT note FROM e2e_comp_probe WHERE id=1;" 2>/dev/null | tr -d ' \n')
+      if [[ "$got" == "spec-049-compression" ]]; then
+        ok "compression: restore round-trip data matches (auto-decompressed)"
+      else
+        fail "compression: restored data mismatch (got '$got')"
+      fi
+    else
+      skip "compression: could not create sentinel_restore_comp (restore skipped)"
+    fi
+    docker compose -f "$INFRA_DIR/docker-compose.yml" exec -T pgsql \
+      psql -U sentinel -d sentinel -c "DROP TABLE IF EXISTS e2e_comp_probe;" >/dev/null 2>&1 || true
+  else
+    skip "compression: could not seed probe row (restore round-trip skipped)"
+  fi
+}
+
 test_encryption() {
   log ""
   log "=== Suite: encryption ==="
@@ -935,6 +1069,7 @@ main() {
   test_unit
   test_config_validate
   test_local_backup
+  test_compression
   test_monitor
   test_retention
   test_retention_gfs


### PR DESCRIPTION
## Recovered PRD 33 — pipeline backup compression (gzip/zstd, all engines)

Recovers roadmap **M2 — Compress (v1.1.0)**, but **corrects its flawed premise**: the roadmap specified non-existent `mysqldump --compress-output` flags. This implements compression as a **generic streaming pipeline stage** (mirroring the crypto stage), engine-agnostic, ADR-0001 clean.

- New `ports.CompressWriter`/`DecompressReader` + `internal/adapters/compress/` (gzip stdlib, zstd via `klauspost/compress` pure-Go). Domain reaches it only through the port; the adapter is constructed by the factory.
- Pipeline order **dump → compress → hash → encrypt → upload** (compress in `ApplyArtifactSecurity` before hash/encrypt; the compressed digest is the stored-artifact hash, overridden by the ciphertext digest when encryption is on).
- Config `CompressionConfig{Enabled,Algorithm,Level}` on `BackupJob.Compression` + `GlobalDefaults.Compression` (inheritance mirrors retention); validator (algorithm ∈ {gzip,zstd,none}; gzip 1–9 / zstd 1–19; enabled+none rejected; **reject-both** guard vs pg/mongo native compression).
- Manifest records `compression: {algorithm, level}`; restore **auto-detects** and decompresses after decrypt (no operator flag); legacy backups without the block restore unchanged.

**Defaults applied** (resolved open questions): Q1 = Option A (pipeline for the uncompressed engines; reject alongside pg/mongo native), Q2 = opt-in default-OFF, Q3 = hash compressed bytes, Q4 = zstd default. Behaviour byte-for-byte unchanged when disabled.

Tests: codec round-trip (gzip/zstd all levels), validator/loader, pipeline compress-then-encrypt order + disabled-unchanged, restore decompress round-trip. Runbook `docs/runbooks/backup-compression.md`. `build/vet/vet-integration/test/lint` green. e2e `test_compression`: local zstd backup → artifact carries zstd magic (not plaintext) + manifest records algo + restore auto-decompresses and round-trips. Release-notes in the consolidated follow-up.
