### PR TITLE
feat(repair): sentinel repair — repository state reconciliation over existing ports (PRD 37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,11 @@ sentinel backup verify --all --config sentinel.yaml          # repository-wide i
 sentinel backup verify --all --since 30d --output json --config sentinel.yaml
 sentinel backup diff <id1> <id2> --config sentinel.yaml      # compare two backups' metadata
 
+# State repair (reconcile monitor rows / manifests / artifacts / locks)
+sentinel repair --dry-run --config sentinel.yaml             # report drift, change nothing
+sentinel repair --fix --config sentinel.yaml                 # apply recoverable fixes
+sentinel repair --purge-orphans --yes --config sentinel.yaml # also delete orphan artifacts
+
 # Config & storage
 sentinel config validate --config sentinel.yaml
 sentinel storage status --config sentinel.yaml
@@ -378,6 +383,42 @@ change (`HASH ALGORITHM CHANGED`), or an encryption-parameter downgrade (`ENCRYP
 Size/duration swings get a `⚠` marker but stay informational (exit 0). A backup with no manifest
 (pre-v1.1) still diffs on its monitor-row fields with a warning. See
 [docs/runbooks/verify-backup-integrity.md](docs/runbooks/verify-backup-integrity.md).
+
+---
+
+## State repair
+
+A crash mid-backup, a hard-killed process, or a manual artifact deletion can leave Sentinel's
+three sources of truth — monitor rows, `*.manifest.json` sidecars, and the artifacts on storage —
+silently disagreeing. `sentinel repair` reconciles them repository-wide (this is **not**
+`monitor doctor --repair`, which is schema-only).
+
+```bash
+sentinel repair --dry-run --config sentinel.yaml    # always run this first
+```
+
+It detects six drift classes: `orphan_artifact` (object with no sidecar and no row),
+`orphan_manifest` (sidecar whose artifact is gone), `artifact_missing` (recorded backup absent
+from storage), `stale_running` (a `running` row whose job holds no live lock), `stale_lock`
+(dead-PID lock past the threshold), and `chain_broken` (incremental chain with a missing or
+non-contiguous link — via the same resolver as `restore validate-chain`).
+
+**Report-only by default; destructive actions are strictly opt-in:**
+
+```bash
+sentinel repair --config sentinel.yaml               # report-only (same as --dry-run)
+sentinel repair --fix --config sentinel.yaml         # finalize stale runs, remove stale locks, mark broken chains
+sentinel repair --purge-orphans --config sentinel.yaml  # also DELETE orphan artifacts (prompts; add --yes for automation)
+sentinel repair --dry-run --format json --config sentinel.yaml   # structured findings for tooling
+```
+
+Safety guards: `--purge-orphans` is the only path that deletes artifacts, it prompts unless
+`--yes`, and it **never** removes an active chain baseline. A `running` row is finalized only when
+no **live** lock is held for its job (the guard the scheduler's blind startup reconcile lacks);
+foreign-host locks and rows are skipped with a warning. Repair refuses to run against a
+`forward-incompatible`/`corrupt` monitor schema (defer to `monitor doctor`), and exits non-zero
+while manual-action inconsistencies (`artifact_missing`, `chain_broken`) remain, so it can gate
+CI/cron. See [docs/runbooks/state-repair.md](docs/runbooks/state-repair.md).
 
 ---
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -29,6 +29,7 @@ Operational procedures for running, recovering, and maintaining Sentinel in prod
 - [Repository-wide integrity sweep (`backup verify --all`)](./integrity-sweep.md)
 
 ## Incidents
+- [Repository state repair (`sentinel repair`)](./state-repair.md)
 - [Stale lock recovery](./stale-lock-recovery.md)
 - [Scheduler crash recovery](./scheduler-crash-recovery.md)
 - [Failed backup triage](./failed-backup-triage.md)

--- a/docs/runbooks/state-repair.md
+++ b/docs/runbooks/state-repair.md
@@ -1,0 +1,141 @@
+# Runbook — Repository state repair (`sentinel repair`)
+
+- **Audience**: ops / SRE
+- **Last reviewed**: 2026-08-03
+- **Related**: [stale-lock-recovery](./stale-lock-recovery.md), [scheduler-crash-recovery](./scheduler-crash-recovery.md), [chain-corruption-recovery](./chain-corruption-recovery.md), [integrity-sweep](./integrity-sweep.md), [monitor-schema-migration](./monitor-schema-migration.md)
+
+## When to use
+
+Sentinel's state lives in three places that can silently drift apart after a
+crash, a hard-killed process, or a manual artifact deletion:
+
+1. **Monitor SQLite** — execution-history rows.
+2. **Manifests** — the `<artifact>.manifest.json` sidecars.
+3. **Artifacts** — the files on the storage backend.
+
+Use `sentinel repair` when:
+
+- a job is stuck showing `running` long after the process died,
+- restore fails because a recorded artifact is missing,
+- storage bills grow from artifacts with no history/manifest,
+- an incremental chain is broken and you want a proactive audit.
+
+`sentinel repair` is **not** `monitor doctor --repair` (that is schema-only,
+one file). Repair is repository-wide and can delete artifacts — always run
+`--dry-run` first.
+
+## Drift classes detected
+
+| Class | Meaning | Fixed by |
+|---|---|---|
+| `orphan_artifact` | storage object with no sidecar and no monitor row | `--purge-orphans` (guarded) |
+| `untracked_artifact` | sidecar present but no monitor row (soft) | never auto-purged; reported only |
+| `orphan_manifest` | sidecar present, referenced artifact absent | reported (no artifact to purge) |
+| `artifact_missing` | monitor/manifest references an artifact that is gone | **manual** (see below) |
+| `stale_running` | `running` row with no live lock for its job | `--fix` → `interrupted` |
+| `stale_lock` | dead-PID lock older than the threshold | `--fix` → removed |
+| `chain_broken` | incremental chain with a missing/non-contiguous link | **manual** |
+
+## Modes (report-only by default; destructive actions opt-in)
+
+| Invocation | Behaviour |
+|---|---|
+| `sentinel repair` / `--dry-run` | Report every drift class. **Mutates nothing.** |
+| `sentinel repair --fix` | Apply the recoverable classes: finalize `stale_running` rows, remove `stale_lock` files, mark `chain_broken`. **Never deletes an artifact.** |
+| `sentinel repair --purge-orphans` | Everything `--fix` does, **plus** delete `orphan_artifact` objects. Requires confirmation unless `--yes`. Implies `--fix`. |
+| add `--dry-run` to any of the above | Forces report-only again. |
+
+Other flags: `--job <name>` narrows to one backup job; `--format text|json`;
+`--yes` skips the purge confirmation (for automation).
+
+## Preconditions
+
+- The monitor schema must be **current**. Repair calls `monitor.Diagnose`
+  first and refuses (non-zero exit, doctor hint) against a
+  `forward-incompatible` / `corrupt` / `missing` / `stale-pending` database —
+  it will not reconcile against a schema it cannot trust. Fix the schema with
+  [`monitor doctor`](./monitor-schema-migration.md) first.
+- Read access to the storage backend(s) and the lock directory.
+
+## Steps
+
+### 1. Always dry-run first
+
+```bash
+sentinel repair --dry-run --config sentinel.yaml
+```
+
+```
+Repository: prod-mysql (s3://backups/prod-mysql)
+  stale_running     run-8f3a...   no live lock            → would mark interrupted
+  stale_lock        prod-mysql.lock  dead pid=41 age=3h0s → report (use --fix to remove)
+  orphan_artifact   2026-07-30.sql   1.9 GB               → report (use --purge-orphans to delete)
+  artifact_missing  s3://.../2026-07-29.sql               → manual action required
+  chain_broken      chain=ab12: broken_lineage_chain: rule_4_non_contiguous_chain_index → manual action required (blocks incremental restore)
+
+5 finding(s): 1 orphan_artifact · 0 untracked · 0 orphan_manifest · 1 artifact_missing · 1 stale_running · 1 stale_lock · 1 chain_broken
+Nothing was modified (report-only; use --fix / --purge-orphans to apply).
+```
+
+For tooling: `sentinel repair --dry-run --format json`.
+
+### 2. Apply the safe, recoverable fixes
+
+```bash
+sentinel repair --fix --config sentinel.yaml
+```
+
+This finalizes stale `running` rows to `interrupted` (only when **no live lock**
+is held for the job — the guard the scheduler's blind startup reconcile lacks),
+removes dead-PID stale locks (host-local; foreign-host locks are skipped with a
+warning), and marks broken chains. **No artifact is deleted.**
+
+### 3. Purge orphan artifacts (deliberate, guarded)
+
+```bash
+sentinel repair --purge-orphans --config sentinel.yaml          # prompts before deleting
+sentinel repair --purge-orphans --yes --config sentinel.yaml    # automation
+```
+
+Only `orphan_artifact` objects (no sidecar **and** no monitor row) are deleted.
+The **active chain baseline is always protected** (via
+`retention.ProtectActiveBaseline`) even under `--purge-orphans` — a live chain's
+`full` / `ChainIndex==0` baseline is never removed.
+
+## Manual-action classes
+
+`artifact_missing` and `chain_broken` are **not** auto-fixed (repair marks and
+reports them, it never fabricates lineage or re-derives a missing artifact).
+Repair exits **non-zero** while any remain, so it can gate CI/cron.
+
+- `artifact_missing`: recover the artifact from another copy, or delete the
+  stale monitor row / manifest if the backup is genuinely gone.
+- `chain_broken`: see [chain-corruption-recovery](./chain-corruption-recovery.md);
+  force a fresh full backup (`sentinel backup force-full`) to start a new chain.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | No manual-action inconsistencies remain |
+| 4 | Operational failure (config/backend/db) — `ErrRepairInternal` |
+| 5 | `artifact_missing` / `chain_broken` remain — `ErrRepairInconsistent` |
+| 1/2/3/4 | Schema refusal (reuses the `monitor doctor` exit-code contract) |
+
+## Host-scoping caveat
+
+Lock reconciliation is **host-local**. Repair never finalizes a `running` row
+whose job lock is held on another host, and never removes a foreign-host lock —
+it warns and skips. In multi-host deployments, run repair per host.
+
+## References
+
+- `internal/cli/repair.go`
+- Reuses: `internal/adapters/monitor` (`GetStaleRunningExecutions`,
+  `RecordInterrupted`, `Diagnose`), `internal/adapters/lock` (`Inspect`,
+  `ListLockFiles`, `EvaluateLockState`, `ScanStale`),
+  `internal/adapters/manifest_store` (`ReadManifest`),
+  `internal/domain/manifest` (`ValidateIncrementalLineageContract`),
+  `internal/domain/restore/incremental` (`ResolveOrderedChain`),
+  `internal/domain/retention` (`ProtectActiveBaseline`).
+- ADR 0001 — hexagonal layering (repair is a driving/composition command).

--- a/internal/cli/exit_codes.go
+++ b/internal/cli/exit_codes.go
@@ -32,6 +32,14 @@ var (
 	ErrDoctorForwardIncompat = errors.New("monitor schema is ahead of this binary")
 	ErrDoctorMissing         = errors.New("monitor database is missing")
 	ErrDoctorCorrupt         = errors.New("monitor database is corrupt or unreadable")
+
+	// `sentinel repair` exit-code carriers (PRD 37). ErrRepairInternal marks an
+	// operational failure that prevented reconciliation (config/backend/db);
+	// ErrRepairInconsistent marks that manual-action inconsistencies remain
+	// (artifact_missing / chain_broken) so repair can gate CI/cron. Schema
+	// refusal reuses the doctor sentinels above.
+	ErrRepairInternal     = errors.New("repair internal error")
+	ErrRepairInconsistent = errors.New("repair: unresolved inconsistencies require manual action")
 )
 
 // Code translates an error returned from RootCmd.Execute() into a process exit code.
@@ -61,6 +69,10 @@ func Code(err error) int {
 		return 3
 	case errors.Is(err, ErrDoctorCorrupt):
 		return 4
+	case errors.Is(err, ErrRepairInternal):
+		return 4
+	case errors.Is(err, ErrRepairInconsistent):
+		return 5
 	default:
 		return 1
 	}

--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -1,0 +1,1133 @@
+package cli
+
+// `sentinel repair` — repository-wide internal-state reconciliation (PRD 37).
+//
+// Repair is a DRIVING/COMPOSITION command over existing adapters and domain
+// functions (ADR 0001): it reconciles the three sources of truth — monitor
+// SQLite rows, manifest sidecars, and storage artifacts — plus the lock
+// directory. It introduces NO new port and NO adapter->adapter cross-import.
+//
+// It is NOT `monitor doctor --repair` (that is schema-only, one file). Repair
+// detects six drift classes across every configured job's storage backend and,
+// on opt-in, applies the recoverable fixes.
+//
+// Flag matrix (Q1 default = report-only; destructive actions strictly opt-in):
+//
+//	(no flags) / --dry-run : report every drift class, mutate NOTHING.
+//	--fix                  : apply recoverable classes 4/5/6 (finalize stale
+//	                         running rows, remove stale locks, mark broken chains).
+//	--purge-orphans        : additionally delete orphan artifacts (class 1),
+//	                         guarded by confirmation (--yes) + active-baseline
+//	                         protection; implies --fix.
+//	--dry-run              : forces report-only even combined with the above.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/denisakp/sentinel/internal/adapters/lock"
+	manifeststore "github.com/denisakp/sentinel/internal/adapters/manifest_store"
+	"github.com/denisakp/sentinel/internal/adapters/monitor"
+	storage "github.com/denisakp/sentinel/internal/adapters/storage"
+	"github.com/denisakp/sentinel/internal/config"
+	domainmanifest "github.com/denisakp/sentinel/internal/domain/manifest"
+	incremental "github.com/denisakp/sentinel/internal/domain/restore/incremental"
+	"github.com/denisakp/sentinel/internal/domain/retention"
+	"github.com/denisakp/sentinel/internal/ports"
+	"github.com/spf13/cobra"
+)
+
+// Drift class identifiers (stable across releases; used in text + JSON output).
+const (
+	driftOrphanArtifact    = "orphan_artifact"
+	driftUntrackedArtifact = "untracked_artifact"
+	driftOrphanManifest    = "orphan_manifest"
+	driftArtifactMissing   = "artifact_missing"
+	driftStaleRunning      = "stale_running"
+	driftStaleLock         = "stale_lock"
+	driftChainBroken       = "chain_broken"
+)
+
+// repairListLimit bounds the number of executions the repair sweep enumerates
+// from the monitor, mirroring the verify/retention fetch caps.
+const repairListLimit = 100000
+
+// newRepairBackend is a test seam over the storage registry (mirrors
+// newVerifyBackend / newRetentionDeleteBackend).
+var newRepairBackend = func(p *storage.BackendParams) (ports.StorageBackend, error) {
+	return storage.NewBackend(p)
+}
+
+// repairConfirm prompts on out and reads a yes/no answer from in. Package-level
+// var so tests can override.
+var repairConfirm = func(in io.Reader, out io.Writer, prompt string) bool {
+	fmt.Fprint(out, prompt)
+	line, _ := bufio.NewReader(in).ReadString('\n')
+	line = strings.ToLower(strings.TrimSpace(line))
+	return line == "y" || line == "yes"
+}
+
+// repairMode captures the resolved action posture from the flag matrix.
+type repairMode struct {
+	reportOnly bool // true: no mutation of any kind (no-flag / --dry-run)
+	fix        bool // apply recoverable classes 4/5/6
+	purge      bool // additionally delete orphan artifacts (class 1)
+	assumeYes  bool // skip interactive confirmation for purge
+}
+
+// doRecoverable reports whether recoverable fixes (4/5/6) should be applied.
+func (m repairMode) doRecoverable() bool { return !m.reportOnly && (m.fix || m.purge) }
+
+// doPurge reports whether orphan-artifact deletion (class 1) should be applied.
+func (m repairMode) doPurge() bool { return !m.reportOnly && m.purge }
+
+// repairFinding is one detected drift item plus the action taken/intended.
+type repairFinding struct {
+	Class      string `json:"class"`
+	Job        string `json:"job,omitempty"`
+	Repository string `json:"repository,omitempty"`
+	Path       string `json:"path,omitempty"`
+	Detail     string `json:"detail,omitempty"`
+	Action     string `json:"action"`
+	SizeBytes  int64  `json:"size_bytes,omitempty"`
+	Applied    bool   `json:"applied"`
+}
+
+// orphanCandidate carries what purge needs to delete an orphan artifact.
+type orphanCandidate struct {
+	repoKey    string
+	repoLabel  string
+	backend    ports.StorageBackend
+	objectPath string // storage.List Path, deletable directly via backend.Delete
+	base       string // filepath.Base, join key for baseline protection
+	size       int64
+}
+
+var repairCmd = &cobra.Command{
+	Use:   "repair",
+	Short: "Reconcile internal state across monitor rows, manifests, artifacts, and locks",
+	Long: "Detect and (on opt-in) fix repository-wide state drift: orphan artifacts, orphan\n" +
+		"manifests, missing artifacts, stale running executions, stale locks, and broken\n" +
+		"incremental chains. Report-only by default; pass --fix to apply recoverable fixes\n" +
+		"and --purge-orphans to delete orphan artifacts.\n\n" +
+		"This is NOT `monitor doctor --repair` (schema-only). Always run with --dry-run first.",
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return runRepairCommand(cmd)
+	},
+}
+
+func runRepairCommand(cmd *cobra.Command) error {
+	mode := resolveRepairMode(cmd)
+	format, _ := cmd.Flags().GetString("format")
+	jobFilter, _ := cmd.Flags().GetString("job")
+
+	cfg, err := loadConfigFromFlags(cmd)
+	if err != nil {
+		return fmt.Errorf("load config: %w: %v", ErrRepairInternal, err)
+	}
+
+	// Schema-health precondition: refuse to reconcile against a schema this
+	// binary cannot trust. Diagnose is read-only and never migrates.
+	report, derr := monitor.Diagnose(cfg.HistoryDBPath)
+	if derr != nil {
+		return fmt.Errorf("diagnose monitor db: %w: %v", ErrRepairInternal, derr)
+	}
+	if report.Status != monitor.StatusCurrent {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Error: monitor schema is %q; repair refuses to run.\n", report.Status)
+		if report.Hint != "" {
+			fmt.Fprintf(cmd.ErrOrStderr(), "  Fix: %s\n", report.Hint)
+		}
+		return schemaRefusalError(report.Status)
+	}
+
+	mon, err := monitor.NewMonitor(cfg.HistoryDBPath)
+	if err != nil {
+		return fmt.Errorf("open history db: %w: %v", ErrRepairInternal, err)
+	}
+	defer mon.Close()
+
+	lm := lock.NewManager(cfg.Scheduler.LockDir)
+
+	findings, err := runRepair(cmd.Context(), cmd, cfg, mon, lm, mode, jobFilter)
+	if err != nil {
+		return err
+	}
+
+	if strings.EqualFold(format, "json") {
+		renderRepairJSON(cmd.OutOrStdout(), findings, mode)
+	} else {
+		renderRepairText(cmd.OutOrStdout(), findings, mode)
+	}
+
+	return repairExitError(findings)
+}
+
+// resolveRepairMode maps the flags to a posture. --dry-run always forces
+// report-only; --purge-orphans implies --fix.
+func resolveRepairMode(cmd *cobra.Command) repairMode {
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	fix, _ := cmd.Flags().GetBool("fix")
+	purge, _ := cmd.Flags().GetBool("purge-orphans")
+	yes, _ := cmd.Flags().GetBool("yes")
+
+	m := repairMode{fix: fix, purge: purge, assumeYes: yes}
+	// Report-only when no action flag is set OR --dry-run is present.
+	m.reportOnly = dryRun || (!fix && !purge)
+	return m
+}
+
+// runRepair performs detection across all target jobs and applies fixes per the
+// mode. It returns the ordered finding list.
+func runRepair(ctx context.Context, cmd *cobra.Command, cfg *config.Configuration, mon *monitor.Monitor, lm *lock.Manager, mode repairMode, jobFilter string) ([]repairFinding, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	allRows, err := mon.ListExecutions(ctx, &ports.Filter{}, repairListLimit, 0)
+	if err != nil {
+		return nil, fmt.Errorf("list executions: %w: %v", ErrRepairInternal, err)
+	}
+
+	// Global tracked base-name set (all rows, any status): an artifact is
+	// "known" if ANY row references it — this avoids flagging one job's
+	// artifacts as orphans on a bucket shared with another job.
+	trackedBases := map[string]struct{}{}
+	for i := range allRows {
+		if b := baseName(allRows[i].FilePath); b != "" {
+			trackedBases[b] = struct{}{}
+		}
+	}
+
+	// Success records (newest-first) for baseline protection.
+	records := successRecords(allRows)
+
+	repos := collectRepos(cfg, jobFilter)
+
+	var findings []repairFinding
+	var purgeCandidates []orphanCandidate
+
+	// Per-repo storage enumeration (orphan_artifact / untracked / orphan_manifest).
+	for _, repo := range repos {
+		params, prefix, perr := repairBackendParams(repo.cfg)
+		if perr != nil {
+			findings = append(findings, repairFinding{
+				Class: driftOrphanArtifact, Repository: repo.label,
+				Detail: perr.Error(), Action: "skipped (unsupported storage)",
+			})
+			continue
+		}
+		backend, berr := newRepairBackend(params)
+		if berr != nil {
+			findings = append(findings, repairFinding{
+				Class: driftOrphanArtifact, Repository: repo.label,
+				Detail: fmt.Sprintf("backend init: %v", berr), Action: "skipped (backend error)",
+			})
+			continue
+		}
+		objs, lerr := backend.List(ctx, prefix)
+		if lerr != nil {
+			// Degrade: orphan classes need the listing; row-driven classes still run.
+			findings = append(findings, repairFinding{
+				Class: driftOrphanArtifact, Repository: repo.label,
+				Detail: fmt.Sprintf("list failed: %v", lerr), Action: "skipped (list error)",
+			})
+			repo.presentBases = nil
+			continue
+		}
+		repo.presentBases = presentBaseSet(objs)
+
+		orphans, cands := classifyStorageObjects(objs, trackedBases, backend, repo)
+		findings = append(findings, orphans...)
+		purgeCandidates = append(purgeCandidates, cands...)
+	}
+
+	// Per-job classes: artifact_missing (class 3) + chain_broken (class 6).
+	for _, repo := range repos {
+		for _, job := range repo.jobs {
+			jobRows := rowsForJob(allRows, job)
+			findings = append(findings, classifyMissing(jobRows, repo.presentBases, repo.label)...)
+			findings = append(findings, detectBrokenChains(ctx, jobRows, repo)...)
+		}
+	}
+
+	// stale_running (class 4) — GetStaleRunningExecutions is global; scope to
+	// target jobs, lock-guarded, host-local honest.
+	findings = append(findings, reconcileStaleRunning(ctx, mon, lm, cfg, mode, repos)...)
+
+	// stale_lock (class 5) — host-local lock directory scan.
+	findings = append(findings, reconcileStaleLocks(lm, cfg, mode, repos)...)
+
+	// orphan purge (class 1) — the ONLY artifact-deleting path, guarded.
+	findings = applyOrphanPurge(ctx, cmd, findings, purgeCandidates, records, mode)
+
+	return findings, nil
+}
+
+// classifyStorageObjects detects orphan_artifact (no sidecar AND no row),
+// untracked_artifact (sidecar present but no row — soft, never purged), and
+// orphan_manifest (sidecar present, referenced artifact absent). Pure over the
+// listing + tracked set; backend/repo carried only to build purge candidates.
+func classifyStorageObjects(objs []ports.StorageObject, trackedBases map[string]struct{}, backend ports.StorageBackend, repo *repairRepo) ([]repairFinding, []orphanCandidate) {
+	artifactBases := map[string]struct{}{}
+	for _, o := range objs {
+		if !isManifestKey(o.Path) {
+			artifactBases[baseName(o.Path)] = struct{}{}
+		}
+	}
+
+	var findings []repairFinding
+	var cands []orphanCandidate
+
+	for _, o := range objs {
+		base := baseName(o.Path)
+		if isManifestKey(o.Path) {
+			// orphan_manifest: referenced artifact absent from the listing.
+			ref := manifestRefBase(o.Path)
+			if _, ok := artifactBases[ref]; !ok {
+				findings = append(findings, repairFinding{
+					Class: driftOrphanManifest, Repository: repo.label, Path: o.Path,
+					Detail: "referenced artifact absent", Action: "report (kept; no artifact to purge)",
+				})
+			}
+			continue
+		}
+
+		_, hasRow := trackedBases[base]
+		_, hasSidecar := manifestSidecarPresent(objs, base)
+		switch {
+		case !hasRow && !hasSidecar:
+			findings = append(findings, repairFinding{
+				Class: driftOrphanArtifact, Repository: repo.label, Path: o.Path,
+				SizeBytes: o.SizeBytes, Action: "report (use --purge-orphans to delete)",
+			})
+			cands = append(cands, orphanCandidate{
+				repoKey: repo.key, repoLabel: repo.label, backend: backend,
+				objectPath: o.Path, base: base, size: o.SizeBytes,
+			})
+		case !hasRow && hasSidecar:
+			// Q3: sidecar present but no row is a softer untracked_artifact.
+			findings = append(findings, repairFinding{
+				Class: driftUntrackedArtifact, Repository: repo.label, Path: o.Path,
+				SizeBytes: o.SizeBytes, Detail: "manifest present, no monitor row",
+				Action: "report (never auto-purged)",
+			})
+		}
+	}
+	return findings, cands
+}
+
+// classifyMissing detects artifact_missing: a successful backup row whose
+// artifact is absent from the storage listing. Manual action required.
+func classifyMissing(rows []ports.Execution, presentBases map[string]struct{}, repoLabel string) []repairFinding {
+	if presentBases == nil {
+		return nil // listing unavailable/degraded — do not guess
+	}
+	var findings []repairFinding
+	for i := range rows {
+		r := rows[i]
+		if r.Status != ports.StatusSuccess && r.Status != ports.StatusCompleted {
+			continue
+		}
+		base := baseName(r.FilePath)
+		if base == "" {
+			continue
+		}
+		if _, ok := presentBases[base]; !ok {
+			findings = append(findings, repairFinding{
+				Class: driftArtifactMissing, Job: r.BackupName, Repository: repoLabel,
+				Path: r.FilePath, Detail: "recorded artifact absent from storage",
+				Action: "manual action required",
+			})
+		}
+	}
+	return findings
+}
+
+// detectBrokenChains groups a job's incremental rows by ChainID, loads each
+// member's manifest for lineage fields, and runs the SAME resolver that powers
+// `restore validate-chain` (incremental.ResolveOrderedChain) plus the pure
+// lineage-field validator. Repair does NOT re-hash: chain detection is
+// structural, so HashVerified is asserted true and only missing / non-contiguous
+// / mismatched links surface as chain_broken.
+func detectBrokenChains(ctx context.Context, rows []ports.Execution, repo *repairRepo) []repairFinding {
+	chains := map[string][]ports.Execution{}
+	order := []string{}
+	for i := range rows {
+		r := rows[i]
+		if r.ChainID == "" {
+			continue
+		}
+		if r.Status != ports.StatusSuccess && r.Status != ports.StatusCompleted {
+			continue
+		}
+		if _, seen := chains[r.ChainID]; !seen {
+			order = append(order, r.ChainID)
+		}
+		chains[r.ChainID] = append(chains[r.ChainID], r)
+	}
+
+	var findings []repairFinding
+	for _, chainID := range order {
+		members := chains[chainID]
+		sort.SliceStable(members, func(i, j int) bool { return members[i].ChainIndex < members[j].ChainIndex })
+
+		arts := make([]incremental.ChainArtifact, 0, len(members))
+		var lineageErr string
+		for i := range members {
+			m := members[i]
+			man := loadManifestForRow(ctx, repo, m)
+			art := incremental.ChainArtifact{
+				BackupID:        m.ID,
+				ChainIndex:      m.ChainIndex,
+				ManifestPresent: man != nil,
+				HashVerified:    true, // structural check only; repair does not re-hash
+			}
+			if man != nil {
+				if man.BackupID != "" {
+					art.BackupID = man.BackupID
+				}
+				art.HashValue = man.Hash.Value
+				art.HashAlgorithm = man.Hash.Algorithm
+				if man.AdvancedRestore != nil && man.AdvancedRestore.IncrementalLineage != nil {
+					lin := man.AdvancedRestore.IncrementalLineage
+					art.BaselineBackupID = lin.BaselineBackupID
+					art.TimelineID = lin.TimelineID
+				}
+				if verr := domainmanifest.ValidateIncrementalLineageContract(man); verr != nil && lineageErr == "" {
+					lineageErr = verr.Error()
+				}
+			}
+			arts = append(arts, art)
+		}
+
+		_, rerr := incremental.ResolveOrderedChain(arts, "")
+		if rerr != nil {
+			findings = append(findings, repairFinding{
+				Class: driftChainBroken, Job: firstJob(members), Repository: repo.label,
+				Detail:  fmt.Sprintf("chain=%s: %v", chainID, rerr),
+				Action:  "manual action required (blocks incremental restore)",
+			})
+			continue
+		}
+		if lineageErr != "" {
+			findings = append(findings, repairFinding{
+				Class: driftChainBroken, Job: firstJob(members), Repository: repo.label,
+				Detail:  fmt.Sprintf("chain=%s: %s", chainID, lineageErr),
+				Action:  "manual action required (blocks incremental restore)",
+			})
+		}
+	}
+	return findings
+}
+
+// reconcileStaleRunning finalizes stale running rows to `interrupted`, but ONLY
+// when no live lock is held for the job (the correctness improvement over the
+// blind ReconcileStaleExecutions). Foreign-host locks are skipped with a
+// warning (host-scoping honesty).
+func reconcileStaleRunning(ctx context.Context, mon *monitor.Monitor, lm *lock.Manager, cfg *config.Configuration, mode repairMode, repos []*repairRepo) []repairFinding {
+	staleRows, err := mon.GetStaleRunningExecutions(ctx)
+	if err != nil {
+		return []repairFinding{{
+			Class: driftStaleRunning, Detail: fmt.Sprintf("query failed: %v", err),
+			Action: "skipped (query error)",
+		}}
+	}
+
+	targets := jobLabelIndex(repos)
+	threshold := staleThreshold(cfg)
+	thisHost, _ := os.Hostname()
+
+	var findings []repairFinding
+	for i := range staleRows {
+		r := staleRows[i]
+		label, ok := targets[r.BackupName]
+		if !ok {
+			continue // not a target job
+		}
+
+		jl, _ := lm.ReadLock(r.BackupName)
+		decision, detail := classifyStaleRunning(jl, threshold, thisHost)
+
+		f := repairFinding{
+			Class: driftStaleRunning, Job: r.BackupName, Repository: label,
+			Path: r.ID, Detail: detail,
+		}
+		switch decision {
+		case staleSkipLive:
+			f.Action = "skipped (live lock)"
+		case staleSkipForeign:
+			f.Action = "skipped (foreign-host lock)"
+		case staleFinalize:
+			if mode.doRecoverable() {
+				if rerr := mon.RecordInterrupted(ctx, r.ID, false, nil, "unclean shutdown (repair)"); rerr != nil {
+					f.Action = fmt.Sprintf("finalize failed: %v", rerr)
+				} else {
+					f.Action = "marked interrupted"
+					f.Applied = true
+				}
+			} else {
+				f.Action = "would mark interrupted"
+			}
+		}
+		findings = append(findings, f)
+	}
+	return findings
+}
+
+type staleDecision int
+
+const (
+	staleFinalize staleDecision = iota
+	staleSkipLive
+	staleSkipForeign
+)
+
+// classifyStaleRunning decides how to handle a stale running row given the
+// current lock (may be nil). Pure.
+func classifyStaleRunning(jl *ports.JobLock, threshold time.Duration, thisHost string) (staleDecision, string) {
+	if jl == nil {
+		return staleFinalize, "no live lock"
+	}
+	if jl.Hostname != "" && thisHost != "" && jl.Hostname != thisHost {
+		return staleSkipForeign, fmt.Sprintf("lock held on host %q (pid=%d)", jl.Hostname, jl.PID)
+	}
+	state := lock.EvaluateLockState(jl, threshold)
+	if state.Live {
+		return staleSkipLive, fmt.Sprintf("live lock pid=%d", jl.PID)
+	}
+	return staleFinalize, fmt.Sprintf("no live lock (dead pid=%d)", jl.PID)
+}
+
+// reconcileStaleLocks reports removable locks and, when applying, removes them
+// via ScanStale (which already skips foreign-host and live locks).
+func reconcileStaleLocks(lm *lock.Manager, cfg *config.Configuration, mode repairMode, repos []*repairRepo) []repairFinding {
+	threshold := staleThreshold(cfg)
+	thisHost, _ := os.Hostname()
+
+	files, err := lm.ListLockFiles()
+	if err != nil {
+		return []repairFinding{{
+			Class: driftStaleLock, Detail: fmt.Sprintf("list lock files failed: %v", err),
+			Action: "skipped (list error)",
+		}}
+	}
+
+	labels := jobLabelIndex(repos)
+
+	// Detect removable locks first (report intent), then apply once via ScanStale.
+	type pending struct {
+		idx  int
+		path string
+	}
+	var findings []repairFinding
+	var removable []pending
+	for _, path := range files {
+		job := strings.TrimSuffix(filepath.Base(path), ".lock")
+		jl, rerr := lm.ReadLock(job)
+		if rerr != nil || jl == nil {
+			continue
+		}
+		if jl.Hostname != "" && thisHost != "" && jl.Hostname != thisHost {
+			continue // foreign-host lock: never touched
+		}
+		state := lock.EvaluateLockState(jl, threshold)
+		if !state.Removable {
+			continue
+		}
+		f := repairFinding{
+			Class: driftStaleLock, Job: job, Repository: labels[job], Path: path,
+			Detail: fmt.Sprintf("dead pid=%d age=%s", state.PID, state.Age.Truncate(time.Second)),
+		}
+		if mode.doRecoverable() {
+			f.Action = "would remove" // provisionally; upgraded to "removed" below
+		} else {
+			f.Action = "report (use --fix to remove)"
+		}
+		removable = append(removable, pending{idx: len(findings), path: path})
+		findings = append(findings, f)
+	}
+
+	if mode.doRecoverable() && len(removable) > 0 {
+		removed, _ := lm.ScanStale(threshold)
+		removedSet := map[string]struct{}{}
+		for _, p := range removed {
+			removedSet[p] = struct{}{}
+		}
+		for _, p := range removable {
+			if _, ok := removedSet[p.path]; ok {
+				findings[p.idx].Action = "removed"
+				findings[p.idx].Applied = true
+			} else {
+				findings[p.idx].Action = "kept (scan skipped it)"
+			}
+		}
+	}
+	return findings
+}
+
+// applyOrphanPurge deletes orphan artifacts (class 1) when --purge-orphans is
+// active. It protects active chain baselines via retention.ProtectActiveBaseline
+// and requires confirmation unless --yes. In report-only / no-purge modes the
+// candidates are already reported by classifyStorageObjects; this only mutates
+// findings that get deleted.
+func applyOrphanPurge(ctx context.Context, cmd *cobra.Command, findings []repairFinding, candidates []orphanCandidate, records []retention.BackupRecord, mode repairMode) []repairFinding {
+	if len(candidates) == 0 || !mode.doPurge() {
+		return findings
+	}
+
+	purge, protected := filterProtectedOrphans(candidates, records)
+
+	// Reflect baseline protection in the corresponding findings.
+	protectedPaths := map[string]struct{}{}
+	for _, c := range protected {
+		protectedPaths[c.objectPath] = struct{}{}
+	}
+	for i := range findings {
+		if findings[i].Class == driftOrphanArtifact {
+			if _, ok := protectedPaths[findings[i].Path]; ok {
+				findings[i].Action = "kept (protected active baseline)"
+			}
+		}
+	}
+
+	if len(purge) == 0 {
+		return findings
+	}
+
+	confirmed := mode.assumeYes
+	if !confirmed {
+		var total int64
+		for _, c := range purge {
+			total += c.size
+		}
+		prompt := fmt.Sprintf("Delete %d orphan artifact(s) (%d bytes)? [y/N] ", len(purge), total)
+		confirmed = repairConfirm(cmd.InOrStdin(), cmd.OutOrStdout(), prompt)
+	}
+
+	purgeSet := map[string]struct{}{}
+	for _, c := range purge {
+		purgeSet[c.objectPath] = struct{}{}
+	}
+
+	for _, c := range purge {
+		var action string
+		var applied bool
+		if !confirmed {
+			action = "kept (not confirmed)"
+		} else if err := c.backend.Delete(ctx, c.objectPath); err != nil {
+			action = fmt.Sprintf("delete failed: %v", err)
+		} else {
+			action = "deleted"
+			applied = true
+		}
+		for i := range findings {
+			if findings[i].Class == driftOrphanArtifact && findings[i].Path == c.objectPath {
+				findings[i].Action = action
+				findings[i].Applied = applied
+			}
+		}
+	}
+	return findings
+}
+
+// filterProtectedOrphans partitions orphan candidates into purgeable vs
+// protected-active-baseline, wiring retention.ProtectActiveBaseline over a
+// base-name join. An orphan whose base name matches the active chain's baseline
+// is protected even under --purge-orphans.
+func filterProtectedOrphans(candidates []orphanCandidate, records []retention.BackupRecord) (purge, protected []orphanCandidate) {
+	byBase := map[string]orphanCandidate{}
+	rc := make([]retention.BackupCandidate, 0, len(candidates))
+	for _, c := range candidates {
+		byBase[c.base] = c
+		rc = append(rc, retention.BackupCandidate{FilePath: c.base})
+	}
+
+	survivors := retention.ProtectActiveBaseline(rc, records)
+	survivingBase := map[string]struct{}{}
+	for _, s := range survivors {
+		survivingBase[s.FilePath] = struct{}{}
+	}
+
+	for _, c := range candidates {
+		if _, ok := survivingBase[c.base]; ok {
+			purge = append(purge, c)
+		} else {
+			protected = append(protected, c)
+		}
+	}
+	return purge, protected
+}
+
+// ---------- helpers ----------
+
+// repairRepo groups a distinct storage backend identity with the jobs using it.
+type repairRepo struct {
+	key          string
+	label        string
+	cfg          config.StorageConfig
+	jobs         []string
+	presentBases map[string]struct{} // filled during enumeration; nil if listing degraded
+}
+
+// collectRepos builds the distinct-repository grouping for the target jobs
+// (all enabled jobs, or the single --job).
+func collectRepos(cfg *config.Configuration, jobFilter string) []*repairRepo {
+	byKey := map[string]*repairRepo{}
+	order := []string{}
+	// Stable job order.
+	names := make([]string, 0, len(cfg.Databases))
+	for name := range cfg.Databases {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		job := cfg.Databases[name]
+		if job.Enabled != nil && !*job.Enabled {
+			continue
+		}
+		if jobFilter != "" && name != jobFilter {
+			continue
+		}
+		sc := effectiveStorageForJob(cfg, job)
+		key := repoKeyFor(sc)
+		repo, ok := byKey[key]
+		if !ok {
+			repo = &repairRepo{key: key, label: repoLabelFor(sc), cfg: sc}
+			byKey[key] = repo
+			order = append(order, key)
+		}
+		repo.jobs = append(repo.jobs, name)
+	}
+
+	out := make([]*repairRepo, 0, len(order))
+	for _, k := range order {
+		out = append(out, byKey[k])
+	}
+	return out
+}
+
+func effectiveStorageForJob(cfg *config.Configuration, job config.BackupJob) config.StorageConfig {
+	if job.Storage.Type != "" {
+		return job.Storage
+	}
+	if cfg.Defaults.Storage.Type != "" {
+		return cfg.Defaults.Storage
+	}
+	return config.StorageConfig{Type: "local"}
+}
+
+func repoKeyFor(sc config.StorageConfig) string {
+	switch storageTypeOf(sc) {
+	case "s3":
+		return "s3:" + sc.S3BucketEndpoint + "/" + sc.S3Bucket
+	case "gcs":
+		return "gcs:" + sc.GCSBucket
+	case "azure":
+		return "azure:" + sc.AzureStorageAccount + "/" + sc.AzureContainer
+	case "google-drive":
+		return "google-drive:" + sc.GDriveFolderID
+	default:
+		return "local:" + sc.LocalPath
+	}
+}
+
+func repoLabelFor(sc config.StorageConfig) string {
+	switch storageTypeOf(sc) {
+	case "s3":
+		return "s3://" + sc.S3Bucket
+	case "gcs":
+		return "gs://" + sc.GCSBucket
+	case "azure":
+		return "azure://" + sc.AzureContainer
+	case "google-drive":
+		return "gdrive:" + sc.GDriveFolderID
+	default:
+		if sc.LocalPath != "" {
+			return sc.LocalPath
+		}
+		return "local"
+	}
+}
+
+func storageTypeOf(sc config.StorageConfig) string {
+	if sc.Type == "" {
+		return "local"
+	}
+	return sc.Type
+}
+
+// repairBackendParams builds registry params + a List prefix from a storage
+// config, mirroring retention_cleaner.go's per-type construction.
+func repairBackendParams(sc config.StorageConfig) (*storage.BackendParams, string, error) {
+	switch storageTypeOf(sc) {
+	case "local":
+		return &storage.BackendParams{StorageType: "local", LocalPath: sc.LocalPath}, "", nil
+	case "s3":
+		return &storage.BackendParams{
+			StorageType:        "s3",
+			AWSBucket:          sc.S3Bucket,
+			AWSRegion:          sc.S3Region,
+			AWSBucketEndpoint:  sc.S3BucketEndpoint,
+			AWSAccessKeyID:     sc.S3AccessKeyID,
+			AWSSecretAccessKey: sc.S3SecretAccessKey,
+		}, "", nil
+	case "gcs":
+		return &storage.BackendParams{
+			StorageType:        "gcs",
+			GCSBucket:          sc.GCSBucket,
+			GCSProjectID:       sc.GCSProjectID,
+			GCSCredentialsFile: sc.GCSCredentialsFile,
+		}, "", nil
+	case "azure":
+		return &storage.BackendParams{
+			StorageType:         "azure",
+			AzureStorageAccount: sc.AzureStorageAccount,
+			AzureStorageKey:     sc.AzureStorageKey,
+			AzureContainer:      sc.AzureContainer,
+		}, "", nil
+	case "google-drive":
+		return &storage.BackendParams{
+			StorageType:          "google-drive",
+			GoogleDriveFolderId:  sc.GDriveFolderID,
+			GoogleServiceAccount: sc.GDriveSAFile,
+		}, "", nil
+	default:
+		return nil, "", fmt.Errorf("repair not supported for storage type %q", sc.Type)
+	}
+}
+
+// loadManifestForRow reads a chain member's manifest. Local: from the recorded
+// ManifestPath (or FilePath + .manifest.json). Remote: download the sidecar to
+// a temp dir. Returns nil when the manifest cannot be read.
+func loadManifestForRow(ctx context.Context, repo *repairRepo, row ports.Execution) *ports.BackupManifest {
+	if storageTypeOf(repo.cfg) == "local" {
+		path := row.ManifestPath
+		if path == "" {
+			path = row.FilePath + ".manifest.json"
+		}
+		m, err := manifeststore.ReadManifest(path)
+		if err != nil {
+			return nil
+		}
+		return m
+	}
+
+	// Remote: fetch just the sidecar.
+	params, _, perr := repairBackendParams(repo.cfg)
+	if perr != nil {
+		return nil
+	}
+	backend, berr := newRepairBackend(params)
+	if berr != nil {
+		return nil
+	}
+	object, oerr := objectKeyForRow(repo.cfg, row.FilePath)
+	if oerr != nil {
+		return nil
+	}
+	tmpDir, terr := os.MkdirTemp("", "sentinel-repair-*")
+	if terr != nil {
+		return nil
+	}
+	defer os.RemoveAll(tmpDir)
+
+	local := filepath.Join(tmpDir, filepath.Base(object)+".manifest.json")
+	if err := backend.Download(ctx, object+".manifest.json", local); err != nil {
+		return nil
+	}
+	m, err := manifeststore.ReadManifest(local)
+	if err != nil {
+		return nil
+	}
+	return m
+}
+
+// objectKeyForRow resolves the storage object key for a remote artifact
+// reference, reusing parseBucketObjectRef.
+func objectKeyForRow(sc config.StorageConfig, filePath string) (string, error) {
+	switch storageTypeOf(sc) {
+	case "s3":
+		_, object, err := parseBucketObjectRef(filePath, "s3", sc.S3Bucket)
+		return object, err
+	case "gcs":
+		_, object, err := parseBucketObjectRef(filePath, "gs", sc.GCSBucket)
+		return object, err
+	case "azure":
+		_, object, err := parseBucketObjectRef(filePath, "azure", sc.AzureContainer)
+		return object, err
+	case "google-drive":
+		return filePath, nil
+	default:
+		return filePath, nil
+	}
+}
+
+func successRecords(rows []ports.Execution) []retention.BackupRecord {
+	recs := make([]retention.BackupRecord, 0, len(rows))
+	for i := range rows {
+		r := rows[i]
+		if r.Status != ports.StatusSuccess && r.Status != ports.StatusCompleted {
+			continue
+		}
+		recs = append(recs, retention.BackupRecord{
+			FilePath:   baseName(r.FilePath),
+			Timestamp:  r.Timestamp,
+			FileSize:   r.FileSizeBytes,
+			Status:     "success",
+			BackupType: r.BackupType,
+			ChainID:    r.ChainID,
+			ChainIndex: r.ChainIndex,
+		})
+	}
+	// Newest-first (ProtectActiveBaseline treats records[0] as the latest).
+	sort.SliceStable(recs, func(i, j int) bool { return recs[i].Timestamp.After(recs[j].Timestamp) })
+	return recs
+}
+
+func rowsForJob(rows []ports.Execution, job string) []ports.Execution {
+	out := make([]ports.Execution, 0)
+	for i := range rows {
+		if rows[i].BackupName == job {
+			out = append(out, rows[i])
+		}
+	}
+	return out
+}
+
+func jobLabelIndex(repos []*repairRepo) map[string]string {
+	idx := map[string]string{}
+	for _, repo := range repos {
+		for _, job := range repo.jobs {
+			idx[job] = repo.label
+		}
+	}
+	return idx
+}
+
+func presentBaseSet(objs []ports.StorageObject) map[string]struct{} {
+	set := map[string]struct{}{}
+	for _, o := range objs {
+		if isManifestKey(o.Path) {
+			continue
+		}
+		set[baseName(o.Path)] = struct{}{}
+	}
+	return set
+}
+
+func manifestSidecarPresent(objs []ports.StorageObject, artifactBase string) (string, bool) {
+	want := artifactBase + ".manifest.json"
+	for _, o := range objs {
+		if baseName(o.Path) == want {
+			return o.Path, true
+		}
+	}
+	return "", false
+}
+
+func baseName(p string) string {
+	if p == "" {
+		return ""
+	}
+	return filepath.Base(p)
+}
+
+func isManifestKey(p string) bool { return strings.HasSuffix(p, ".manifest.json") }
+
+func manifestRefBase(p string) string {
+	return strings.TrimSuffix(baseName(p), ".manifest.json")
+}
+
+func firstJob(rows []ports.Execution) string {
+	if len(rows) == 0 {
+		return ""
+	}
+	return rows[0].BackupName
+}
+
+func staleThreshold(cfg *config.Configuration) time.Duration {
+	minutes := cfg.Scheduler.StaleLockThreshold
+	if minutes <= 0 {
+		minutes = 60
+	}
+	return time.Duration(minutes) * time.Minute
+}
+
+// schemaRefusalError maps a non-current doctor status to the sentinel whose
+// Code() mapping produces the doctor-contract exit code.
+func schemaRefusalError(status string) error {
+	switch status {
+	case monitor.StatusStalePending:
+		return ErrDoctorStalePending
+	case monitor.StatusForwardIncompatible:
+		return ErrDoctorForwardIncompat
+	case monitor.StatusMissing:
+		return ErrDoctorMissing
+	case monitor.StatusCorrupt:
+		return ErrDoctorCorrupt
+	default:
+		return fmt.Errorf("monitor schema is %q: %w", status, ErrRepairInternal)
+	}
+}
+
+// repairExitError returns a non-zero sentinel when manual-action inconsistencies
+// (artifact_missing, chain_broken) remain — so repair can gate CI/cron.
+func repairExitError(findings []repairFinding) error {
+	for _, f := range findings {
+		if f.Class == driftArtifactMissing || f.Class == driftChainBroken {
+			return fmt.Errorf("repair: unresolved inconsistencies remain: %w", ErrRepairInconsistent)
+		}
+	}
+	return nil
+}
+
+// ---------- rendering ----------
+
+func renderRepairText(w io.Writer, findings []repairFinding, mode repairMode) {
+	// Group by repository label, preserving first-seen order.
+	order := []string{}
+	groups := map[string][]repairFinding{}
+	global := []repairFinding{}
+	for _, f := range findings {
+		key := f.Repository
+		if key == "" {
+			global = append(global, f)
+			continue
+		}
+		if _, ok := groups[key]; !ok {
+			order = append(order, key)
+		}
+		groups[key] = append(groups[key], f)
+	}
+
+	if len(findings) == 0 {
+		fmt.Fprintln(w, "No drift detected.")
+	}
+
+	for _, label := range order {
+		fmt.Fprintf(w, "\nRepository: %s\n", label)
+		tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+		for _, f := range groups[label] {
+			detail := f.Detail
+			if f.Path != "" {
+				if detail != "" {
+					detail = f.Path + "  " + detail
+				} else {
+					detail = f.Path
+				}
+			}
+			fmt.Fprintf(tw, "  %s\t%s\t→ %s\n", f.Class, detail, f.Action)
+		}
+		_ = tw.Flush()
+	}
+
+	if len(global) > 0 {
+		fmt.Fprintln(w, "\nGeneral:")
+		tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+		for _, f := range global {
+			fmt.Fprintf(tw, "  %s\t%s\t→ %s\n", f.Class, f.Detail, f.Action)
+		}
+		_ = tw.Flush()
+	}
+
+	s := summarizeRepair(findings)
+	fmt.Fprintf(w, "\n%d finding(s): %d orphan_artifact · %d untracked · %d orphan_manifest · %d artifact_missing · %d stale_running · %d stale_lock · %d chain_broken\n",
+		s.total, s.orphanArtifact, s.untracked, s.orphanManifest, s.artifactMissing, s.staleRunning, s.staleLock, s.chainBroken)
+
+	if mode.reportOnly {
+		fmt.Fprintln(w, "Nothing was modified (report-only; use --fix / --purge-orphans to apply).")
+	} else if s.applied == 0 {
+		fmt.Fprintln(w, "Nothing was modified.")
+	} else {
+		fmt.Fprintf(w, "%d change(s) applied.\n", s.applied)
+	}
+}
+
+func renderRepairJSON(w io.Writer, findings []repairFinding, mode repairMode) {
+	s := summarizeRepair(findings)
+	if findings == nil {
+		findings = []repairFinding{}
+	}
+	payload := map[string]interface{}{
+		"mode": map[string]bool{
+			"report_only": mode.reportOnly,
+			"fix":         mode.fix,
+			"purge":       mode.purge,
+		},
+		"findings": findings,
+		"summary": map[string]int{
+			"total":            s.total,
+			"orphan_artifact":  s.orphanArtifact,
+			"untracked":        s.untracked,
+			"orphan_manifest":  s.orphanManifest,
+			"artifact_missing": s.artifactMissing,
+			"stale_running":    s.staleRunning,
+			"stale_lock":       s.staleLock,
+			"chain_broken":     s.chainBroken,
+			"applied":          s.applied,
+		},
+		"modified": s.applied > 0,
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(payload)
+}
+
+type repairSummary struct {
+	total           int
+	orphanArtifact  int
+	untracked       int
+	orphanManifest  int
+	artifactMissing int
+	staleRunning    int
+	staleLock       int
+	chainBroken     int
+	applied         int
+}
+
+func summarizeRepair(findings []repairFinding) repairSummary {
+	s := repairSummary{total: len(findings)}
+	for _, f := range findings {
+		if f.Applied {
+			s.applied++
+		}
+		switch f.Class {
+		case driftOrphanArtifact:
+			s.orphanArtifact++
+		case driftUntrackedArtifact:
+			s.untracked++
+		case driftOrphanManifest:
+			s.orphanManifest++
+		case driftArtifactMissing:
+			s.artifactMissing++
+		case driftStaleRunning:
+			s.staleRunning++
+		case driftStaleLock:
+			s.staleLock++
+		case driftChainBroken:
+			s.chainBroken++
+		}
+	}
+	return s
+}
+
+func init() {
+	repairCmd.Flags().StringP("config", "c", "", "Path to YAML configuration file")
+	repairCmd.Flags().Bool("dry-run", false, "Report-only: detect all drift, mutate nothing (default posture)")
+	repairCmd.Flags().Bool("fix", false, "Apply recoverable fixes: finalize stale running rows, remove stale locks, mark broken chains")
+	repairCmd.Flags().Bool("purge-orphans", false, "Also delete orphan artifacts (implies --fix); requires confirmation unless --yes")
+	repairCmd.Flags().Bool("yes", false, "Skip the interactive confirmation for --purge-orphans")
+	repairCmd.Flags().String("job", "", "Restrict reconciliation to a single named backup job")
+	repairCmd.Flags().String("format", "text", "Output format: text or json")
+}

--- a/internal/cli/repair_test.go
+++ b/internal/cli/repair_test.go
@@ -1,0 +1,603 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/denisakp/sentinel/internal/adapters/lock"
+	"github.com/denisakp/sentinel/internal/adapters/monitor"
+	storage "github.com/denisakp/sentinel/internal/adapters/storage"
+	"github.com/denisakp/sentinel/internal/config"
+	"github.com/denisakp/sentinel/internal/ports"
+	"github.com/denisakp/sentinel/internal/ports/storagetesting"
+	"github.com/denisakp/sentinel/internal/domain/retention"
+	"github.com/spf13/cobra"
+)
+
+// ---- shared helpers ----
+
+func newRepairTestMonitor(t *testing.T) *monitor.Monitor {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "history.db")
+	mon, err := monitor.NewMonitor(dbPath)
+	if err != nil {
+		t.Fatalf("NewMonitor: %v", err)
+	}
+	t.Cleanup(func() { _ = mon.Close() })
+	return mon
+}
+
+func seedRow(t *testing.T, mon *monitor.Monitor, exec ports.Execution) {
+	t.Helper()
+	if err := mon.RecordExecution(context.Background(), &exec); err != nil {
+		t.Fatalf("RecordExecution: %v", err)
+	}
+}
+
+func writeLockJSON(t *testing.T, dir, job string, jl ports.JobLock) string {
+	t.Helper()
+	body, _ := json.Marshal(jl)
+	p := filepath.Join(dir, job+".lock")
+	if err := os.WriteFile(p, body, 0o600); err != nil {
+		t.Fatalf("write lock: %v", err)
+	}
+	return p
+}
+
+func repairTestCfg(lockDir string) *config.Configuration {
+	return &config.Configuration{
+		Databases: map[string]config.BackupJob{
+			"job1": {Name: "job1", Storage: config.StorageConfig{Type: "s3", S3Bucket: "b"}},
+		},
+		Scheduler: config.SchedulerConfig{StaleLockThreshold: 60, LockDir: lockDir},
+	}
+}
+
+func withMockBackend(t *testing.T, mb *storagetesting.MockBackend) {
+	t.Helper()
+	orig := newRepairBackend
+	newRepairBackend = func(_ *storage.BackendParams) (ports.StorageBackend, error) { return mb, nil }
+	t.Cleanup(func() { newRepairBackend = orig })
+}
+
+func hasClass(findings []repairFinding, class string) bool {
+	for _, f := range findings {
+		if f.Class == class {
+			return true
+		}
+	}
+	return false
+}
+
+func findByPath(findings []repairFinding, class, path string) (repairFinding, bool) {
+	for _, f := range findings {
+		if f.Class == class && f.Path == path {
+			return f, true
+		}
+	}
+	return repairFinding{}, false
+}
+
+// ---- flag matrix ----
+
+func TestResolveRepairMode(t *testing.T) {
+	build := func(dry, fix, purge, yes bool) *cobra.Command {
+		c := &cobra.Command{}
+		c.Flags().Bool("dry-run", dry, "")
+		c.Flags().Bool("fix", fix, "")
+		c.Flags().Bool("purge-orphans", purge, "")
+		c.Flags().Bool("yes", yes, "")
+		return c
+	}
+	cases := []struct {
+		name                              string
+		dry, fix, purge                   bool
+		wantReportOnly, wantRecoverable   bool
+		wantPurge                         bool
+	}{
+		{"no-flags", false, false, false, true, false, false},
+		{"dry-run", true, false, false, true, false, false},
+		{"fix", false, true, false, false, true, false},
+		{"purge-implies-fix", false, false, true, false, true, true},
+		{"dry-run-overrides-fix", true, true, false, true, false, false},
+		{"dry-run-overrides-purge", true, false, true, true, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := resolveRepairMode(build(tc.dry, tc.fix, tc.purge, false))
+			if m.reportOnly != tc.wantReportOnly {
+				t.Errorf("reportOnly=%v want %v", m.reportOnly, tc.wantReportOnly)
+			}
+			if m.doRecoverable() != tc.wantRecoverable {
+				t.Errorf("doRecoverable=%v want %v", m.doRecoverable(), tc.wantRecoverable)
+			}
+			if m.doPurge() != tc.wantPurge {
+				t.Errorf("doPurge=%v want %v", m.doPurge(), tc.wantPurge)
+			}
+		})
+	}
+}
+
+// ---- class 1/2 : orphan_artifact / untracked / orphan_manifest ----
+
+func TestClassifyStorageObjects(t *testing.T) {
+	objs := []ports.StorageObject{
+		{Path: "good.sql", SizeBytes: 10},                 // tracked → nothing
+		{Path: "good.sql.manifest.json", SizeBytes: 1},    // sidecar for good.sql
+		{Path: "orphan.sql", SizeBytes: 20},               // no row, no sidecar → orphan_artifact
+		{Path: "untracked.sql", SizeBytes: 30},            // no row, HAS sidecar → untracked
+		{Path: "untracked.sql.manifest.json", SizeBytes: 1},
+		{Path: "lonely.sql.manifest.json", SizeBytes: 1},  // sidecar, artifact absent → orphan_manifest
+	}
+	tracked := map[string]struct{}{"good.sql": {}}
+	repo := &repairRepo{key: "s3:b", label: "s3://b"}
+
+	findings, cands := classifyStorageObjects(objs, tracked, storagetesting.NewMockBackend(), repo)
+
+	if _, ok := findByPath(findings, driftOrphanArtifact, "orphan.sql"); !ok {
+		t.Errorf("expected orphan_artifact for orphan.sql; got %+v", findings)
+	}
+	if _, ok := findByPath(findings, driftUntrackedArtifact, "untracked.sql"); !ok {
+		t.Errorf("expected untracked_artifact for untracked.sql")
+	}
+	if _, ok := findByPath(findings, driftOrphanManifest, "lonely.sql.manifest.json"); !ok {
+		t.Errorf("expected orphan_manifest for lonely.sql.manifest.json")
+	}
+	// Only the strict orphan is a purge candidate.
+	if len(cands) != 1 || cands[0].objectPath != "orphan.sql" {
+		t.Errorf("purge candidates = %+v, want [orphan.sql]", cands)
+	}
+}
+
+// ---- class 3 : artifact_missing ----
+
+func TestClassifyMissing(t *testing.T) {
+	rows := []ports.Execution{
+		{BackupName: "job1", Status: ports.StatusSuccess, FilePath: "present.sql"},
+		{BackupName: "job1", Status: ports.StatusSuccess, FilePath: "gone.sql"},
+		{BackupName: "job1", Status: ports.StatusFailed, FilePath: "failed.sql"}, // ignored
+	}
+	present := map[string]struct{}{"present.sql": {}}
+
+	findings := classifyMissing(rows, present, "s3://b")
+	if len(findings) != 1 || findings[0].Path != "gone.sql" {
+		t.Fatalf("classifyMissing = %+v, want single gone.sql", findings)
+	}
+
+	// nil present set (degraded listing) → no guessing.
+	if got := classifyMissing(rows, nil, "s3://b"); got != nil {
+		t.Errorf("nil presentBases should yield no findings, got %+v", got)
+	}
+}
+
+// ---- class 4 : stale_running lock guard ----
+
+func TestClassifyStaleRunning(t *testing.T) {
+	host, _ := os.Hostname()
+	threshold := time.Minute
+
+	if d, _ := classifyStaleRunning(nil, threshold, host); d != staleFinalize {
+		t.Errorf("nil lock → want finalize, got %v", d)
+	}
+	// Live lock (this process pid).
+	live := &ports.JobLock{PID: os.Getpid(), Hostname: host, StartTime: time.Now()}
+	if d, _ := classifyStaleRunning(live, threshold, host); d != staleSkipLive {
+		t.Errorf("live lock → want skipLive, got %v", d)
+	}
+	// Foreign host.
+	foreign := &ports.JobLock{PID: 999999999, Hostname: "other-host", StartTime: time.Now().Add(-2 * time.Hour)}
+	if d, _ := classifyStaleRunning(foreign, threshold, host); d != staleSkipForeign {
+		t.Errorf("foreign lock → want skipForeign, got %v", d)
+	}
+	// Dead pid over threshold, same host → finalize.
+	dead := &ports.JobLock{PID: 999999999, Hostname: host, StartTime: time.Now().Add(-2 * time.Hour)}
+	if d, _ := classifyStaleRunning(dead, threshold, host); d != staleFinalize {
+		t.Errorf("dead lock → want finalize, got %v", d)
+	}
+}
+
+func TestReconcileStaleRunning_LockGuardAndModes(t *testing.T) {
+	ctx := context.Background()
+	host, _ := os.Hostname()
+	lockDir := t.TempDir()
+	cfg := repairTestCfg(lockDir)
+	lm := lock.NewManager(lockDir)
+	repos := []*repairRepo{{label: "s3://b", jobs: []string{"jobLive", "jobDead"}}}
+
+	seed := func(mon *monitor.Monitor) {
+		seedRow(t, mon, ports.Execution{ID: "live-run", BackupName: "jobLive", Status: ports.StatusRunning, FilePath: "a.sql"})
+		seedRow(t, mon, ports.Execution{ID: "dead-run", BackupName: "jobDead", Status: ports.StatusRunning, FilePath: "b.sql"})
+	}
+
+	// jobLive holds a real live lock; jobDead has none.
+	if _, err := lm.TryAcquire("jobLive", time.Minute); err != nil {
+		t.Fatalf("TryAcquire: %v", err)
+	}
+	t.Cleanup(func() { _ = lm.Release("jobLive") })
+	_ = host
+
+	// report-only: nothing finalized.
+	monRep := newRepairTestMonitor(t)
+	seed(monRep)
+	_ = reconcileStaleRunning(ctx, monRep, lm, cfg, repairMode{reportOnly: true}, repos)
+	if e, _ := monRep.GetExecution(ctx, "dead-run"); e.Status != ports.StatusRunning {
+		t.Errorf("report-only must not finalize; dead-run status=%s", e.Status)
+	}
+
+	// fix: dead-run finalized to interrupted, live-run untouched.
+	monFix := newRepairTestMonitor(t)
+	seed(monFix)
+	findings := reconcileStaleRunning(ctx, monFix, lm, cfg, repairMode{fix: true}, repos)
+	if e, _ := monFix.GetExecution(ctx, "dead-run"); e.Status != ports.StatusInterrupted {
+		t.Errorf("dead-run should be interrupted, got %s", e.Status)
+	}
+	if e, _ := monFix.GetExecution(ctx, "live-run"); e.Status != ports.StatusRunning {
+		t.Errorf("live-run should stay running (live lock), got %s", e.Status)
+	}
+	// The live one is reported as skipped(live lock), the dead one marked.
+	var sawSkip, sawMark bool
+	for _, f := range findings {
+		if f.Job == "jobLive" && f.Action == "skipped (live lock)" {
+			sawSkip = true
+		}
+		if f.Job == "jobDead" && f.Applied {
+			sawMark = true
+		}
+	}
+	if !sawSkip || !sawMark {
+		t.Errorf("expected skip(live)+mark(dead); findings=%+v", findings)
+	}
+}
+
+// ---- class 5 : stale_lock ----
+
+func TestReconcileStaleLocks(t *testing.T) {
+	host, _ := os.Hostname()
+	lockDir := t.TempDir()
+	cfg := repairTestCfg(lockDir)
+	lm := lock.NewManager(lockDir)
+	repos := []*repairRepo{{label: "s3://b", jobs: []string{"deadjob"}}}
+
+	deadPath := writeLockJSON(t, lockDir, "deadjob", ports.JobLock{
+		PID: 999999999, JobName: "deadjob", Hostname: host, StartTime: time.Now().Add(-2 * time.Hour),
+	})
+	// live lock held by this process
+	if _, err := lm.TryAcquire("livejob", time.Minute); err != nil {
+		t.Fatalf("TryAcquire: %v", err)
+	}
+	t.Cleanup(func() { _ = lm.Release("livejob") })
+	foreignPath := writeLockJSON(t, lockDir, "foreignjob", ports.JobLock{
+		PID: 999999999, JobName: "foreignjob", Hostname: "other-host", StartTime: time.Now().Add(-2 * time.Hour),
+	})
+
+	// report-only: reports the dead lock but removes nothing.
+	rep := reconcileStaleLocks(lm, cfg, repairMode{reportOnly: true}, repos)
+	if !hasClass(rep, driftStaleLock) {
+		t.Errorf("expected stale_lock finding in report-only")
+	}
+	if _, err := os.Stat(deadPath); err != nil {
+		t.Errorf("report-only removed the dead lock: %v", err)
+	}
+
+	// fix: removes only the dead lock; live + foreign untouched.
+	fixFindings := reconcileStaleLocks(lm, cfg, repairMode{fix: true}, repos)
+	if _, err := os.Stat(deadPath); !os.IsNotExist(err) {
+		t.Errorf("dead lock should be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(foreignPath); err != nil {
+		t.Errorf("foreign lock must be preserved: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(lockDir, "livejob.lock")); err != nil {
+		t.Errorf("live lock must be preserved: %v", err)
+	}
+	var applied bool
+	for _, f := range fixFindings {
+		if f.Class == driftStaleLock && f.Applied {
+			applied = true
+		}
+	}
+	if !applied {
+		t.Errorf("expected an applied stale_lock removal; got %+v", fixFindings)
+	}
+}
+
+// ---- class 6 : chain_broken ----
+
+func TestDetectBrokenChains(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	repo := &repairRepo{label: "local", cfg: config.StorageConfig{Type: "local", LocalPath: dir}}
+
+	writeManifest := func(name, backupID, chainID, baseline string, idx int) string {
+		p := filepath.Join(dir, name+".manifest.json")
+		m := ports.BackupManifest{
+			BackupID: backupID,
+			Hash:     ports.HashInfo{Algorithm: "sha256", Value: "deadbeef"},
+			AdvancedRestore: &ports.AdvancedRestoreMetadata{
+				IncrementalLineage: &ports.IncrementalLineageMetadata{
+					Enabled: true, ChainID: chainID, ChainIndex: idx, BaselineBackupID: baseline,
+				},
+			},
+		}
+		body, _ := json.MarshalIndent(&m, "", "  ")
+		if err := os.WriteFile(p, body, 0o600); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+		return p
+	}
+
+	// Intact chain: baseline idx0 + increment idx1, both manifests present.
+	writeManifest("full.sql", "bk0", "chainOK", "bk0", 0)
+	writeManifest("inc1.sql", "bk1", "chainOK", "bk0", 1)
+	okRows := []ports.Execution{
+		{ID: "bk0", BackupName: "job1", Status: ports.StatusSuccess, ChainID: "chainOK", ChainIndex: 0,
+			FilePath: filepath.Join(dir, "full.sql"), ManifestPath: filepath.Join(dir, "full.sql.manifest.json")},
+		{ID: "bk1", BackupName: "job1", Status: ports.StatusSuccess, ChainID: "chainOK", ChainIndex: 1,
+			FilePath: filepath.Join(dir, "inc1.sql"), ManifestPath: filepath.Join(dir, "inc1.sql.manifest.json")},
+	}
+	if got := detectBrokenChains(ctx, okRows, repo); len(got) != 0 {
+		t.Errorf("intact chain flagged broken: %+v", got)
+	}
+
+	// Broken chain: baseline present, idx1 missing, idx2 present (non-contiguous).
+	writeManifest("full2.sql", "cb0", "chainBad", "cb0", 0)
+	writeManifest("inc2.sql", "cb2", "chainBad", "cb0", 2)
+	badRows := []ports.Execution{
+		{ID: "cb0", BackupName: "job1", Status: ports.StatusSuccess, ChainID: "chainBad", ChainIndex: 0,
+			FilePath: filepath.Join(dir, "full2.sql"), ManifestPath: filepath.Join(dir, "full2.sql.manifest.json")},
+		{ID: "cb2", BackupName: "job1", Status: ports.StatusSuccess, ChainID: "chainBad", ChainIndex: 2,
+			FilePath: filepath.Join(dir, "inc2.sql"), ManifestPath: filepath.Join(dir, "inc2.sql.manifest.json")},
+	}
+	got := detectBrokenChains(ctx, badRows, repo)
+	if !hasClass(got, driftChainBroken) {
+		t.Errorf("expected chain_broken for non-contiguous chain; got %+v", got)
+	}
+}
+
+// ---- purge + active-baseline protection ----
+
+func TestFilterProtectedOrphans(t *testing.T) {
+	cands := []orphanCandidate{
+		{objectPath: "base.sql", base: "base.sql"},
+		{objectPath: "junk.sql", base: "junk.sql"},
+	}
+	// Active chain baseline is base.sql.
+	records := []retention.BackupRecord{
+		{FilePath: "base.sql", ChainID: "c1", BackupType: "full", ChainIndex: 0, Timestamp: time.Now()},
+	}
+	purge, protected := filterProtectedOrphans(cands, records)
+	if len(protected) != 1 || protected[0].base != "base.sql" {
+		t.Errorf("base.sql should be protected; protected=%+v", protected)
+	}
+	if len(purge) != 1 || purge[0].base != "junk.sql" {
+		t.Errorf("junk.sql should be purgeable; purge=%+v", purge)
+	}
+}
+
+func TestApplyOrphanPurge_ConfirmationAndProtection(t *testing.T) {
+	ctx := context.Background()
+	mb := storagetesting.NewMockBackend()
+	mb.PutBytes("orphan.sql", []byte("x"))
+	mb.PutBytes("base.sql", []byte("y"))
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("yes", true, "")
+
+	newFindings := func() []repairFinding {
+		return []repairFinding{
+			{Class: driftOrphanArtifact, Path: "orphan.sql", Action: "report"},
+			{Class: driftOrphanArtifact, Path: "base.sql", Action: "report"},
+		}
+	}
+	cands := []orphanCandidate{
+		{objectPath: "orphan.sql", base: "orphan.sql", backend: mb},
+		{objectPath: "base.sql", base: "base.sql", backend: mb},
+	}
+	records := []retention.BackupRecord{
+		{FilePath: "base.sql", ChainID: "c1", BackupType: "full", ChainIndex: 0, Timestamp: time.Now()},
+	}
+
+	// report-only: nothing deleted.
+	_ = applyOrphanPurge(ctx, cmd, newFindings(), cands, records, repairMode{reportOnly: true})
+	if _, ok := mb.GetBytes("orphan.sql"); !ok {
+		t.Errorf("report-only must not delete")
+	}
+
+	// purge + yes: orphan deleted, protected baseline kept.
+	out := applyOrphanPurge(ctx, cmd, newFindings(), cands, records, repairMode{purge: true, assumeYes: true})
+	if _, ok := mb.GetBytes("orphan.sql"); ok {
+		t.Errorf("orphan.sql should be deleted under --purge-orphans --yes")
+	}
+	if _, ok := mb.GetBytes("base.sql"); !ok {
+		t.Errorf("active baseline base.sql must never be deleted")
+	}
+	if f, _ := findByPath(out, driftOrphanArtifact, "base.sql"); f.Action != "kept (protected active baseline)" {
+		t.Errorf("base.sql action=%q want protected", f.Action)
+	}
+	if f, _ := findByPath(out, driftOrphanArtifact, "orphan.sql"); !f.Applied {
+		t.Errorf("orphan.sql should be applied(deleted); action=%q", f.Action)
+	}
+}
+
+func TestApplyOrphanPurge_NotConfirmed(t *testing.T) {
+	ctx := context.Background()
+	mb := storagetesting.NewMockBackend()
+	mb.PutBytes("orphan.sql", []byte("x"))
+
+	// Confirmation declined.
+	orig := repairConfirm
+	repairConfirm = func(_ io.Reader, _ io.Writer, _ string) bool { return false }
+	defer func() { repairConfirm = orig }()
+
+	cmd := &cobra.Command{}
+	findings := []repairFinding{{Class: driftOrphanArtifact, Path: "orphan.sql", Action: "report"}}
+	cands := []orphanCandidate{{objectPath: "orphan.sql", base: "orphan.sql", backend: mb}}
+
+	out := applyOrphanPurge(ctx, cmd, findings, cands, nil, repairMode{purge: true})
+	if _, ok := mb.GetBytes("orphan.sql"); !ok {
+		t.Errorf("declined confirmation must not delete")
+	}
+	if f, _ := findByPath(out, driftOrphanArtifact, "orphan.sql"); f.Applied {
+		t.Errorf("orphan.sql must not be applied when confirmation declined")
+	}
+}
+
+// ---- exit-code contract ----
+
+func TestRepairExitError(t *testing.T) {
+	if err := repairExitError([]repairFinding{{Class: driftStaleLock}}); err != nil {
+		t.Errorf("no manual-action classes → nil, got %v", err)
+	}
+	for _, cls := range []string{driftArtifactMissing, driftChainBroken} {
+		err := repairExitError([]repairFinding{{Class: cls}})
+		if Code(err) != 5 {
+			t.Errorf("class %s should map to exit 5, got %d", cls, Code(err))
+		}
+	}
+}
+
+func TestSchemaRefusalMapping(t *testing.T) {
+	cases := map[string]int{
+		monitor.StatusForwardIncompatible: 2,
+		monitor.StatusMissing:             3,
+		monitor.StatusCorrupt:             4,
+		monitor.StatusStalePending:        1,
+	}
+	for status, wantCode := range cases {
+		if got := Code(schemaRefusalError(status)); got != wantCode {
+			t.Errorf("status %s → exit %d, want %d", status, got, wantCode)
+		}
+	}
+}
+
+func TestRepair_RefusesCorruptSchema(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "history.db")
+	if err := os.WriteFile(dbPath, []byte("not a sqlite file"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	report, err := monitor.Diagnose(dbPath)
+	if err != nil {
+		t.Fatalf("Diagnose: %v", err)
+	}
+	if report.Status == monitor.StatusCurrent {
+		t.Fatalf("corrupt DB reported current")
+	}
+	if Code(schemaRefusalError(report.Status)) == 0 {
+		t.Errorf("corrupt schema must map to a non-zero exit code")
+	}
+}
+
+// ---- end-to-end runRepair: dry-run modifies nothing, fix applies safe set ----
+
+func repairE2ESetup(t *testing.T) (*monitor.Monitor, *storagetesting.MockBackend, string, *config.Configuration) {
+	t.Helper()
+	mon := newRepairTestMonitor(t)
+	lockDir := t.TempDir()
+	cfg := repairTestCfg(lockDir)
+
+	// monitor rows
+	seedRow(t, mon, ports.Execution{ID: "ok1", BackupName: "job1", Status: ports.StatusSuccess, StorageBackend: "s3", FilePath: "s3://b/good.sql"})
+	seedRow(t, mon, ports.Execution{ID: "gone1", BackupName: "job1", Status: ports.StatusSuccess, StorageBackend: "s3", FilePath: "s3://b/gone.sql"})
+	seedRow(t, mon, ports.Execution{ID: "run1", BackupName: "job1", Status: ports.StatusRunning, StorageBackend: "s3", FilePath: "s3://b/partial.sql"})
+
+	// storage
+	mb := storagetesting.NewMockBackend()
+	mb.PutBytes("good.sql", []byte("good"))                         // tracked
+	mb.PutBytes("orphan.sql", []byte("orphan"))                     // orphan_artifact
+	mb.PutBytes("lonely.sql.manifest.json", []byte(`{"x":1}`))      // orphan_manifest
+
+	// stale lock (dead pid, old)
+	host, _ := os.Hostname()
+	writeLockJSON(t, lockDir, "stalejob", ports.JobLock{PID: 999999999, JobName: "stalejob", Hostname: host, StartTime: time.Now().Add(-2 * time.Hour)})
+
+	return mon, mb, lockDir, cfg
+}
+
+func TestRunRepair_DryRunDetectsAllAndModifiesNothing(t *testing.T) {
+	ctx := context.Background()
+	mon, mb, lockDir, cfg := repairE2ESetup(t)
+	withMockBackend(t, mb)
+	lm := lock.NewManager(lockDir)
+
+	cmd := &cobra.Command{}
+	findings, err := runRepair(ctx, cmd, cfg, mon, lm, repairMode{reportOnly: true}, "")
+	if err != nil {
+		t.Fatalf("runRepair: %v", err)
+	}
+
+	for _, cls := range []string{driftOrphanArtifact, driftOrphanManifest, driftArtifactMissing, driftStaleRunning, driftStaleLock} {
+		if !hasClass(findings, cls) {
+			t.Errorf("dry-run missing class %s; findings=%+v", cls, findings)
+		}
+	}
+
+	// Nothing modified.
+	if _, ok := mb.GetBytes("orphan.sql"); !ok {
+		t.Errorf("dry-run deleted orphan artifact")
+	}
+	if e, _ := mon.GetExecution(ctx, "run1"); e.Status != ports.StatusRunning {
+		t.Errorf("dry-run finalized a running row: %s", e.Status)
+	}
+	if _, err := os.Stat(filepath.Join(lockDir, "stalejob.lock")); err != nil {
+		t.Errorf("dry-run removed a stale lock: %v", err)
+	}
+	for _, f := range findings {
+		if f.Applied {
+			t.Errorf("dry-run applied a change: %+v", f)
+		}
+	}
+
+	// Manual-action inconsistency remains → non-zero exit.
+	if Code(repairExitError(findings)) != 5 {
+		t.Errorf("expected exit 5 (artifact_missing present)")
+	}
+}
+
+func TestRunRepair_FixAppliesSafeSetNotPurge(t *testing.T) {
+	ctx := context.Background()
+	mon, mb, lockDir, cfg := repairE2ESetup(t)
+	withMockBackend(t, mb)
+	lm := lock.NewManager(lockDir)
+
+	cmd := &cobra.Command{}
+	_, err := runRepair(ctx, cmd, cfg, mon, lm, repairMode{fix: true}, "")
+	if err != nil {
+		t.Fatalf("runRepair: %v", err)
+	}
+
+	if e, _ := mon.GetExecution(ctx, "run1"); e.Status != ports.StatusInterrupted {
+		t.Errorf("fix should finalize run1, got %s", e.Status)
+	}
+	if _, err := os.Stat(filepath.Join(lockDir, "stalejob.lock")); !os.IsNotExist(err) {
+		t.Errorf("fix should remove stale lock; stat err=%v", err)
+	}
+	// --fix must NOT delete orphan artifacts.
+	if _, ok := mb.GetBytes("orphan.sql"); !ok {
+		t.Errorf("--fix deleted an orphan artifact (should require --purge-orphans)")
+	}
+}
+
+func TestRunRepair_PurgeDeletesOrphan(t *testing.T) {
+	ctx := context.Background()
+	mon, mb, lockDir, cfg := repairE2ESetup(t)
+	withMockBackend(t, mb)
+	lm := lock.NewManager(lockDir)
+
+	cmd := &cobra.Command{}
+	_, err := runRepair(ctx, cmd, cfg, mon, lm, repairMode{purge: true, assumeYes: true}, "")
+	if err != nil {
+		t.Fatalf("runRepair: %v", err)
+	}
+	if _, ok := mb.GetBytes("orphan.sql"); ok {
+		t.Errorf("--purge-orphans --yes should delete orphan.sql")
+	}
+	// good.sql is tracked and must survive.
+	if _, ok := mb.GetBytes("good.sql"); !ok {
+		t.Errorf("tracked artifact good.sql must never be deleted")
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -90,6 +90,7 @@ func init() {
 	RootCmd.AddCommand(dbCmd)
 	RootCmd.AddCommand(SecurityCmd)
 	RootCmd.AddCommand(StorageCmd)
+	RootCmd.AddCommand(repairCmd)
 	RootCmd.AddCommand(versionCmd)
 }
 


### PR DESCRIPTION
## What

`sentinel repair` (PRD 37) — recovers roadmap M5 "Watchdog" F-04. New top-level command that reconciles Sentinel's three sources of truth — monitor rows, manifest sidecars, and storage artifacts — plus the lock directory, across all configured jobs. Detects and (opt-in) fixes internal-state drift left by a crash mid-backup, a hard-killed process, or a manual artifact deletion.

Distinct from `monitor doctor --repair` (schema-only, one file). This is repository-wide and can delete artifacts — different blast radius, different verb.

## How

New `internal/cli/repair.go` + registration in `root.go`. A driving/composition command over existing adapters — **no new port, no adapter→adapter import** (ADR-0001 clean). Six drift classes, each wired to the existing function that already knows how:

| Class | Detection / fix |
|---|---|
| orphan_artifact | storage `List` object with no sidecar AND no monitor row → `Delete` (guarded) |
| orphan_manifest | sidecar present, artifact absent |
| artifact_missing | row/manifest `FilePath` absent |
| stale_running | `GetStaleRunningExecutions` + lock guard → `RecordInterrupted("unclean shutdown (repair)")` |
| stale_lock | dead-PID over-threshold lock → `ScanStale` |
| chain_broken | `ResolveOrderedChain` (same resolver as `restore validate-chain`) + lineage validator |

**Flag matrix (safe by default):**
- no flag / `--dry-run` → report everything, mutate nothing;
- `--fix` → apply recoverable classes 4/5/6 (never deletes an artifact);
- `--purge-orphans` (implies `--fix`) → additionally delete class-1 orphans, **interactive confirmation** unless `--yes`.

**Load-bearing guards:**
- The only artifact-delete path is `--purge-orphans`; an **active chain baseline is never purged** (`retention.ProtectActiveBaseline`).
- **Lock-guarded stale-running finalize** — a `running` row is finalized only when no live lock is held for its job (the correctness improvement over the blind `ReconcileStaleExecutions` used at `schedule` startup); a live lock → skip.
- **Host-local honesty** — foreign-host locks/rows are skipped with a warning, never guessed.
- **Schema precondition** — `monitor.Diagnose` refuses to reconcile against a non-`current` (forward-incompatible/corrupt) DB, deferring to `monitor doctor`.
- **Non-zero exit** (`ErrRepairInconsistent`=5) while `artifact_missing`/`chain_broken` remain → CI/cron-gateable; operational failures → `ErrRepairInternal`=4.

`--format json` for tooling. Runbook `docs/runbooks/state-repair.md` (dry-run-first) + index + README.

## Test

22 repair unit tests (fakes: `storagetesting.MockBackend` + in-memory monitor) covering each drift class, the flag matrix, confirmation + baseline protection, lock-guarded finalize (live vs dead vs foreign), schema refusal, and the exit-code contract.

`go build` / `go vet` / `go vet -tags=integration` / `golangci-lint` / `go test ./...` (1451 passed) — all green. Rebased onto develop (post-PRD-36); `exit_codes.go` carries both PRDs' sentinels.

## Notes

- Q5 (adopting repair's lock-guarded reconcile at `schedule` startup) left as a documented follow-up — startup still uses the blind `ReconcileStaleExecutions`.
- Chain detection is structural (missing/non-contiguous links), not hash-based — re-hashing is `backup verify`'s job.
