### PR TITLE
feat(integrity): verify_after_upload — post-upload re-download + re-hash (PRD 40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,31 @@ Size/duration swings get a `⚠` marker but stay informational (exit 0). A backu
 (pre-v1.1) still diffs on its monitor-row fields with a warning. See
 [docs/runbooks/verify-backup-integrity.md](docs/runbooks/verify-backup-integrity.md).
 
+### Verifying immediately after upload
+
+The checks above catch corruption **after the fact** — at the next scheduled sweep or restore.
+`integrity.verify_after_upload` closes that gap at backup time: right after the artifact reaches
+its storage backend, Sentinel re-downloads it and re-hashes it against the manifest, **failing the
+backup immediately** on a mismatch instead of reporting success on a corrupted upload:
+
+```yaml
+integrity:
+  verify_after_upload: true   # default for every job unless overridden
+
+databases:
+  prod-s3:
+    type: postgres
+    storage: { type: s3, s3_bucket: backups }
+    verify_after_upload: true   # per-job override (inherits the default above when omitted)
+```
+
+Opt-in and **off by default** — it doubles read I/O and, on S3/GCS/Azure/GDrive, adds egress cost
+and latency proportional to the backup size. It is most valuable for **remote** backends (network
+writes can be silently truncated); it also works for local storage (catches disk write faults) but
+is lower-value there since it re-reads the same file. On mismatch the job fails with
+`verify_after_upload_failed`, is recorded/notified like any other failure, and the corrupt object
+is **left in place** (never auto-deleted) so it can be inspected.
+
 ---
 
 ## State repair

--- a/docs/runbooks/verify-backup-integrity.md
+++ b/docs/runbooks/verify-backup-integrity.md
@@ -84,6 +84,30 @@ Security regressions between the two backups are flagged and set a **non-zero ex
 Size/duration swings get a `⚠` marker but keep exit 0. A pre-v1.1 backup with no manifest still
 diffs on its monitor-row fields with a warning.
 
+### Catching corruption at backup time (`verify_after_upload`)
+
+Everything above verifies **after the fact** (a later sweep, or manually). `integrity.verify_after_upload`
+does it immediately, as part of the backup job itself: right after the artifact reaches its storage
+backend, Sentinel re-downloads it and re-hashes it against the manifest — failing the backup with
+`verify_after_upload_failed` on a mismatch instead of reporting success on a silently-corrupted upload.
+
+```yaml
+integrity:
+  verify_after_upload: true   # default for all jobs
+
+databases:
+  prod-s3:
+    storage: { type: s3, s3_bucket: backups }
+    verify_after_upload: true   # per-job override (wins over the default above)
+```
+
+Opt-in, default off (doubles read I/O; adds egress cost/latency on remote backends proportional to
+artifact size). Its value is remote storage (S3/GCS/Azure/GDrive — network writes can be silently
+truncated); it also runs for local storage if enabled, but that mainly catches disk write faults
+between the write and the re-read. On mismatch: the job is recorded/notified as a failure, and the
+corrupt object is **left in place** (never auto-deleted) so it can be pulled for forensics before
+retention has a chance to sweep the last good copy.
+
 ## Manifest contract (per ADR 0005)
 
 - Sidecar file: `<backup-filename>.manifest.json`, JSON, mode `0600`.
@@ -110,3 +134,4 @@ If verify fails, treat the artifact as untrusted:
 - `internal/manifest/manifest.go`, `internal/manifest/types.go`
 - `internal/cli/backup_verify.go`
 - `internal/cli/backup_diff.go` — `backup diff <id1> <id2>` metadata comparison
+- `internal/domain/backup/executor.go::verifyAfterUpload`, `internal/cli/backup_factory.go::resolveVerifyAfterUpload` — `integrity.verify_after_upload` (PRD 40)

--- a/internal/cli/backup_factory.go
+++ b/internal/cli/backup_factory.go
@@ -134,6 +134,8 @@ func NewBackupExecutorFromConfig(
 	// backend. Wired only for stageable single-artifact dumps (the engine
 	// Builders); the pg/mysql/mariadb dump-all closure writes remotely itself
 	// and is left untouched. Local storage is never staged.
+	verifyAfterUpload := resolveVerifyAfterUpload(cfg, job)
+
 	var storageBackend ports.StorageBackend
 	stagingDir := ""
 	if shouldStageRemote(storageParams, engineOpts, dumps) {
@@ -149,6 +151,21 @@ func NewBackupExecutorFromConfig(
 		// be staged in place, so the artifact cannot be encrypted before it
 		// leaves the host. Refuse rather than leak plaintext to the bucket.
 		return nil, fmt.Errorf("backup '%s': encrypted remote backup is not supported for the auto-discovery 'single' strategy; use strategy 'individual' or local storage", job.Name)
+	} else if verifyAfterUpload && storageParams != nil {
+		// verify_after_upload (spec 053 / PRD 40): no staging redirect is in
+		// play here — either local storage, or a remote auto-discovery
+		// "single" dump-all with no encryption. Construct a real backend
+		// purely so the Executor's post-upload verify step can re-download
+		// the artifact. For local storage this simply re-reads the on-disk
+		// file (Q4: allowed but off by default; its real value is remote).
+		// For the remote dump-all case there is no staged artifact and thus
+		// no manifest hash, so the verify step degrades to a no-op — see
+		// Executor.verifyAfterUpload.
+		backend, err := storage.NewBackend(storageParams)
+		if err != nil {
+			return nil, fmt.Errorf("backup '%s': verify_after_upload: %w", job.Name, err)
+		}
+		storageBackend = backend
 	}
 
 	exec := backup.NewExecutor(
@@ -165,6 +182,7 @@ func NewBackupExecutorFromConfig(
 
 	djob := buildDomainBackupJob(cfg, job, storageParams, scheduled, forceFull, engineOpts)
 	djob.StagingDir = stagingDir
+	djob.VerifyAfterUpload = verifyAfterUpload
 
 	return &backupExecution{
 		exec:      exec,
@@ -181,6 +199,23 @@ func isRemoteStorage(p *storage.Params) bool {
 // encryptionConfigured reports whether the config enables at-rest encryption.
 func encryptionConfigured(cfg *config.Configuration) bool {
 	return cfg != nil && (cfg.EncryptionKeyEnv != "" || cfg.EncryptionKeyFile != "")
+}
+
+// resolveVerifyAfterUpload resolves the effective verify_after_upload flag
+// for job: a per-job override (job.VerifyAfterUpload) wins when set,
+// otherwise the top-level integrity.verify_after_upload default applies.
+// loader.go's applyDefaults already resolves job.VerifyAfterUpload to a
+// non-nil pointer for configs loaded from YAML; this fallback also covers
+// BackupJob values built directly (e.g. by tests) that bypass the loader.
+// Spec 053 / PRD 40 (Q5: opt-in, default off).
+func resolveVerifyAfterUpload(cfg *config.Configuration, job config.BackupJob) bool {
+	if job.VerifyAfterUpload != nil {
+		return *job.VerifyAfterUpload
+	}
+	if cfg != nil {
+		return cfg.Integrity.VerifyAfterUpload
+	}
+	return false
 }
 
 // shouldStageRemote decides whether to redirect a remote dump through a local

--- a/internal/cli/backup_factory_verify_test.go
+++ b/internal/cli/backup_factory_verify_test.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	dumppg "github.com/denisakp/sentinel/internal/adapters/dump/pg"
+	"github.com/denisakp/sentinel/internal/adapters/storage"
+	"github.com/denisakp/sentinel/internal/config"
+	"github.com/denisakp/sentinel/internal/ports"
+)
+
+// TestResolveVerifyAfterUpload exercises the inheritance precedence: a
+// per-job override always wins; otherwise the top-level
+// integrity.verify_after_upload default applies; a nil Configuration (or an
+// unset job pointer with no config) is off (spec 053 / PRD 40, Q5: opt-in,
+// default off).
+func TestResolveVerifyAfterUpload(t *testing.T) {
+	trueVal, falseVal := true, false
+
+	cases := []struct {
+		name string
+		cfg  *config.Configuration
+		job  config.BackupJob
+		want bool
+	}{
+		{"nil config, no override", nil, config.BackupJob{}, false},
+		{"default off, no override", &config.Configuration{}, config.BackupJob{}, false},
+		{"default on, no override", &config.Configuration{Integrity: config.IntegrityConfig{VerifyAfterUpload: true}}, config.BackupJob{}, true},
+		{"default on, job override off", &config.Configuration{Integrity: config.IntegrityConfig{VerifyAfterUpload: true}}, config.BackupJob{VerifyAfterUpload: &falseVal}, false},
+		{"default off, job override on", &config.Configuration{}, config.BackupJob{VerifyAfterUpload: &trueVal}, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveVerifyAfterUpload(tc.cfg, tc.job); got != tc.want {
+				t.Fatalf("resolveVerifyAfterUpload() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNewBackupExecutorFromConfigWiresLocalStorageForVerifyAfterUpload proves
+// the factory wires a REAL local ports.StorageBackend (not the historical
+// nil) when a local-storage job enables verify_after_upload, and that a
+// healthy round trip (dump → hash → re-download → re-hash) succeeds through
+// the production manifest_store.Adapter — an integration-level complement to
+// the domain-level MockBackend tests in internal/domain/backup.
+func TestNewBackupExecutorFromConfigWiresLocalStorageForVerifyAfterUpload(t *testing.T) {
+	dir := t.TempDir()
+	const outName = "job.sql"
+
+	content := []byte("-- real dump content\n")
+	sum := sha256.Sum256(content)
+	digest := hex.EncodeToString(sum[:])
+
+	cfg := &config.Configuration{Integrity: config.IntegrityConfig{VerifyAfterUpload: true}}
+	job := config.BackupJob{Name: "local-verify", Type: "postgres"}
+	storageParams := &storage.Params{StorageType: "local", LocalPath: dir, OutName: outName}
+	engineOpts := &dumppg.PgDumpArgs{}
+	dumps := dumpBuilderFunc(func(_ ports.BuildContext) (ports.BuildResult, error) {
+		if err := os.WriteFile(filepath.Join(dir, outName), content, 0o644); err != nil {
+			return ports.BuildResult{}, err
+		}
+		return ports.BuildResult{Digest: digest}, nil
+	})
+
+	be, err := NewBackupExecutorFromConfig(cfg, job, storageParams, false, false, engineOpts, dumps)
+	if err != nil {
+		t.Fatalf("NewBackupExecutorFromConfig() error = %v", err)
+	}
+	if !be.job.VerifyAfterUpload {
+		t.Fatal("expected the resolved domain job to have VerifyAfterUpload = true")
+	}
+
+	res, err := be.exec.Run(context.Background(), be.job)
+	if err != nil {
+		t.Fatalf("Run() error = %v, want success (real local backend wired + hash matches)", err)
+	}
+	if res.HashValue != digest {
+		t.Fatalf("HashValue = %q, want %q", res.HashValue, digest)
+	}
+}
+
+// TestNewBackupExecutorFromConfigLocalVerifyAfterUploadFailsOnMismatch proves
+// the wired verify step surfaces a real failure end-to-end (through the
+// production local backend + manifest_store.Adapter, not a test double) when
+// the recorded digest does not match what is actually on disk.
+func TestNewBackupExecutorFromConfigLocalVerifyAfterUploadFailsOnMismatch(t *testing.T) {
+	dir := t.TempDir()
+	const outName = "job.sql"
+
+	cfg := &config.Configuration{Integrity: config.IntegrityConfig{VerifyAfterUpload: true}}
+	job := config.BackupJob{Name: "local-verify-bad", Type: "postgres"}
+	storageParams := &storage.Params{StorageType: "local", LocalPath: dir, OutName: outName}
+	engineOpts := &dumppg.PgDumpArgs{}
+	dumps := dumpBuilderFunc(func(_ ports.BuildContext) (ports.BuildResult, error) {
+		if err := os.WriteFile(filepath.Join(dir, outName), []byte("-- real dump content\n"), 0o644); err != nil {
+			return ports.BuildResult{}, err
+		}
+		// Wrong digest — does not match what was actually written to disk.
+		return ports.BuildResult{Digest: strings.Repeat("0", 64)}, nil
+	})
+
+	be, err := NewBackupExecutorFromConfig(cfg, job, storageParams, false, false, engineOpts, dumps)
+	if err != nil {
+		t.Fatalf("NewBackupExecutorFromConfig() error = %v", err)
+	}
+
+	if _, err := be.exec.Run(context.Background(), be.job); err == nil {
+		t.Fatal("Run() error = nil, want verify_after_upload_failed")
+	} else if !strings.Contains(err.Error(), "verify_after_upload_failed") {
+		t.Fatalf("Run() error = %v, want it to contain verify_after_upload_failed", err)
+	}
+}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -105,6 +105,9 @@ func applyDefaults(cfg *Configuration) {
 			job.Compression = &inherited
 		}
 		applyCompressionDefaults(job.Compression)
+		if job.VerifyAfterUpload == nil {
+			job.VerifyAfterUpload = boolPtr(cfg.Integrity.VerifyAfterUpload)
+		}
 		if job.Notifications == nil && len(cfg.Defaults.Notifications) > 0 {
 			job.Notifications = cfg.Defaults.Notifications
 		}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -60,6 +60,14 @@ type IntegrityConfig struct {
 	// "sha256" is supported today; empty means the default (sha256).
 	Algorithm string `yaml:"algorithm,omitempty"`
 
+	// VerifyAfterUpload is the default for backup jobs: re-download the
+	// artifact from its storage backend immediately after upload/write and
+	// re-hash it against the manifest hash, failing the backup on mismatch.
+	// Opt-in; default false (zero behaviour/cost change when unset). A
+	// per-job `verify_after_upload` (BackupJob.VerifyAfterUpload) overrides
+	// this default. Recovered M3 roadmap item; spec 053 / PRD 40.
+	VerifyAfterUpload bool `yaml:"verify_after_upload,omitempty"`
+
 	// ScheduledCheck declares an optional cron-driven repository integrity
 	// sweep (spec 052 / PRD 35). When enabled, the scheduler registers a
 	// reserved `__integrity_check` job that runs the same sweep as
@@ -322,6 +330,11 @@ type BackupJob struct {
 
 	// TLS holds TLS/SSL settings for the database connection
 	TLS *TLSConfig `yaml:"tls,omitempty"`
+
+	// VerifyAfterUpload overrides the top-level integrity.verify_after_upload
+	// default for this job (nil = inherit; loader.go resolves it to a
+	// non-nil pointer after applying defaults). Spec 053 / PRD 40.
+	VerifyAfterUpload *bool `yaml:"verify_after_upload,omitempty"`
 }
 
 // StorageConfig defines a storage backend for backups

--- a/internal/domain/backup/executor.go
+++ b/internal/domain/backup/executor.go
@@ -142,6 +142,19 @@ func (e *Executor) Run(ctx context.Context, job Job) (RunResult, error) {
 		runErr = e.uploadStagedArtifact(ctx, job, build.LocalPath, sec, &res)
 	}
 
+	// 7.5. Post-upload verify (opt-in, spec 053 / PRD 40): re-download the
+	// artifact from the injected StorageBackend and re-hash it against the
+	// manifest hash, failing the backup on mismatch rather than letting a
+	// storage-side corruption surface at the next restore. A no-op unless
+	// both the job enables it AND a storage port was wired (the factory only
+	// wires one for local storage when this is explicitly on; for staged
+	// remote uploads the same backend used to upload is reused).
+	if runErr == nil && job.VerifyAfterUpload && e.storage != nil {
+		if verifyErr := e.verifyAfterUpload(ctx, job, sec); verifyErr != nil {
+			runErr = verifyErr
+		}
+	}
+
 	res.FinishedAt = time.Now()
 	res.ArtifactPath, res.ArtifactSize = ResolveArtifactRef(job.StorageType, job.LocalPath, job.OutName, job.GCSBucket, build.LocalPath)
 	if sec != nil {
@@ -184,6 +197,48 @@ func (e *Executor) uploadStagedArtifact(ctx context.Context, job Job, stagedPath
 		if err := e.storage.Upload(ctx, sec.ManifestPath, job.OutName+".manifest.json"); err != nil {
 			res.Warnings = append(res.Warnings, fmt.Sprintf("Warning: failed to upload manifest sidecar for '%s': %v", job.Name, err))
 		}
+	}
+
+	return nil
+}
+
+// verifyAfterUpload re-downloads job.OutName from e.storage into a temp file
+// and re-hashes it against sec.HashValue via ports.ManifestStore.VerifyHash,
+// returning an error tagged "verify_after_upload_failed" on mismatch (Q3:
+// the job fails and the stored object is left in place — never deleted —
+// for forensics; its path is included in the error). The temp file is always
+// removed, on both the match and mismatch paths.
+//
+// When no baseline hash exists for this artifact (sec == nil ||
+// sec.HashValue == "", e.g. a remote auto-discovery "single" dump-all job
+// that uploads without staging and therefore has no manifest — see
+// ApplyArtifactSecurity's remote/no-staging early return) there is nothing
+// to compare against, so this degrades to a no-op rather than a false
+// failure. Likewise a nil ManifestStore (never wired by the production
+// factory) degrades to a no-op.
+func (e *Executor) verifyAfterUpload(ctx context.Context, job Job, sec *SecurityOutcome) error {
+	if sec == nil || sec.HashValue == "" || job.OutName == "" || e.manifests == nil {
+		return nil
+	}
+
+	tmp, err := os.CreateTemp("", "sentinel-verify-*")
+	if err != nil {
+		return fmt.Errorf("backup '%s': verify_after_upload: failed to create temp file: %w", job.Name, err)
+	}
+	tmpPath := tmp.Name()
+	_ = tmp.Close()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if err := e.storage.Download(ctx, job.OutName, tmpPath); err != nil {
+		return fmt.Errorf("backup '%s': verify_after_upload: re-download of %q failed: %w", job.Name, job.OutName, err)
+	}
+
+	algo := sec.HashAlgorithm
+	if algo == "" {
+		algo = "sha256"
+	}
+	if verifyErr := e.manifests.VerifyHash(tmpPath, algo, sec.HashValue); verifyErr != nil {
+		return fmt.Errorf("backup '%s': verify_after_upload_failed: %w (stored object left in place: %s)", job.Name, verifyErr, job.OutName)
 	}
 
 	return nil

--- a/internal/domain/backup/executor_test.go
+++ b/internal/domain/backup/executor_test.go
@@ -2,13 +2,17 @@ package backup
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/denisakp/sentinel/internal/ports"
 	"github.com/denisakp/sentinel/internal/ports/dbprobertesting"
+	"github.com/denisakp/sentinel/internal/ports/storagetesting"
 )
 
 // fakeOptions satisfies the ports.EngineOptions marker.
@@ -66,6 +70,11 @@ func (s *stubRecorder) ListExecutions(_ context.Context, _ *ports.Filter, _, _ i
 type stubManifestStore struct {
 	written  map[string]*ports.BackupManifest
 	writeErr error
+
+	// verifyHashFn, when set, backs VerifyHash with a real check (used by the
+	// verify_after_upload tests). Nil preserves the historical always-nil
+	// stub behaviour relied on by the other tests in this file.
+	verifyHashFn func(path, algorithm, expected string) error
 }
 
 func (s *stubManifestStore) Write(path string, m *ports.BackupManifest) error {
@@ -85,7 +94,55 @@ func (s *stubManifestStore) Read(string) (*ports.BackupManifest, error) {
 func (s *stubManifestStore) LoadForRestore(string) (*ports.BackupManifest, error) {
 	return nil, ports.ErrNoManifest
 }
-func (s *stubManifestStore) VerifyHash(string, string, string) error { return nil }
+func (s *stubManifestStore) VerifyHash(path, algorithm, expected string) error {
+	if s.verifyHashFn != nil {
+		return s.verifyHashFn(path, algorithm, expected)
+	}
+	return nil
+}
+
+// realVerifyHash computes the real SHA-256 of the file at path and compares
+// it against expected — a faithful-enough stand-in for
+// manifest_store.VerifyBackupHash without importing the concrete adapter
+// from domain test code.
+func realVerifyHash(path, _, expected string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	sum := sha256.Sum256(data)
+	got := hex.EncodeToString(sum[:])
+	if got != expected {
+		return errors.New("hash mismatch: expected=" + expected + " computed=" + got)
+	}
+	return nil
+}
+
+// tamperingBackend wraps a MockBackend but returns corrupted bytes on
+// Download, simulating storage-side corruption that occurred after a
+// successful upload (e.g. a truncated multipart PUT).
+type tamperingBackend struct {
+	*storagetesting.MockBackend
+}
+
+func (t *tamperingBackend) Download(ctx context.Context, src, dest string) error {
+	if err := t.MockBackend.Download(ctx, src, dest); err != nil {
+		return err
+	}
+	return os.WriteFile(dest, []byte("corrupted-bytes-do-not-match-hash"), 0o644)
+}
+
+// countingBackend wraps a MockBackend and counts Download calls, used to
+// assert that a disabled verify_after_upload performs no re-download.
+type countingBackend struct {
+	*storagetesting.MockBackend
+	downloads int
+}
+
+func (c *countingBackend) Download(ctx context.Context, src, dest string) error {
+	c.downloads++
+	return c.MockBackend.Download(ctx, src, dest)
+}
 func (s *stubManifestStore) ValidateIncrementalLineage(*ports.BackupManifest) error {
 	return nil
 }
@@ -303,5 +360,115 @@ func TestExecutorRunRejectsNilOptions(t *testing.T) {
 	e := NewExecutor(&fakeDumpBuilder{}, nil, nil, nil, nil, nil, nil, nil, nil)
 	if _, err := e.Run(context.Background(), job); err == nil {
 		t.Fatal("Run() error = nil, want options-required error")
+	}
+}
+
+// verifyAfterUploadJob builds a staged-remote job (mirrors
+// TestExecutorRemoteBackupCleansStagingOnSuccess) with VerifyAfterUpload
+// enabled, plus a fakeDumpBuilder whose digest is the REAL SHA-256 of the
+// fixture payload it writes — matching what a real dump adapter records
+// (e.g. mongo_dump.go's sha256.Sum256(stdOut.Bytes())) so realVerifyHash has
+// something genuine to compare against.
+func verifyAfterUploadJob(t *testing.T) (Job, *fakeDumpBuilder, *stubRecorder) {
+	t.Helper()
+	stagingDir := t.TempDir()
+	stagedArtifact := filepath.Join(stagingDir, "out.sql")
+	payload := []byte("-- dump payload\n")
+	sum := sha256.Sum256(payload)
+	digest := hex.EncodeToString(sum[:])
+
+	job := Job{
+		Name:              "verify-job",
+		Engine:            "postgres",
+		Database:          "app",
+		Options:           fakeOptions{},
+		StorageType:       "s3", // remote — staged upload path
+		OutName:           "backup.sql",
+		StagingDir:        stagingDir,
+		VerifyAfterUpload: true,
+	}
+	dumps := &fakeDumpBuilder{digest: digest, writePath: stagedArtifact, localPath: stagedArtifact}
+	rec := &stubRecorder{}
+	return job, dumps, rec
+}
+
+// TestExecutorVerifyAfterUploadSuccess: a healthy remote backup re-downloads
+// the uploaded artifact, re-hashes it, matches the manifest hash, and the
+// job succeeds (exit criteria #1).
+func TestExecutorVerifyAfterUploadSuccess(t *testing.T) {
+	job, dumps, rec := verifyAfterUploadJob(t)
+	backend := storagetesting.NewMockBackend()
+	manifests := &stubManifestStore{verifyHashFn: realVerifyHash}
+
+	e := NewExecutor(dumps, backend, nil, nil, rec, nil, nil, nil, manifests)
+	if _, err := e.Run(context.Background(), job); err != nil {
+		t.Fatalf("Run() error = %v, want success", err)
+	}
+	if len(rec.execs) != 1 || rec.execs[0].Status != "success" {
+		t.Fatalf("recorded execs = %#v, want one success row", rec.execs)
+	}
+	if _, ok := backend.GetBytes(job.OutName); !ok {
+		t.Fatal("artifact was not uploaded to the backend")
+	}
+}
+
+// TestExecutorVerifyAfterUploadMismatchFails: an artifact corrupted in
+// storage after upload (fault-injected via tamperingBackend) makes the job
+// FAIL at backup time with reason verify_after_upload_failed — not silently
+// succeed (exit criteria #2).
+func TestExecutorVerifyAfterUploadMismatchFails(t *testing.T) {
+	job, dumps, rec := verifyAfterUploadJob(t)
+	backend := &tamperingBackend{MockBackend: storagetesting.NewMockBackend()}
+	manifests := &stubManifestStore{verifyHashFn: realVerifyHash}
+
+	e := NewExecutor(dumps, backend, nil, nil, rec, nil, nil, nil, manifests)
+	_, err := e.Run(context.Background(), job)
+	if err == nil {
+		t.Fatal("Run() error = nil, want verify_after_upload_failed")
+	}
+	if !strings.Contains(err.Error(), "verify_after_upload_failed") {
+		t.Fatalf("Run() error = %v, want it to contain verify_after_upload_failed", err)
+	}
+	if !strings.Contains(err.Error(), job.OutName) {
+		t.Errorf("Run() error = %v, want it to surface the stored object path %q", err, job.OutName)
+	}
+	if len(rec.execs) != 1 || rec.execs[0].Status != "failure" {
+		t.Fatalf("recorded execs = %#v, want one failure row", rec.execs)
+	}
+	// The corrupt object is left in place for forensics (Q3) — not deleted.
+	if _, ok := backend.GetBytes(job.OutName); !ok {
+		t.Error("corrupt object was deleted; Q3 requires leaving it in place")
+	}
+}
+
+// TestExecutorVerifyAfterUploadDisabledNoDownload: when the job does not
+// enable verify_after_upload, the Executor performs no re-download even if a
+// storage backend happens to be wired — zero added cost (exit criteria #4).
+func TestExecutorVerifyAfterUploadDisabledNoDownload(t *testing.T) {
+	job, dumps, rec := verifyAfterUploadJob(t)
+	job.VerifyAfterUpload = false
+	backend := &countingBackend{MockBackend: storagetesting.NewMockBackend()}
+	manifests := &stubManifestStore{verifyHashFn: realVerifyHash}
+
+	e := NewExecutor(dumps, backend, nil, nil, rec, nil, nil, nil, manifests)
+	if _, err := e.Run(context.Background(), job); err != nil {
+		t.Fatalf("Run() error = %v, want success", err)
+	}
+	if backend.downloads != 0 {
+		t.Fatalf("Download call count = %d, want 0 (verify_after_upload disabled)", backend.downloads)
+	}
+}
+
+// TestExecutorVerifyAfterUploadNilStorageNoDownload asserts the unset ⇒ nil
+// storage port ⇒ no re-download contract even when the job itself requests
+// verification (mirrors the factory's "keep storage nil unless enabled"
+// wiring — this is the Executor-side half of that contract).
+func TestExecutorVerifyAfterUploadNilStorageNoDownload(t *testing.T) {
+	job, dumps, rec := verifyAfterUploadJob(t)
+	manifests := &stubManifestStore{verifyHashFn: realVerifyHash}
+
+	e := NewExecutor(dumps, nil, nil, nil, rec, nil, nil, nil, manifests)
+	if _, err := e.Run(context.Background(), job); err != nil {
+		t.Fatalf("Run() error = %v, want success (nil storage = no-op verify)", err)
 	}
 }

--- a/internal/domain/backup/job.go
+++ b/internal/domain/backup/job.go
@@ -77,6 +77,14 @@ type Job struct {
 	// VerifyArtifactHash overrides the incremental artifact hash check
 	// (test seam). nil → ports.ManifestStore.VerifyHash.
 	VerifyArtifactHash func(path, algorithm, expected string) error
+
+	// VerifyAfterUpload re-downloads the artifact from the injected
+	// StorageBackend after upload/write and re-hashes it against the
+	// manifest hash, failing the backup on mismatch. Opt-in (spec 053 /
+	// PRD 40); a no-op unless the Executor's storage port is also non-nil
+	// (the driving factory only wires a real backend for verification when
+	// this is set — or, for staged remote uploads, unconditionally).
+	VerifyAfterUpload bool
 }
 
 // EncryptArtifactFunc is the in-place artifact encryption hook.


### PR DESCRIPTION
## Summary
Opt-in `verify_after_upload`: after a backup artifact is written/uploaded, re-download it from its storage backend and re-hash against the manifest hash, failing the job on mismatch instead of letting storage-side corruption surface at the next restore. Recovered M3 roadmap item (spec 053 / PRD 40).

Default **off** — zero behaviour/cost change when unset (Executor keeps a `nil` storage port, no re-download).

## Config
```yaml
integrity:
  verify_after_upload: true      # default for every job
databases:
  prod-s3:
    verify_after_upload: true    # per-job *bool override; nil = inherit
```
Added to the existing top-level `IntegrityConfig` (PRD 34/35) rather than a colliding new struct; per-job `*bool` override with retention-style inheritance resolved in `loader.go` + `backup_factory.go::resolveVerifyAfterUpload`.

## Behaviour
- Domain `Executor.verifyAfterUpload` re-downloads `job.OutName` into a temp file (always removed, both paths), compares via `ports.ManifestStore.VerifyHash`. Domain reaches storage only through `ports.StorageBackend`.
- Mismatch ⇒ `status: failure`, reason `verify_after_upload_failed`; the stored object is **left in place** for forensics (never deleted), its path surfaced in the error.
- Remote manifest precondition (Q2) already covered by spec 047 stage-then-upload — `sec.HashValue` reflects the uploaded bytes. The remote auto-discovery `single` dump-all path has no manifest hash → verify degrades to a no-op rather than a false failure.
- Q3 leave-object, Q4 local allowed/off-by-default, Q5 opt-in default-off.

## Tests
- Domain: success; mismatch (fault-injected via `tamperingBackend` over `storagetesting.MockBackend`); disabled-with-storage-present (asserts zero `Download`); nil-storage-with-flag-set.
- Factory: `resolveVerifyAfterUpload` precedence table + two end-to-end (real `local` backend + `manifest_store.Adapter`) success/mismatch.
- `go build/vet/test ./...` green (1472 pass), `go vet -tags=integration` clean, `golangci-lint` 0 issues.

Release notes intentionally omitted here (separate docs PR).