### PR TITLE
feat(backup): backup diff <id1> <id2> — metadata comparison + security-regression detection (PRD 36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ sentinel retention apply --config sentinel.yaml
 sentinel backup verify <backup-id> --config sentinel.yaml   # verify one backup
 sentinel backup verify --all --config sentinel.yaml          # repository-wide integrity sweep
 sentinel backup verify --all --since 30d --output json --config sentinel.yaml
+sentinel backup diff <id1> <id2> --config sentinel.yaml      # compare two backups' metadata
 
 # Config & storage
 sentinel config validate --config sentinel.yaml
@@ -357,6 +358,26 @@ what was found (added by monitor schema migration `005`; existing history DBs up
 A non-`ok` result pages the configured channels (`defaults.notifications`) when `notify_on` is
 `failure`/`always`; `never` stays silent; delivery is best-effort. See
 [docs/runbooks/integrity-sweep.md](docs/runbooks/integrity-sweep.md).
+
+### Comparing two backups
+
+`sentinel backup diff <id1> <id2>` compares the **recorded metadata** of two backups — size,
+duration, hash algorithm, encryption posture, backup type and chain depth — to diagnose a
+sudden anomaly (a backup 3× larger, twice as slow, or silently plaintext) **without a restore**:
+
+```bash
+sentinel backup diff abc123 def456 --config sentinel.yaml
+sentinel backup diff abc123 def456 --output json --config sentinel.yaml   # for CI/alerting
+```
+
+It reads only the monitor row and each artifact's `.manifest.json` sidecar — **no artifact
+bytes are read** (remote backups fetch just the tiny sidecar, never the artifact). Only the
+fields that differ are printed. **Security regressions** are flagged explicitly and yield a
+**non-zero exit** so CI can gate: encryption turned off (`ENCRYPTION DISABLED`), a hash-algorithm
+change (`HASH ALGORITHM CHANGED`), or an encryption-parameter downgrade (`ENCRYPTION WEAKENED`).
+Size/duration swings get a `⚠` marker but stay informational (exit 0). A backup with no manifest
+(pre-v1.1) still diffs on its monitor-row fields with a warning. See
+[docs/runbooks/verify-backup-integrity.md](docs/runbooks/verify-backup-integrity.md).
 
 ---
 

--- a/docs/runbooks/verify-backup-integrity.md
+++ b/docs/runbooks/verify-backup-integrity.md
@@ -57,6 +57,33 @@ grep -m 1 "MySQL dump"   /workspace/backups/mysql-dev.sql
 grep -m 1 "MariaDB dump" /workspace/backups/mariadb-dev.sql
 ```
 
+### Compare two backups (`backup diff`)
+
+When a backup looks anomalous (much larger/slower than the last, or you suspect the safety
+posture changed), compare the two **recorded metadata** sources — no restore, no re-download of
+the artifact:
+
+```bash
+sentinel backup diff <old-id> <new-id> --config /workspace/infra/dataset/local.yaml
+sentinel backup diff <old-id> <new-id> --output json   # for CI/alerting
+```
+
+`backup diff` reads only the monitor row + each `.manifest.json` sidecar (remote backups fetch
+just the sidecar) and prints a `FIELD | BEFORE | AFTER | DELTA` table of the fields that differ:
+`size_bytes`, `duration_ms`, `hash.algorithm`, `hash.value`, `encryption`, `backup_type`,
+`chain_depth`. It **never opens the artifact** — use `backup verify` for byte-level integrity.
+
+Security regressions between the two backups are flagged and set a **non-zero exit** (CI-gateable):
+
+| Signal                 | Meaning                                                        |
+|------------------------|---------------------------------------------------------------|
+| `ENCRYPTION DISABLED`  | the newer backup is plaintext where the older was encrypted   |
+| `HASH ALGORITHM CHANGED` | the integrity hash algorithm changed (e.g. a downgrade)     |
+| `ENCRYPTION WEAKENED`  | KDF/algorithm changed, iterations decreased, or envelope dropped |
+
+Size/duration swings get a `⚠` marker but keep exit 0. A pre-v1.1 backup with no manifest still
+diffs on its monitor-row fields with a warning.
+
 ## Manifest contract (per ADR 0005)
 
 - Sidecar file: `<backup-filename>.manifest.json`, JSON, mode `0600`.
@@ -82,3 +109,4 @@ If verify fails, treat the artifact as untrusted:
 - ADR 0005 — Manifest v1 format (`docs/adr/0005-manifest-format-v1.md`)
 - `internal/manifest/manifest.go`, `internal/manifest/types.go`
 - `internal/cli/backup_verify.go`
+- `internal/cli/backup_diff.go` — `backup diff <id1> <id2>` metadata comparison

--- a/internal/cli/backup_diff.go
+++ b/internal/cli/backup_diff.go
@@ -1,0 +1,544 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	manifest "github.com/denisakp/sentinel/internal/adapters/manifest_store"
+	"github.com/denisakp/sentinel/internal/adapters/monitor"
+	"github.com/denisakp/sentinel/internal/config"
+	"github.com/denisakp/sentinel/internal/ports"
+	"github.com/spf13/cobra"
+)
+
+// diffLargeSwingPct is the absolute percentage change at or above which a
+// size/duration delta is annotated with a ⚠ marker. It is informational only —
+// magnitude swings never change the exit code (only security regressions do,
+// per PRD 36 Q1).
+const diffLargeSwingPct = 50.0
+
+// diffSide holds the two recorded metadata sources for one backup: the monitor
+// row (always present) and the manifest sidecar (nil when absent — a pre-v1.1
+// backup or a remote manifest that could not be fetched). No artifact bytes are
+// ever read to populate this — only the SQLite row and the .manifest.json
+// sidecar (PRD 36 exit criterion).
+type diffSide struct {
+	id       string
+	exec     *ports.Execution
+	manifest *ports.BackupManifest
+}
+
+func (s diffSide) hasManifest() bool { return s.manifest != nil }
+
+// diffFieldResult is a single differing field in the comparison.
+type diffFieldResult struct {
+	Field    string `json:"field"`
+	Before   string `json:"before"`
+	After    string `json:"after"`
+	Delta    string `json:"delta"`
+	Security bool   `json:"security"`
+	Warn     bool   `json:"warn"`
+}
+
+// diffResult is the full structured comparison, emitted verbatim by --output
+// json and rendered as a table by the default text output.
+type diffResult struct {
+	ID1                 string            `json:"id1"`
+	ID2                 string            `json:"id2"`
+	Differences         []diffFieldResult `json:"differences"`
+	SecurityRegressions []string          `json:"security_regressions"`
+	Warnings            []string          `json:"warnings,omitempty"`
+}
+
+func (r diffResult) hasSecurityRegression() bool { return len(r.SecurityRegressions) > 0 }
+
+var backupDiffCmd = &cobra.Command{
+	Use:   "diff <id1> <id2>",
+	Short: "Compare the recorded metadata of two backups (flags security regressions)",
+	Long: "Compare two backups' recorded metadata — size, duration, hash algorithm, encryption\n" +
+		"posture, backup type and chain depth — reading only the monitor row and the\n" +
+		"<artifact>.manifest.json sidecar for each. No artifact bytes are read.\n\n" +
+		"Silent security regressions between the two backups — encryption turned off, a hash\n" +
+		"algorithm change, or an encryption-parameter downgrade — are flagged explicitly and\n" +
+		"yield a non-zero exit code so CI/alerting can gate on them. Size/duration swings are\n" +
+		"informational (⚠ marker, exit 0).",
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id1, id2 := args[0], args[1]
+
+		cfgPath, _ := cmd.Flags().GetString("config")
+		if cfgPath == "" {
+			cfgPath = os.ExpandEnv("$HOME/.sentinel/config.yaml")
+		}
+		outputFmt := verifyOutputFormat(cmd)
+
+		cfg, err := config.LoadConfig(cfgPath)
+		if err != nil {
+			verifyPrintError(outputFmt, id1, "", fmt.Sprintf("failed to load config: %v", err))
+			return fmt.Errorf("load config: %w", ErrVerifyInternal)
+		}
+		if outputFmt == "" {
+			outputFmt = cfg.LogFormat
+		}
+
+		mon, err := monitor.NewMonitor(cfg.HistoryDBPath)
+		if err != nil {
+			verifyPrintError(outputFmt, id1, "", fmt.Sprintf("failed to open history db: %v", err))
+			return fmt.Errorf("open history db: %w", ErrVerifyInternal)
+		}
+		defer mon.Close()
+
+		ctx := context.Background()
+
+		s1, err := resolveDiffExecution(ctx, mon, id1)
+		if err != nil {
+			verifyPrintError(outputFmt, id1, "",
+				fmt.Sprintf("backup ID %q not found in history\n  Fix: run 'sentinel monitor list' to see available backup IDs", id1))
+			return fmt.Errorf("backup %q: %w", id1, ErrVerifyNotFound)
+		}
+		s2, err := resolveDiffExecution(ctx, mon, id2)
+		if err != nil {
+			verifyPrintError(outputFmt, id2, "",
+				fmt.Sprintf("backup ID %q not found in history\n  Fix: run 'sentinel monitor list' to see available backup IDs", id2))
+			return fmt.Errorf("backup %q: %w", id2, ErrVerifyNotFound)
+		}
+
+		var warnings []string
+		if m, warn, mErr := resolveDiffManifest(ctx, cfg, s1.exec); mErr != nil {
+			verifyPrintError(outputFmt, id1, s1.exec.BackupName, fmt.Sprintf("failed to read manifest: %v", mErr))
+			return fmt.Errorf("read manifest for %q: %w", id1, ErrVerifyInternal)
+		} else {
+			s1.manifest = m
+			if warn != "" {
+				warnings = append(warnings, warn)
+			}
+		}
+		if m, warn, mErr := resolveDiffManifest(ctx, cfg, s2.exec); mErr != nil {
+			verifyPrintError(outputFmt, id2, s2.exec.BackupName, fmt.Sprintf("failed to read manifest: %v", mErr))
+			return fmt.Errorf("read manifest for %q: %w", id2, ErrVerifyInternal)
+		} else {
+			s2.manifest = m
+			if warn != "" {
+				warnings = append(warnings, warn)
+			}
+		}
+
+		fields, regressions := computeBackupDiff(s1, s2)
+		result := diffResult{
+			ID1:                 id1,
+			ID2:                 id2,
+			Differences:         fields,
+			SecurityRegressions: regressions,
+			Warnings:            warnings,
+		}
+		if result.Differences == nil {
+			result.Differences = []diffFieldResult{}
+		}
+		if result.SecurityRegressions == nil {
+			result.SecurityRegressions = []string{}
+		}
+
+		if outputFmt == "json" {
+			verifyPrintJSON(result)
+		} else {
+			renderDiffText(result)
+		}
+
+		if result.hasSecurityRegression() {
+			return fmt.Errorf("backup diff %s..%s: %w", id1, id2, ErrDiffSecurityRegression)
+		}
+		return nil
+	},
+}
+
+// resolveDiffExecution fetches a backup's monitor row. It never opens the
+// artifact referenced by FilePath.
+func resolveDiffExecution(ctx context.Context, mon *monitor.Monitor, id string) (diffSide, error) {
+	exec, err := mon.GetExecution(ctx, id)
+	if err != nil || exec == nil {
+		return diffSide{}, fmt.Errorf("execution %q not found", id)
+	}
+	return diffSide{id: id, exec: exec}, nil
+}
+
+// resolveDiffManifest reads the .manifest.json sidecar for one backup, reusing
+// the byte-identical resolution `backup verify` uses. It returns:
+//   - (m, "", nil)          — manifest read successfully;
+//   - (nil, warning, nil)   — soft signal (pre-v1.1 backup with no manifest, or
+//     a remote manifest that could not be fetched) ⇒ partial diff;
+//   - (nil, "", err)        — a hard error (a present-but-corrupt manifest).
+//
+// It NEVER downloads or opens the backup artifact — for remote backups it
+// fetches only the small <key>.manifest.json sidecar (PRD 36 Q2).
+func resolveDiffManifest(ctx context.Context, cfg *config.Configuration, exec *ports.Execution) (*ports.BackupManifest, string, error) {
+	missingWarn := fmt.Sprintf("no manifest for backup %s (pre-v1.1 backup); compared monitor-row fields only", exec.ID)
+
+	if exec.FilePath == "" {
+		return nil, missingWarn, nil
+	}
+
+	manifestPath := exec.FilePath + ".manifest.json"
+
+	if isRemoteStorageBackend(exec.StorageBackend) {
+		tmpDir, tmpErr := os.MkdirTemp("", "sentinel-diff-*")
+		if tmpErr != nil {
+			return nil, "", fmt.Errorf("failed to create temp dir: %w", tmpErr)
+		}
+		defer os.RemoveAll(tmpDir)
+
+		var storageCfg config.StorageConfig
+		if job, ok := cfg.Databases[exec.BackupName]; ok {
+			storageCfg = job.Storage
+		}
+
+		local, fetchErr := fetchRemoteManifestForDiff(ctx, exec, storageCfg, tmpDir)
+		if fetchErr != nil {
+			if errors.Is(fetchErr, ports.ErrNoManifest) {
+				return nil, missingWarn, nil
+			}
+			// Degrade gracefully on an operational fetch failure rather than
+			// blocking the whole diff (PRD 36 Q2): warn and compare the
+			// monitor-row fields only.
+			return nil, fmt.Sprintf("could not fetch remote manifest for backup %s: %v; compared monitor-row fields only", exec.ID, fetchErr), nil
+		}
+		manifestPath = local
+	}
+
+	m, err := manifest.ReadManifest(manifestPath)
+	if err != nil {
+		if errors.Is(err, ports.ErrNoManifest) {
+			return nil, missingWarn, nil
+		}
+		return nil, "", err
+	}
+	return m, "", nil
+}
+
+// fetchRemoteManifestForDiff downloads ONLY the <key>.manifest.json sidecar for
+// a remote backup into tmpDir, reusing verify's storage seam
+// (verifyBackendParamsAndObject + newVerifyBackend). It returns the local
+// sidecar path, ports.ErrNoManifest if the sidecar object is absent, or an
+// operational error. The backup artifact itself is never referenced.
+func fetchRemoteManifestForDiff(ctx context.Context, exec *ports.Execution, storageCfg config.StorageConfig, tmpDir string) (string, error) {
+	params, object, err := verifyBackendParamsAndObject(exec.StorageBackend, exec.FilePath, storageCfg)
+	if err != nil {
+		return "", err
+	}
+
+	backend, err := newVerifyBackend(params)
+	if err != nil {
+		return "", fmt.Errorf("failed to initialize %s backend: %w", exec.StorageBackend, err)
+	}
+
+	manifestObject := object + ".manifest.json"
+	exists, err := backend.Exists(ctx, manifestObject)
+	if err != nil {
+		return "", fmt.Errorf("failed to check manifest sidecar %q: %w", manifestObject, err)
+	}
+	if !exists {
+		return "", ports.ErrNoManifest
+	}
+
+	local := filepath.Join(tmpDir, filepath.Base(manifestObject))
+	if err := backend.Download(ctx, manifestObject, local); err != nil {
+		return "", fmt.Errorf("failed to download manifest sidecar %q: %w", manifestObject, err)
+	}
+	return local, nil
+}
+
+// computeBackupDiff is the pure comparison over two resolved sides. It returns
+// only the fields that differ plus the deduplicated security-regression labels.
+// It reads nothing but struct fields, so it demonstrably touches zero artifact
+// bytes.
+func computeBackupDiff(s1, s2 diffSide) ([]diffFieldResult, []string) {
+	var fields []diffFieldResult
+	var regressions []string
+
+	// size_bytes — manifest first, monitor-row fallback.
+	if b1, b2 := diffSizeBytes(s1), diffSizeBytes(s2); b1 != b2 {
+		delta, big := pctDelta(float64(b1), float64(b2))
+		if big {
+			delta = "⚠ " + delta
+		}
+		fields = append(fields, diffFieldResult{
+			Field: "size_bytes", Before: humanizeBytes(b1), After: humanizeBytes(b2),
+			Delta: delta, Warn: big,
+		})
+	}
+
+	// duration_ms — monitor row only.
+	if d1, d2 := s1.exec.DurationMs, s2.exec.DurationMs; d1 != d2 {
+		delta, big := pctDelta(float64(d1), float64(d2))
+		if big {
+			delta = "⚠ " + delta
+		}
+		fields = append(fields, diffFieldResult{
+			Field: "duration_ms", Before: strconv.FormatInt(d1, 10), After: strconv.FormatInt(d2, 10),
+			Delta: delta, Warn: big,
+		})
+	}
+
+	// Manifest-derived fields require BOTH manifests (hash + encryption).
+	if s1.hasManifest() && s2.hasManifest() {
+		mf, mr := diffManifestFields(s1.manifest, s2.manifest)
+		fields = append(fields, mf...)
+		regressions = append(regressions, mr...)
+	}
+
+	// backup_type — monitor row first, manifest lineage fallback.
+	if t1, t2 := diffBackupType(s1), diffBackupType(s2); t1 != t2 && (t1 != "" || t2 != "") {
+		fields = append(fields, diffFieldResult{
+			Field: "backup_type", Before: orNone(t1), After: orNone(t2), Delta: "changed",
+		})
+	}
+
+	// chain_depth — manifest lineage first, monitor row fallback.
+	if c1, c2 := diffChainDepth(s1), diffChainDepth(s2); c1 != c2 {
+		delta := fmt.Sprintf("%+d", c2-c1)
+		if c2 == 0 && c1 > 0 {
+			delta = "reset"
+		}
+		fields = append(fields, diffFieldResult{
+			Field: "chain_depth", Before: strconv.Itoa(c1), After: strconv.Itoa(c2), Delta: delta,
+		})
+	}
+
+	return fields, dedupeStrings(regressions)
+}
+
+// diffManifestFields compares the manifest-only fields (hash + encryption) and
+// returns the differing rows plus any security-regression labels.
+func diffManifestFields(m1, m2 *ports.BackupManifest) ([]diffFieldResult, []string) {
+	var fields []diffFieldResult
+	var regressions []string
+
+	// hash.algorithm — a change is a security signal (e.g. sha256 → sha1).
+	if a1, a2 := m1.Hash.Algorithm, m2.Hash.Algorithm; a1 != a2 {
+		fields = append(fields, diffFieldResult{
+			Field: "hash.algorithm", Before: a1, After: a2,
+			Delta: "⚠ HASH ALGORITHM CHANGED", Security: true,
+		})
+		regressions = append(regressions, "HASH ALGORITHM CHANGED")
+	}
+
+	// hash.value — expected to differ; informational.
+	if m1.Hash.Value != m2.Hash.Value {
+		fields = append(fields, diffFieldResult{
+			Field: "hash.value", Before: shortHash(m1.Hash.Value), After: shortHash(m2.Hash.Value),
+			Delta: "changed",
+		})
+	}
+
+	e1, e2 := m1.Encryption, m2.Encryption
+	switch {
+	case e1 != nil && e2 == nil:
+		// The single highest-value signal: a backup silently became plaintext.
+		fields = append(fields, diffFieldResult{
+			Field: "encryption", Before: orNone(e1.Algorithm), After: "(none)",
+			Delta: "⚠ ENCRYPTION DISABLED", Security: true,
+		})
+		regressions = append(regressions, "ENCRYPTION DISABLED")
+	case e1 == nil && e2 != nil:
+		// Encryption turned on — an improvement, not a regression.
+		fields = append(fields, diffFieldResult{
+			Field: "encryption", Before: "(none)", After: orNone(e2.Algorithm), Delta: "enabled",
+		})
+	case e1 != nil && e2 != nil:
+		if diffEncryptionParams(e1, e2, &fields) {
+			regressions = append(regressions, "ENCRYPTION WEAKENED")
+		}
+	}
+
+	return fields, regressions
+}
+
+// diffEncryptionParams appends a row for each differing encryption parameter and
+// reports whether any change constitutes a downgrade (algorithm or key
+// derivation changed, iterations decreased, or envelope version dropped). A
+// change of the crypto algorithm or KDF between consecutive backups is treated
+// conservatively as a downgrade signal (deterministic, no algorithm ranking).
+func diffEncryptionParams(e1, e2 *ports.EncryptionInfo, fields *[]diffFieldResult) bool {
+	weakened := false
+
+	if e1.Algorithm != e2.Algorithm {
+		*fields = append(*fields, diffFieldResult{
+			Field: "encryption.algorithm", Before: orNone(e1.Algorithm), After: orNone(e2.Algorithm),
+			Delta: "⚠ changed", Security: true,
+		})
+		weakened = true
+	}
+	if e1.KeyDerivation != e2.KeyDerivation {
+		*fields = append(*fields, diffFieldResult{
+			Field: "encryption.key_derivation", Before: orNone(e1.KeyDerivation), After: orNone(e2.KeyDerivation),
+			Delta: "⚠ changed", Security: true,
+		})
+		weakened = true
+	}
+	if e1.Iterations != e2.Iterations {
+		down := e2.Iterations < e1.Iterations
+		delta := "increased"
+		if down {
+			delta = "⚠ decreased"
+			weakened = true
+		}
+		*fields = append(*fields, diffFieldResult{
+			Field: "encryption.iterations", Before: strconv.Itoa(e1.Iterations), After: strconv.Itoa(e2.Iterations),
+			Delta: delta, Security: down,
+		})
+	}
+	if e1.EnvelopeVersion != e2.EnvelopeVersion {
+		down := e2.EnvelopeVersion < e1.EnvelopeVersion
+		delta := "upgraded"
+		if down {
+			delta = "⚠ dropped"
+			weakened = true
+		}
+		*fields = append(*fields, diffFieldResult{
+			Field: "encryption.envelope_version", Before: strconv.Itoa(e1.EnvelopeVersion), After: strconv.Itoa(e2.EnvelopeVersion),
+			Delta: delta, Security: down,
+		})
+	}
+
+	return weakened
+}
+
+// diffSizeBytes prefers the manifest-recorded size, falling back to the monitor
+// row's recorded file size.
+func diffSizeBytes(s diffSide) int64 {
+	if s.manifest != nil && s.manifest.SizeBytes > 0 {
+		return s.manifest.SizeBytes
+	}
+	return s.exec.FileSizeBytes
+}
+
+// diffBackupType prefers the monitor row's BackupType (PRD 36 Q3), deriving from
+// the manifest incremental lineage only when the row is empty.
+func diffBackupType(s diffSide) string {
+	if s.exec.BackupType != "" {
+		return s.exec.BackupType
+	}
+	if lineage := diffLineage(s.manifest); lineage != nil && lineage.Enabled {
+		if lineage.ChainIndex > 0 {
+			return "incremental"
+		}
+		return "full"
+	}
+	return ""
+}
+
+// diffChainDepth prefers the manifest lineage chain index, falling back to the
+// monitor row's chain index.
+func diffChainDepth(s diffSide) int {
+	if lineage := diffLineage(s.manifest); lineage != nil {
+		return lineage.ChainIndex
+	}
+	return s.exec.ChainIndex
+}
+
+// diffLineage nil-safely reaches a manifest's incremental lineage metadata.
+func diffLineage(m *ports.BackupManifest) *ports.IncrementalLineageMetadata {
+	if m == nil || m.AdvancedRestore == nil {
+		return nil
+	}
+	return m.AdvancedRestore.IncrementalLineage
+}
+
+// pctDelta renders the signed percentage change from before to after and
+// reports whether its magnitude reaches the large-swing threshold.
+func pctDelta(before, after float64) (string, bool) {
+	if before == 0 {
+		if after == 0 {
+			return "0%", false
+		}
+		return "new", true
+	}
+	pct := (after - before) / before * 100
+	return fmt.Sprintf("%+.0f%%", pct), math.Abs(pct) >= diffLargeSwingPct
+}
+
+// humanizeBytes renders a byte count in a compact human-readable form.
+func humanizeBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for x := n / unit; x >= unit; x /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
+}
+
+// shortHash truncates a long fingerprint for display; the exact bytes are not
+// actionable in a diff (use `backup verify` for that).
+func shortHash(h string) string {
+	const keep = 12
+	if len(h) > keep {
+		return h[:keep] + "…"
+	}
+	return h
+}
+
+func orNone(s string) string {
+	if s == "" {
+		return "(none)"
+	}
+	return s
+}
+
+// dedupeStrings removes duplicate entries while preserving first-seen order.
+func dedupeStrings(in []string) []string {
+	if len(in) == 0 {
+		return in
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+// renderDiffText prints warnings, the FIELD|BEFORE|AFTER|DELTA table (only
+// differing fields), and a security-regression summary when present.
+func renderDiffText(r diffResult) {
+	for _, w := range r.Warnings {
+		fmt.Printf("Warning: %s\n", w)
+	}
+
+	if len(r.Differences) == 0 {
+		fmt.Printf("No metadata differences between %s and %s.\n", r.ID1, r.ID2)
+		return
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "FIELD\tBEFORE\tAFTER\tDELTA")
+	for _, f := range r.Differences {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", f.Field, f.Before, f.After, f.Delta)
+	}
+	_ = tw.Flush()
+
+	if len(r.SecurityRegressions) > 0 {
+		fmt.Printf("\n⚠ Security regression detected: %s\n", strings.Join(r.SecurityRegressions, ", "))
+	}
+}
+
+func init() {
+	BackupCmd.AddCommand(backupDiffCmd)
+	backupDiffCmd.Flags().String("config", "", "Path to sentinel YAML config")
+	backupDiffCmd.Flags().String("output", "", "Output format: json or text")
+	backupDiffCmd.Flags().String("format", "", "Alias for --output")
+	_ = backupDiffCmd.Flags().MarkHidden("format")
+}

--- a/internal/cli/backup_diff_test.go
+++ b/internal/cli/backup_diff_test.go
@@ -1,0 +1,416 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	manifest "github.com/denisakp/sentinel/internal/adapters/manifest_store"
+	"github.com/denisakp/sentinel/internal/adapters/monitor"
+	"github.com/denisakp/sentinel/internal/ports"
+	"github.com/spf13/cobra"
+)
+
+// diffExec describes one backup to seed for a diff test: its monitor-row fields
+// plus (optionally) a local manifest sidecar written next to a NON-EXISTENT
+// artifact path. The artifact file is deliberately never created, so a passing
+// test proves diff reads zero artifact bytes.
+type diffExec struct {
+	job           string
+	fileBase      string // artifact basename (no file is written for it)
+	durationMs    int64
+	sizeBytes     int64
+	backupType    string
+	chainIndex    int
+	writeManifest bool
+	manifest      ports.BackupManifest // used when writeManifest is true
+}
+
+// seedDiffRepo writes a config + history DB with one recorded LOCAL execution
+// per spec and (for those requesting it) a manifest sidecar at
+// <dir>/<fileBase>.manifest.json. The backup artifact itself is never written.
+// Returns the config path and a map fileBase→backup id.
+func seedDiffRepo(t *testing.T, execs []diffExec) (string, map[string]string) {
+	t.Helper()
+	dir := t.TempDir()
+	historyPath := filepath.Join(dir, "history.db")
+	cfgPath := writeYAML(t, dir, "history_db_path: "+historyPath+`
+databases:
+  diff-job:
+    type: postgres
+    storage:
+      type: local
+`)
+
+	mon, err := monitor.NewMonitor(historyPath)
+	if err != nil {
+		t.Fatalf("new monitor: %v", err)
+	}
+	idByFile := make(map[string]string)
+	for _, e := range execs {
+		job := e.job
+		if job == "" {
+			job = "diff-job"
+		}
+		artifactPath := filepath.Join(dir, e.fileBase)
+
+		if e.writeManifest {
+			m := e.manifest
+			if m.BackupID == "" {
+				m.BackupID = e.fileBase
+			}
+			if m.Hash.Algorithm == "" {
+				m.Hash.Algorithm = "sha256"
+			}
+			if m.Hash.Value == "" {
+				m.Hash.Value = "deadbeef" + e.fileBase
+			}
+			if err := manifest.WriteManifest(artifactPath+".manifest.json", &m); err != nil {
+				_ = mon.Close()
+				t.Fatalf("write manifest: %v", err)
+			}
+		}
+
+		exec := &ports.Execution{
+			BackupName:     job,
+			DatabaseType:   "postgres",
+			Timestamp:      time.Now().UTC(),
+			Status:         "success",
+			StorageBackend: "local",
+			FilePath:       artifactPath, // no such file on disk (never opened)
+			FileSizeBytes:  e.sizeBytes,
+			DurationMs:     e.durationMs,
+			BackupType:     e.backupType,
+			ChainIndex:     e.chainIndex,
+		}
+		if err := mon.RecordExecution(context.Background(), exec); err != nil {
+			_ = mon.Close()
+			t.Fatalf("record execution: %v", err)
+		}
+		idByFile[e.fileBase] = exec.ID
+	}
+	_ = mon.Close()
+	return cfgPath, idByFile
+}
+
+// runDiff invokes backupDiffCmd.RunE with the two ids and the given output
+// format, capturing stdout. Mirrors runVerify/runVerifyAll.
+func runDiff(t *testing.T, cfgPath, output, id1, id2 string) (string, error) {
+	t.Helper()
+	cmd := &cobra.Command{Use: "diff-test"}
+	cmd.Flags().String("config", cfgPath, "")
+	cmd.Flags().String("output", output, "")
+	cmd.Flags().String("format", "", "")
+
+	var err error
+	out := captureStdout(t, func() { err = backupDiffCmd.RunE(cmd, []string{id1, id2}) })
+	return out, err
+}
+
+// diffJSON mirrors the machine-readable diff shape.
+type diffJSON struct {
+	ID1         string `json:"id1"`
+	ID2         string `json:"id2"`
+	Differences []struct {
+		Field    string `json:"field"`
+		Before   string `json:"before"`
+		After    string `json:"after"`
+		Delta    string `json:"delta"`
+		Security bool   `json:"security"`
+		Warn     bool   `json:"warn"`
+	} `json:"differences"`
+	SecurityRegressions []string `json:"security_regressions"`
+	Warnings            []string `json:"warnings"`
+}
+
+func parseDiffJSON(t *testing.T, out string) diffJSON {
+	t.Helper()
+	var d diffJSON
+	if err := json.Unmarshal([]byte(out), &d); err != nil {
+		t.Fatalf("parse diff JSON: %v\noutput:\n%s", err, out)
+	}
+	return d
+}
+
+func fieldByName(d diffJSON, name string) (int, bool) {
+	for i, f := range d.Differences {
+		if f.Field == name {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// TestBackupDiff_EncryptionDisabledFlagged asserts the headline signal:
+// encryption present → absent yields ENCRYPTION DISABLED and a non-zero exit.
+func TestBackupDiff_EncryptionDisabledFlagged(t *testing.T) {
+	cfgPath, ids := seedDiffRepo(t, []diffExec{
+		{fileBase: "enc.sql", sizeBytes: 1000, durationMs: 100, writeManifest: true, manifest: ports.BackupManifest{
+			Hash:       ports.HashInfo{Algorithm: "sha256", Value: "aaaa"},
+			Encryption: &ports.EncryptionInfo{Algorithm: "aes-256-gcm", KeyDerivation: "pbkdf2", Iterations: 600000, EnvelopeVersion: 2},
+		}},
+		{fileBase: "plain.sql", sizeBytes: 1000, durationMs: 100, writeManifest: true, manifest: ports.BackupManifest{
+			Hash: ports.HashInfo{Algorithm: "sha256", Value: "bbbb"},
+		}},
+	})
+
+	out, err := runDiff(t, cfgPath, "json", ids["enc.sql"], ids["plain.sql"])
+	if !errors.Is(err, ErrDiffSecurityRegression) {
+		t.Fatalf("encryption on→off must be a security regression, got: %v", err)
+	}
+	if Code(err) == 0 {
+		t.Fatalf("security regression must exit non-zero, got code 0")
+	}
+
+	d := parseDiffJSON(t, out)
+	i, ok := fieldByName(d, "encryption")
+	if !ok {
+		t.Fatalf("expected an 'encryption' diff field:\n%s", out)
+	}
+	if !d.Differences[i].Security {
+		t.Fatalf("encryption field must be flagged security=true")
+	}
+	if !containsStr(d.SecurityRegressions, "ENCRYPTION DISABLED") {
+		t.Fatalf("expected ENCRYPTION DISABLED in %v", d.SecurityRegressions)
+	}
+}
+
+// TestBackupDiff_HashAlgoChangeFlagged asserts a hash-algorithm change is a
+// security regression with a non-zero exit.
+func TestBackupDiff_HashAlgoChangeFlagged(t *testing.T) {
+	cfgPath, ids := seedDiffRepo(t, []diffExec{
+		{fileBase: "a.sql", sizeBytes: 500, durationMs: 50, writeManifest: true, manifest: ports.BackupManifest{
+			Hash: ports.HashInfo{Algorithm: "sha256", Value: "1111"},
+		}},
+		{fileBase: "b.sql", sizeBytes: 500, durationMs: 50, writeManifest: true, manifest: ports.BackupManifest{
+			Hash: ports.HashInfo{Algorithm: "sha1", Value: "2222"},
+		}},
+	})
+
+	out, err := runDiff(t, cfgPath, "json", ids["a.sql"], ids["b.sql"])
+	if !errors.Is(err, ErrDiffSecurityRegression) {
+		t.Fatalf("hash-algo change must be a security regression, got: %v", err)
+	}
+	d := parseDiffJSON(t, out)
+	if i, ok := fieldByName(d, "hash.algorithm"); !ok || !d.Differences[i].Security {
+		t.Fatalf("hash.algorithm must be a flagged security field:\n%s", out)
+	}
+	if !containsStr(d.SecurityRegressions, "HASH ALGORITHM CHANGED") {
+		t.Fatalf("expected HASH ALGORITHM CHANGED in %v", d.SecurityRegressions)
+	}
+}
+
+// TestBackupDiff_EncryptionWeakened asserts a parameter downgrade (iterations
+// decreased) is flagged ENCRYPTION WEAKENED with a non-zero exit.
+func TestBackupDiff_EncryptionWeakened(t *testing.T) {
+	cfgPath, ids := seedDiffRepo(t, []diffExec{
+		{fileBase: "strong.sql", sizeBytes: 1, durationMs: 1, writeManifest: true, manifest: ports.BackupManifest{
+			Hash:       ports.HashInfo{Algorithm: "sha256", Value: "x"},
+			Encryption: &ports.EncryptionInfo{Algorithm: "aes-256-gcm", KeyDerivation: "pbkdf2", Iterations: 600000, EnvelopeVersion: 2},
+		}},
+		{fileBase: "weak.sql", sizeBytes: 1, durationMs: 1, writeManifest: true, manifest: ports.BackupManifest{
+			Hash:       ports.HashInfo{Algorithm: "sha256", Value: "y"},
+			Encryption: &ports.EncryptionInfo{Algorithm: "aes-256-gcm", KeyDerivation: "pbkdf2", Iterations: 100000, EnvelopeVersion: 2},
+		}},
+	})
+
+	out, err := runDiff(t, cfgPath, "json", ids["strong.sql"], ids["weak.sql"])
+	if !errors.Is(err, ErrDiffSecurityRegression) {
+		t.Fatalf("iterations decrease must be a security regression, got: %v", err)
+	}
+	d := parseDiffJSON(t, out)
+	if i, ok := fieldByName(d, "encryption.iterations"); !ok || !d.Differences[i].Security {
+		t.Fatalf("encryption.iterations must be a flagged security field:\n%s", out)
+	}
+	if !containsStr(d.SecurityRegressions, "ENCRYPTION WEAKENED") {
+		t.Fatalf("expected ENCRYPTION WEAKENED in %v", d.SecurityRegressions)
+	}
+}
+
+// TestBackupDiff_SizeAndDurationDeltas asserts size/duration render with correct
+// before/after/percent and DO NOT trip the exit code (no security regression).
+func TestBackupDiff_SizeAndDurationDeltas(t *testing.T) {
+	cfgPath, ids := seedDiffRepo(t, []diffExec{
+		{fileBase: "small.sql", sizeBytes: 1000, durationMs: 100, writeManifest: true, manifest: ports.BackupManifest{
+			Hash: ports.HashInfo{Algorithm: "sha256", Value: "same"},
+		}},
+		{fileBase: "big.sql", sizeBytes: 3000, durationMs: 300, writeManifest: true, manifest: ports.BackupManifest{
+			Hash: ports.HashInfo{Algorithm: "sha256", Value: "same"},
+		}},
+	})
+
+	out, err := runDiff(t, cfgPath, "json", ids["small.sql"], ids["big.sql"])
+	if err != nil {
+		t.Fatalf("size/duration swings alone must exit 0, got: %v", err)
+	}
+	d := parseDiffJSON(t, out)
+
+	si, ok := fieldByName(d, "size_bytes")
+	if !ok {
+		t.Fatalf("expected size_bytes diff:\n%s", out)
+	}
+	if !strings.Contains(d.Differences[si].Delta, "+200%") {
+		t.Fatalf("size delta want +200%%, got %q", d.Differences[si].Delta)
+	}
+	if d.Differences[si].Security {
+		t.Fatalf("size_bytes must not be a security field")
+	}
+
+	di, ok := fieldByName(d, "duration_ms")
+	if !ok {
+		t.Fatalf("expected duration_ms diff:\n%s", out)
+	}
+	if d.Differences[di].Before != "100" || d.Differences[di].After != "300" {
+		t.Fatalf("duration before/after want 100/300, got %s/%s", d.Differences[di].Before, d.Differences[di].After)
+	}
+	if !strings.Contains(d.Differences[di].Delta, "+200%") {
+		t.Fatalf("duration delta want +200%%, got %q", d.Differences[di].Delta)
+	}
+	if len(d.SecurityRegressions) != 0 {
+		t.Fatalf("no security regression expected, got %v", d.SecurityRegressions)
+	}
+}
+
+// TestBackupDiff_IdenticalEmpty asserts identical metadata ⇒ empty diff + exit 0.
+func TestBackupDiff_IdenticalEmpty(t *testing.T) {
+	m := ports.BackupManifest{
+		Hash:       ports.HashInfo{Algorithm: "sha256", Value: "identical"},
+		Encryption: &ports.EncryptionInfo{Algorithm: "aes-256-gcm", KeyDerivation: "pbkdf2", Iterations: 600000, EnvelopeVersion: 2},
+	}
+	cfgPath, ids := seedDiffRepo(t, []diffExec{
+		{fileBase: "one.sql", sizeBytes: 2048, durationMs: 120, backupType: "full", writeManifest: true, manifest: m},
+		{fileBase: "two.sql", sizeBytes: 2048, durationMs: 120, backupType: "full", writeManifest: true, manifest: m},
+	})
+
+	out, err := runDiff(t, cfgPath, "json", ids["one.sql"], ids["two.sql"])
+	if err != nil {
+		t.Fatalf("identical backups must exit 0, got: %v", err)
+	}
+	d := parseDiffJSON(t, out)
+	if len(d.Differences) != 0 {
+		t.Fatalf("identical backups must yield an empty diff, got: %+v", d.Differences)
+	}
+	if len(d.SecurityRegressions) != 0 {
+		t.Fatalf("identical backups must have no regressions, got: %v", d.SecurityRegressions)
+	}
+
+	// Text mode should say there are no differences.
+	textOut, textErr := runDiff(t, cfgPath, "text", ids["one.sql"], ids["two.sql"])
+	if textErr != nil {
+		t.Fatalf("identical text diff must exit 0, got: %v", textErr)
+	}
+	if !strings.Contains(textOut, "No metadata differences") {
+		t.Fatalf("text output should report no differences:\n%s", textOut)
+	}
+}
+
+// TestBackupDiff_MissingManifestPartial asserts one side missing a manifest ⇒
+// partial diff + warning, no crash, exit 0 (no security regression can be
+// computed). It ALSO proves zero artifact bytes are read: neither artifact file
+// exists on disk, yet the diff succeeds.
+func TestBackupDiff_MissingManifestPartial(t *testing.T) {
+	cfgPath, ids := seedDiffRepo(t, []diffExec{
+		{fileBase: "hasman.sql", sizeBytes: 1000, durationMs: 100, backupType: "full", writeManifest: true, manifest: ports.BackupManifest{
+			Hash: ports.HashInfo{Algorithm: "sha256", Value: "hh"},
+		}},
+		{fileBase: "noman.sql", sizeBytes: 5000, durationMs: 500, backupType: "incremental", writeManifest: false},
+	})
+
+	out, err := runDiff(t, cfgPath, "json", ids["hasman.sql"], ids["noman.sql"])
+	if err != nil {
+		t.Fatalf("missing manifest must not fail the diff, got: %v", err)
+	}
+	d := parseDiffJSON(t, out)
+	if len(d.Warnings) == 0 {
+		t.Fatalf("expected a warning about the missing manifest:\n%s", out)
+	}
+	if len(d.SecurityRegressions) != 0 {
+		t.Fatalf("no security regression can be computed with a missing manifest, got: %v", d.SecurityRegressions)
+	}
+	// Monitor-row fields still compared (size/duration/backup_type differ).
+	if _, ok := fieldByName(d, "size_bytes"); !ok {
+		t.Fatalf("partial diff must still compare size_bytes:\n%s", out)
+	}
+	if _, ok := fieldByName(d, "backup_type"); !ok {
+		t.Fatalf("partial diff must still compare backup_type:\n%s", out)
+	}
+	// hash/encryption fields must be ABSENT (needs both manifests).
+	if _, ok := fieldByName(d, "hash.value"); ok {
+		t.Fatalf("hash.value must not appear when a manifest is missing")
+	}
+}
+
+// TestBackupDiff_ZeroArtifactBytesRead is the explicit exit-criterion assertion:
+// the artifact files are never created, so any attempt to open FilePath would
+// fail. The diff succeeds, proving only the row + sidecar are read.
+func TestBackupDiff_ZeroArtifactBytesRead(t *testing.T) {
+	cfgPath, ids := seedDiffRepo(t, []diffExec{
+		{fileBase: "ghost1.sql", sizeBytes: 10, durationMs: 10, writeManifest: true, manifest: ports.BackupManifest{
+			Hash: ports.HashInfo{Algorithm: "sha256", Value: "g1"},
+		}},
+		{fileBase: "ghost2.sql", sizeBytes: 20, durationMs: 20, writeManifest: true, manifest: ports.BackupManifest{
+			Hash: ports.HashInfo{Algorithm: "sha256", Value: "g2"},
+		}},
+	})
+
+	if _, err := runDiff(t, cfgPath, "json", ids["ghost1.sql"], ids["ghost2.sql"]); err != nil {
+		t.Fatalf("diff must succeed without any artifact bytes present, got: %v", err)
+	}
+}
+
+// TestBackupDiff_BackupTypeAndChainDepth asserts the monitor-row-first
+// full↔incremental signal and chain-depth reset render as diff fields.
+func TestBackupDiff_BackupTypeAndChainDepth(t *testing.T) {
+	cfgPath, ids := seedDiffRepo(t, []diffExec{
+		{fileBase: "inc.sql", sizeBytes: 100, durationMs: 10, backupType: "incremental", chainIndex: 3, writeManifest: true, manifest: ports.BackupManifest{
+			Hash: ports.HashInfo{Algorithm: "sha256", Value: "i"},
+		}},
+		{fileBase: "full.sql", sizeBytes: 100, durationMs: 10, backupType: "full", chainIndex: 0, writeManifest: true, manifest: ports.BackupManifest{
+			Hash: ports.HashInfo{Algorithm: "sha256", Value: "f"},
+		}},
+	})
+
+	out, err := runDiff(t, cfgPath, "json", ids["inc.sql"], ids["full.sql"])
+	if err != nil {
+		t.Fatalf("backup_type/chain_depth diff must exit 0, got: %v", err)
+	}
+	d := parseDiffJSON(t, out)
+	bt, ok := fieldByName(d, "backup_type")
+	if !ok || d.Differences[bt].Before != "incremental" || d.Differences[bt].After != "full" {
+		t.Fatalf("backup_type diff wrong:\n%s", out)
+	}
+	cd, ok := fieldByName(d, "chain_depth")
+	if !ok || d.Differences[cd].Delta != "reset" {
+		t.Fatalf("chain_depth reset diff wrong:\n%s", out)
+	}
+}
+
+// TestBackupDiff_NotFound asserts a missing id maps to ErrVerifyNotFound (exit 2).
+func TestBackupDiff_NotFound(t *testing.T) {
+	cfgPath, ids := seedDiffRepo(t, []diffExec{
+		{fileBase: "real.sql", sizeBytes: 1, durationMs: 1, writeManifest: true, manifest: ports.BackupManifest{
+			Hash: ports.HashInfo{Algorithm: "sha256", Value: "r"},
+		}},
+	})
+
+	_, err := runDiff(t, cfgPath, "text", ids["real.sql"], "does-not-exist")
+	if !errors.Is(err, ErrVerifyNotFound) {
+		t.Fatalf("missing id must map to ErrVerifyNotFound, got: %v", err)
+	}
+	if Code(err) != 2 {
+		t.Fatalf("not-found exit code want 2, got %d", Code(err))
+	}
+}
+
+func containsStr(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/exit_codes.go
+++ b/internal/cli/exit_codes.go
@@ -18,6 +18,14 @@ var (
 	// Spec 051 / PRD 34.
 	ErrVerifyIntegrityFailed = errors.New("integrity check failed")
 
+	// ErrDiffSecurityRegression is returned by `backup diff <id1> <id2>` when it
+	// detects a security regression between the two backups (encryption turned
+	// off, a hash-algorithm change, or an encryption-parameter downgrade). It
+	// maps to a non-zero exit (1) so CI/alerting can gate on it. Size/duration
+	// magnitude swings never set this — they stay informational (exit 0).
+	// PRD 36.
+	ErrDiffSecurityRegression = errors.New("backup diff: security regression detected")
+
 	// `sentinel monitor doctor` exit-code carriers. Stable across releases
 	// per specs/017-monitor-schema-migration/contracts/monitor-doctor-cli.md.
 	ErrDoctorStalePending    = errors.New("monitor schema is stale; pending migrations exist")
@@ -41,6 +49,10 @@ func Code(err error) int {
 		return 4
 	case errors.Is(err, ErrVerifyIntegrityFailed):
 		return 5
+	case errors.Is(err, ErrDiffSecurityRegression):
+		// Non-zero, deliberately kept at 1 (matches the PRD 36 example) so a CI
+		// gate simply checks for a non-zero exit.
+		return 1
 	case errors.Is(err, ErrDoctorStalePending):
 		return 1
 	case errors.Is(err, ErrDoctorForwardIncompat):


### PR DESCRIPTION
## What

`sentinel backup diff <id1> <id2>` (PRD 36) — recovers roadmap M5 "Watchdog" F-03. Compare two backups' **recorded metadata** to diagnose anomalies (size/duration jumps, backup-type/chain changes) and — the headline — catch silent **security regressions** (encryption turned off, hash-algorithm change, encryption-parameter downgrade), all **without reading a single artifact byte**.

## How

- New `internal/cli/backup_diff.go`, registered on `BackupCmd` in its own `init()` (no `root.go` change).
- **Zero artifact bytes**: reuses `backup verify`'s ID→row→manifest resolution (`GetExecution` → `FilePath + ".manifest.json"` → `ReadManifest`); the hash-compute/`os.Open(FilePath)` step is deliberately never invoked. Asserted by `TestBackupDiff_ZeroArtifactBytesRead` (artifact files never created, diff still succeeds).
- Compares the 8 fields that exist in manifest v1 (size_bytes, duration_ms, hash.algorithm, hash.value, encryption presence + params, backup_type, chain_depth). `compression.ratio`/`database_version` are **not fabricated** (gated on PRD 33).
- **Security-regression exit gate**: ENCRYPTION DISABLED / HASH ALGORITHM CHANGED / ENCRYPTION WEAKENED → `ErrDiffSecurityRegression` (non-zero exit, CI-gateable). Size/duration swings get a `⚠` but stay exit 0.
- **Remote sidecars**: for remote backups, fetches only the `<key>.manifest.json` via verify's existing storage seam — never the artifact; graceful degrade (warn + partial diff) on fetch failure.
- Pre-v1.1 backups (`ErrNoManifest`): warn + partial monitor-row-only diff, never a hard fail.
- `--output json` for automation; text renders a `FIELD | BEFORE | AFTER | DELTA` tabwriter table of only differing fields.

No new port, no new adapter cross-import (ADR-0001 clean).

## Test

9 unit tests (in-memory monitor + temp manifests, no infra): encryption on→off + non-zero exit; hash-algo change; encryption weakened; size/duration deltas stay exit 0; identical ⇒ empty diff exit 0; missing-manifest partial diff; zero-artifact-bytes; backup_type/chain_depth; not-found → exit 2.

`go build` / `go vet` / `go vet -tags=integration` / `go test ./...` / `golangci-lint` — all green.
