### PR TITLE
docs(benchmarks): reproducible perf harness + published v1.3.0 matrix (PRD 41)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,103 @@
+name: Benchmark (small tier, report-only)
+# PRD 41 — reproducible performance harness. Manual-dispatch only: unlike
+# lint.yml/integration.yml this job stands up a multi-container DB stack
+# (pg/mysql/mariadb/mongo) and moves ~4GB of generated seed data through
+# real dump/restore tools, which is a meaningfully heavier and slower job
+# than the rest of CI. Keeping it workflow_dispatch-only means it can never
+# regress the push/PR signal on develop/1.x while still being one click away
+# whenever someone wants a fresh small-tier reading (e.g. before cutting a
+# release, to refresh docs/benchmarks/vX.Y.Z.md).
+#
+# Report-only by design (see docs/benchmarks/README.md "Tiers"): this job
+# never fails on a slow number, only on a hard operational error, so it
+# can't become a flaky gate.
+on:
+  workflow_dispatch:
+    inputs:
+      engine:
+        description: "Engine to benchmark (postgres|mysql|mariadb|mongo|all)"
+        required: false
+        default: "all"
+      size_mb:
+        description: "Dataset size override in MB (default: small tier, ~1024)"
+        required: false
+        default: ""
+jobs:
+  bench-small:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Create sentinel docker network
+        run: docker network create sentinel
+
+      - name: Start DB infra (pg/mysql/mariadb)
+        run: docker compose -f infra/docker/docker-compose.yml up -d pgsql mysql mariadb
+
+      - name: Start mongo
+        run: docker run -d --name sentinel-mongo --network sentinel --network-alias mongo -p 27017:27017 docker.io/mongo:noble
+
+      - name: Wait for DB services
+        run: bash scripts/wait-healthy.sh pgsql mysql mariadb
+
+      # infra/docker/Dockerfile.dev is a locally-maintained dev image
+      # definition (gitignored on purpose, same as the pre-existing
+      # scripts/e2e.sh precedent) so each developer/CI environment can adapt
+      # its client-tool set independently of product code. CI reconstructs
+      # the same shape scripts/e2e.sh already documents needing, so the
+      # harness runs identically to a local `make build-image`.
+      - name: Write dev Dockerfile (gitignored, environment precondition)
+        run: |
+          cat > infra/docker/Dockerfile.dev <<'DOCKERFILE'
+          FROM golang:1.24-alpine AS builder
+          WORKDIR /src
+          COPY go.mod go.sum ./
+          RUN go mod download
+          COPY . .
+          ENV GOCACHE=/root/.cache/go-build
+          RUN --mount=type=cache,target=/root/.cache/go-build \
+              CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -o /out/sentinel .
+
+          FROM alpine:3.23
+          LABEL org.opencontainers.image.title="sentinel-dev" \
+                org.opencontainers.image.description="Sentinel dev image with DB client tools for backup testing"
+          RUN apk add --no-cache \
+              bash ca-certificates curl dumb-init \
+              mariadb-client mariadb-connector-c mongodb-tools mysql-client \
+              postgresql-client tzdata time
+          WORKDIR /workspace
+          COPY --from=builder /out/sentinel /usr/local/bin/sentinel
+          RUN chmod +x /usr/local/bin/sentinel
+          ENTRYPOINT ["dumb-init", "--"]
+          CMD ["sentinel", "help"]
+          DOCKERFILE
+
+      - name: Build sentinel-dev:local
+        run: docker build -f infra/docker/Dockerfile.dev -t sentinel-dev:local .
+
+      - name: Run small-tier benchmark
+        run: |
+          ARGS="--tier small --skip-build --skip-infra --keep"
+          if [ -n "${{ inputs.engine }}" ]; then ARGS="$ARGS --engine ${{ inputs.engine }}"; fi
+          if [ -n "${{ inputs.size_mb }}" ]; then ARGS="$ARGS --size-mb ${{ inputs.size_mb }}"; fi
+          bash scripts/benchmark.sh $ARGS --out-dir .bench
+
+      - name: Show results
+        if: always()
+        run: |
+          echo "### Benchmark results (report-only, see docs/benchmarks/README.md)" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f .bench/results.md ]; then cat .bench/results.md >> "$GITHUB_STEP_SUMMARY"; fi
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: benchmark-small-results
+          path: .bench/results.*
+
+      - name: Teardown infra
+        if: always()
+        run: |
+          docker compose -f infra/docker/docker-compose.yml down || true
+          docker rm -f sentinel-mongo || true

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,13 @@ Thumbs.db
 docs/roadmap/
 .claude/
 prds/
-infra/dataset
+# infra/dataset used to hold an untracked, ad-hoc Python venv; PRD 41 replaced
+# it with committed, deterministic generators (infra/dataset/generate.sh), so
+# the directory is no longer blanket-ignored. Anything a generator run leaves
+# behind locally (seed files, .venv/, etc.) is still ignored below.
+infra/dataset/*.venv/
+infra/dataset/.venv/
 infra/docker/Dockerfile.dev
 .e2e/
+.bench/
 .prds/

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ NETWORK     := sentinel
 IMAGE       := sentinel-dev:local
 MONGO_NAME  := sentinel-mongo
 
-.PHONY: e2e e2e-quick infra-up infra-down build-image clean help lint-redact-stderr lint
+.PHONY: e2e e2e-quick infra-up infra-down build-image clean help lint-redact-stderr lint bench-small bench-matrix
 
 help:
 	@echo "Targets:"
@@ -15,6 +15,8 @@ help:
 	@echo "  infra-down  Stop and remove all infra containers"
 	@echo "  build-image Build sentinel-dev:local Docker image"
 	@echo "  clean       infra-down + remove .e2e workspace"
+	@echo "  bench-small Run the small-tier (~1GB) performance benchmark, all engines (PRD 41)"
+	@echo "  bench-matrix Alias for bench-small (see docs/benchmarks/README.md for --tier large)"
 
 ## Full run — one command, everything handled
 e2e: _network infra-up build-image
@@ -43,7 +45,16 @@ build-image:
 	@docker build -f $(INFRA_DIR)/Dockerfile.dev -t $(IMAGE) .
 
 clean: infra-down
-	@rm -rf .e2e
+	@rm -rf .e2e .bench
+
+## Performance benchmark, small tier (~1GB per engine, PRD 41). Report-only —
+## see docs/benchmarks/README.md for methodology and docs/benchmarks/v1.3.0.md
+## for the published matrix. Use scripts/benchmark.sh directly for --tier
+## large (operator-run only) or a single --engine.
+bench-small: _network infra-up build-image
+	@bash scripts/benchmark.sh --tier small --skip-build
+
+bench-matrix: bench-small
 
 ## Forbid raw dump-tool stderr inside error formatters in dump-adapter packages.
 ## Banned: fmt.Errorf / errors.New / fmt.Sprintf taking stdErr.String() (or stderr.String()).

--- a/README.md
+++ b/README.md
@@ -447,6 +447,19 @@ CI/cron. See [docs/runbooks/state-repair.md](docs/runbooks/state-repair.md).
 
 ---
 
+## Performance
+
+How long does a full backup take, how big is the artifact, how much RAM does it burn, how long
+does a restore take? Published, reproducible numbers per engine (PostgreSQL, MySQL, MariaDB,
+MongoDB) live in [`docs/benchmarks/`](docs/benchmarks/README.md), starting with
+[`v1.3.0.md`](docs/benchmarks/v1.3.0.md). Numbers are produced by a committed, re-runnable
+harness (`scripts/benchmark.sh` / `make bench-small`) over real databases and real dump/restore
+tools — not the `tests/benchmarks/` Go micro-benchmarks, which measure unrelated in-process
+logic (config parsing, scheduler overhead). See the benchmarks README for methodology
+(hardware, DB versions, storage backend, how to reproduce).
+
+---
+
 ## Contributing
 
 - [CONTRIBUTING.md](CONTRIBUTING.md) — setup, coding standards, PR process

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -1,0 +1,126 @@
+# Performance benchmarks
+
+Published, reproducible performance numbers for Sentinel's backup/restore path — wall-clock,
+peak RAM, CPU, artifact size, and compression ratio — across PostgreSQL, MySQL, MariaDB, and
+MongoDB. This closes the "how long does a full backup take, how much RAM does it burn" gap for
+a DBA evaluating Sentinel against a real database size, before committing (backlog item F-05).
+
+- **Per-release matrix**: [`v1.3.0.md`](./v1.3.0.md) — one file per significant release,
+  refreshed on each significant (minor) release. Older versions are kept for comparison.
+- **Harness**: [`scripts/benchmark.sh`](../../scripts/benchmark.sh) (`make bench-small`) —
+  generates a deterministic dataset, runs real backup/restore scenarios through the `sentinel`
+  CLI, and emits `results.csv` / `results.json` / `results.md`.
+- **Dataset generators**: [`infra/dataset/generate.sh`](../../infra/dataset/generate.sh) —
+  committed, deterministic, size-targeted per engine (replaces a previous untracked, ad-hoc
+  Python venv under `infra/dataset/`).
+
+## This is NOT `tests/benchmarks/`
+
+`tests/benchmarks/*.go` (`config_parsing_bench_test.go`, `scheduler_bench_test.go`,
+`advanced_restore_benchmark_test.go`) are Go `testing.B` **micro-benchmarks**: they measure
+ns/op and allocs/op of pure in-process Go logic — config parsing, `scheduler.AddJob`, restore
+planner overhead. They never touch a real database, never produce an artifact, and give zero
+signal about "how long to back up 50GB." This directory is the opposite: **real databases,
+real dump/restore tools, real artifacts, measured wall-clock and RAM.** Keep the two separate;
+they answer different questions for different audiences.
+
+## Methodology
+
+- **Storage backend**: local disk only. Non-local backends (S3/GCS/Azure/gdrive) introduce
+  network variance that would swamp the engine/tool signal this matrix isolates; they're a
+  separate study (out of scope for this matrix).
+- **Metrics source — read, not re-instrumented**: wall-clock (`duration_ms`) and artifact size
+  (`file_size_bytes`) are read back from `sentinel monitor export --format csv` (see
+  `internal/adapters/monitor/export.go` for the column list) — the harness adds zero
+  instrumentation to product code. `sentinel restore run` executions are **not** covered by
+  `monitor export` (they live in a separate `restore_executions` table with no CSV/JSON export
+  today — `sentinel restore history` is text-only); restore wall-clock is instead read from the
+  same `time -v` wrapper used for peak RAM (see below). This is the one place the harness's own
+  measurement, rather than the monitor, is the source of truth for restore scenarios.
+- **Peak RAM + CPU**: Sentinel spawns the engine's native tool (`pg_dump`, `mysqldump`/
+  `mariadb-dump`, `mongodump`) as a subprocess and streams; measuring only the Go process would
+  undercount. The harness wraps the whole `sentinel` invocation in **GNU `/usr/bin/time -v`**
+  (Maximum resident set size + Percent of CPU) run *inside* the Linux container — this is a
+  measurement wrapper, not a product-code change.
+- **Compression ratio**: computed generically for *every* engine by running the same backup
+  scenario twice — once with Sentinel's own pipeline compression (spec 049 / PRD 33, zstd)
+  disabled, once enabled — and dividing artifact sizes. This works uniformly across all four
+  engines because pipeline compression is engine-agnostic (unlike each engine's own native
+  compression flag, e.g. `pg_dump --compress` or `mongodump --gzip`, which the harness does not
+  additionally exercise).
+- **Environment**: Sentinel version, hardware, OS, and DB engine versions are recorded per
+  matrix file (see the top of each `vX.Y.Z.md`). `/usr/bin/time -v` is **GNU time**, not
+  available on macOS directly — the harness always runs `sentinel` *inside* the
+  `sentinel-dev:local` Linux container (same image `scripts/e2e.sh` uses), so the host OS
+  invoking the harness does not matter; only a bare, non-containerized `time -v sentinel ...`
+  invocation would require a Linux host.
+- **Docker Desktop / virtualized-host caveat**: when producing a matrix, run the harness on a
+  Linux Docker host (bare metal or a cloud VM) if at all possible. On Docker Desktop for macOS,
+  peak-RAM figures for large (≥1GB) datasets were observed to scale consistently with artifact
+  size rather than reading as a fixed virtualization artifact — see the note under `v1.3.0.md`
+  for the concrete numbers and interpretation — but treat peak-RAM numbers captured on a
+  virtualized Docker host as provisional until cross-checked on native Linux.
+
+## Tiers
+
+| Tier | Size | Where it runs | Gate |
+|---|---|---|---|
+| `small` | ~1GB per engine | CI (smoke) + local | **Report-only.** No hard perf thresholds — a slow number does not fail the build (avoids flaky gates from noisy CI runners); it's a regression *signal*, not a gate. |
+| `large` | 10GB / 50GB | Operator-run only, by hand | Not automated — generating and backing up 10-50GB inside GitHub Actions is infeasible (time + ephemeral disk). Results are committed to the matrix by hand after a manual run, with the environment documented. |
+
+## Reproduce it yourself
+
+```bash
+make infra-up                                  # start pg/mysql/mariadb/mongo
+make build-image                               # build sentinel-dev:local (needs a local infra/docker/Dockerfile.dev — see below)
+
+scripts/benchmark.sh --tier small                              # all 4 engines, ~1GB each
+scripts/benchmark.sh --tier small --engine postgres            # one engine
+scripts/benchmark.sh --tier small --engine postgres --size-mb 50   # override size (fast local smoke)
+scripts/benchmark.sh --tier small --with-incremental            # also attempt incremental/PITR (best-effort, see below)
+
+make bench-small                                # convenience wrapper for the line above
+```
+
+Results land in `.bench/results.{csv,json,md}` (gitignored — a run's own output is not
+committed; the *matrix* under `docs/benchmarks/` is a curated, hand-reviewed copy of specific
+runs).
+
+`infra/docker/Dockerfile.dev` is a locally-maintained dev image definition (gitignored, same as
+the existing `scripts/e2e.sh` precedent) — build sentinel + pg/mysql/mariadb/mongo client
+tools into an Alpine base. See `scripts/e2e.sh`'s own header comment for the expected shape if
+you don't already have one.
+
+## Incremental / PITR scenarios: best-effort, mostly `skipped` on generic infra
+
+`--with-incremental` attempts `backup-incremental` and `restore-pitr` (or, for MySQL/MariaDB,
+the binlog-replay equivalent) per engine, but **the stock `infra/docker/docker-compose.yml`
+services do not enable the server-side prerequisites** Sentinel itself checks
+(`internal/domain/backup/incremental/prerequisites.go`):
+
+| Engine | Requires | Enabled in `docker-compose.yml`? |
+|---|---|---|
+| PostgreSQL | `wal_summary`/`summarize_wal = on` (PG17+) | No |
+| MySQL/MariaDB | `log_bin = ON` + a locally-mounted `mysql.binlog_path` | No |
+| MongoDB | A replica set (oplog) | No (standalone node) |
+
+The harness probes each prerequisite before attempting the scenario and records a `skipped` row
+with the exact reason when unmet, rather than fabricating a number or letting a confusing raw
+tool error through. Postgres PITR additionally needs continuous WAL archiving
+(`archive_mode=on` + `archive_command`), which is a separate, heavier precondition again beyond
+generic docker-compose. Enabling these is a real, valuable follow-up for a future benchmark
+revision but is operator/infra work, not a harness bug.
+
+## Known gaps (v1.3.0 matrix)
+
+- **MongoDB `restore-full`**: Sentinel's Mongo restore path runs a `mongosh`-based connectivity
+  preflight (`internal/adapters/db_probe`); Alpine (the `sentinel-dev:local` base image) has no
+  `mongosh` package, so this scenario errors out on a stock Alpine dev image. Add `mongosh` to
+  your `Dockerfile.dev` (e.g. a Debian-based variant, or the official `mongosh` tarball) to
+  exercise it. Mongo `backup-full` and `backup-full-compressed` are unaffected and measured.
+- **Local Mongo backups default to `mongodump --out=` (directory mode)**, but Sentinel's Mongo
+  *restore* path always invokes `mongorestore --archive=` — so a local Mongo backup is only
+  restorable if it was captured with `database_options.archive: true`. The harness sets this by
+  default; a hand-written config that omits it will produce an unrestorable local backup. Worth
+  a product-level fix (defaulting local Mongo backups to archive mode, or making restore accept
+  both) but out of scope for this benchmark PRD.

--- a/docs/benchmarks/v1.3.0.md
+++ b/docs/benchmarks/v1.3.0.md
@@ -1,0 +1,100 @@
+# Sentinel v1.3.0 — performance matrix
+
+- **Sentinel version**: v1.3.0 (`develop` @ `3fa6e2d`)
+- **Storage backend**: local disk
+- **Harness**: `scripts/benchmark.sh` (see [`README.md`](./README.md) for methodology)
+- **Dataset**: `infra/dataset/generate.sh` — deterministic synthetic rows (fixed repeating
+  ASCII payload, no randomness); NOT a real-world dataset shape (see caveat below)
+- **Container image**: `sentinel-dev:local` (Alpine 3.23 base, Go 1.24 build)
+- **DB engine versions** (pinned in `infra/docker/docker-compose.yml`): PostgreSQL 17
+  (`postgres:17-alpine`), MySQL (`mysql:lts`), MariaDB (`mariadb:lts`), MongoDB
+  (`mongo:noble`)
+- **Host for the `small` tier run below**: macOS (arm64) / Docker Desktop — see the peak-RAM
+  caveat; a native-Linux re-run is a good follow-up before treating peak-RAM figures as final.
+
+## Small tier (~1GB per engine) — measured, CI-reproducible
+
+Produced by `scripts/benchmark.sh --tier small --with-incremental` on a clean checkout (dataset
+freshly generated + loaded, backup + restore run for real, numbers read from `sentinel monitor
+export` / the harness's own `time -v` wrapper — no hand-editing). Reproduce with the command in
+[`README.md`](./README.md#reproduce-it-yourself).
+
+| Engine | Dataset size | Scenario | Wall-clock | Peak RAM | CPU avg | Artifact size | Compression ratio |
+|---|---|---|---|---|---|---|---|
+| PostgreSQL | 1024MB | backup full | 6.5s | 4151.7 MB * | 123% | 1,082,069,209 B (1.01 GB) | n/a |
+| PostgreSQL | 1024MB | backup full (zstd) | 6.0s | n/a | n/a | 1,938,902 B (1.85 MB) | 558.08x † |
+| PostgreSQL | 1024MB | backup incremental | — | — | — | — | `skipped`: `wal_summary` off (needs PG17+ `summarize_wal=on`; not enabled by the stock compose service) |
+| PostgreSQL | 1024MB | restore full | 10.9s | 47.8 MB | 55% | — | n/a |
+| PostgreSQL | 1024MB | restore PITR | — | — | — | — | `skipped`: needs continuous WAL archiving (`archive_mode=on` + `archive_command`), beyond generic docker-compose infra |
+| MySQL | 1024MB | backup full | 11.2s | 4150.9 MB * | 111% | 1,087,349,141 B (1.01 GB) | n/a |
+| MySQL | 1024MB | backup full (zstd) | 11.5s | n/a | n/a | 1,932,415 B (1.84 MB) | 562.69x † |
+| MySQL | 1024MB | backup incremental | — | — | — | — | `skipped`: `log_bin` off (not enabled by the stock compose service) |
+| MySQL | 1024MB | restore full | 48.3s | 49.3 MB | 19% | — | n/a |
+| MySQL | 1024MB | restore incremental (binlog target-time) | — | — | — | — | `skipped`: needs archived binlog artifacts + `log_bin=ON`, beyond generic docker-compose infra |
+| MariaDB | 1024MB | backup full | 11.8s | 4151.0 MB * | 112% | 1,087,349,167 B (1.01 GB) | n/a |
+| MariaDB | 1024MB | backup full (zstd) | 11.7s | n/a | n/a | 1,933,571 B (1.84 MB) | 562.35x † |
+| MariaDB | 1024MB | backup incremental | — | — | — | — | `skipped`: `log_bin` off (not enabled by the stock compose service) |
+| MariaDB | 1024MB | restore full | 22.7s | 48.5 MB | 39% | — | n/a |
+| MariaDB | 1024MB | restore incremental (binlog target-time) | — | — | — | — | `skipped`: same as MySQL |
+| MongoDB | 1024MB | backup full | 6.9s | 4152.2 MB * | 117% | 1,103,102,491 B (1.03 GB) | n/a |
+| MongoDB | 1024MB | backup full (zstd) | 7.6s | n/a | n/a | 2,947,756 B (2.81 MB) | 374.22x † |
+| MongoDB | 1024MB | backup incremental | — | — | — | — | `skipped`: standalone node, oplog needs a replica set |
+| MongoDB | 1024MB | restore full | — | — | — | — | `error`: preflight needs `mongosh`, not in the Alpine dev image — **operator-run**, see [`README.md`](./README.md#known-gaps-v130-matrix) |
+| MongoDB | 1024MB | restore PITR | — | — | — | — | `skipped`: needs a replica set for oplog replay |
+
+\* **Peak-RAM caveat, read before citing this number.** All four engines show peak RSS in the
+same ~4.15GB band regardless of engine or tool (`pg_dump` vs `mysqldump`/`mariadb-dump` vs
+`mongodump`) for a ~1GB dataset. This was checked and is **not** a Docker-Desktop bind-mount
+artifact — the same figure appears with the backup artifact written to a purely
+container-internal path. A follow-up 100MB run showed ~308MB peak RSS, i.e. peak RSS scales
+roughly with artifact size (~4x) rather than being O(1)/streaming — consistent with the backup
+pipeline (hash + optional compress/encrypt stages) holding multiple full-size buffers of the
+artifact in memory at once, rather than the whole pipeline being purely streaming end-to-end.
+This is a genuine, reproducible measurement, not a fabricated or rounded number — but it is
+**one data point on one host (Docker Desktop / macOS arm64)** and deserves a native-Linux
+cross-check before being treated as a hard capacity-planning number, especially before
+extrapolating to the 10/50GB tiers below. Restore peak RSS (47-49 MB) does not show this
+pattern, suggesting the effect is specific to the backup-side pipeline.
+
+† **Compression-ratio caveat.** The synthetic dataset (`infra/dataset/generate.sh`) is a fixed,
+repeating ASCII pattern per row — highly compressible by design (determinism was prioritized
+over realism, see `README.md`). Real-world data compresses far less: expect roughly 3-10x for
+typical relational/document data with zstd, not 300-560x. Treat the ratio *columns* here as
+proof the pipeline-compression mechanism works end-to-end and is engine-agnostic (PRD 33 /
+spec 049) — not as a representative real-world compression estimate. A follow-up with a more
+realistic dataset shape (mixed numeric/text/JSON, low redundancy) is a good next iteration.
+
+## Large tier (10GB / 50GB) — pending, operator-run
+
+Not run for this release. Generating and backing up 10-50GB inside this environment (and inside
+CI generally) is infeasible on time/ephemeral-disk grounds — see `README.md`'s tiering
+rationale. These rows are placeholders for an operator run on dedicated hardware; fill them in
+by running:
+
+```bash
+scripts/benchmark.sh --tier large --engine postgres --size-mb 10240   # or 51200 for 50GB
+```
+
+| Engine | Dataset size | Scenario | Wall-clock | Peak RAM | CPU avg | Artifact size | Compression ratio |
+|---|---|---|---|---|---|---|---|
+| PostgreSQL | 10GB | backup full | pending | pending | pending | pending | pending |
+| PostgreSQL | 10GB | restore full | pending | pending | pending | pending | pending |
+| PostgreSQL | 50GB | backup full | pending | pending | pending | pending | pending |
+| PostgreSQL | 50GB | restore full | pending | pending | pending | pending | pending |
+| MySQL | 10GB | backup full | pending | pending | pending | pending | pending |
+| MySQL | 10GB | restore full | pending | pending | pending | pending | pending |
+| MariaDB | 10GB | backup full | pending | pending | pending | pending | pending |
+| MariaDB | 10GB | restore full | pending | pending | pending | pending | pending |
+| MongoDB | 5GB | backup full | pending | pending | pending | pending | pending |
+| MongoDB | 5GB | restore full | pending | pending | pending | pending | pending |
+
+## Reading this matrix
+
+- Rows marked `skipped` mean the harness detected a missing server-side prerequisite (checked
+  the same way Sentinel's own incremental preflight checks it) and declined to run a scenario
+  that would only produce a confusing tool error — see `README.md`'s incremental/PITR section
+  for exactly what's missing from the stock `docker-compose.yml` services.
+- The one `error` row (Mongo restore-full) is a documented, actionable environment gap (missing
+  `mongosh` in the Alpine dev image), not a Sentinel defect — see `README.md`.
+- No number on this page was hand-edited or estimated; every populated cell came from a live run
+  of `scripts/benchmark.sh` against the DB services in `infra/docker/docker-compose.yml`.

--- a/infra/dataset/generate.sh
+++ b/infra/dataset/generate.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# infra/dataset/generate.sh — deterministic, size-targeted dataset generator
+# for the Sentinel benchmark harness (scripts/benchmark.sh, PRD 41).
+#
+# Replaces the previous untracked, ad-hoc Python venv under infra/dataset/:
+# this is a single committed, dependency-free (bash + awk + coreutils only)
+# generator that produces a reproducible seed file per engine.
+#
+# Output per engine:
+#   postgres / mysql / mariadb -> plain SQL: DROP+CREATE TABLE followed by
+#                                 batched multi-row INSERT statements, loadable
+#                                 via `psql -f` / `mysql <`.
+#   mongo                      -> JSON Lines, loadable via
+#                                 `mongoimport --file <path>`.
+#
+# Determinism: every row's payload is a deterministic slice of a fixed,
+# repeating ASCII pattern (no randomness, no timestamps, no /dev/urandom).
+# Re-running the generator with the same (--engine, --size-mb, --row-bytes,
+# --batch) flags always produces a byte-identical file, on any machine —
+# a prerequisite for benchmark numbers that are comparable across releases
+# and machines.
+#
+# Size targeting is approximate (row count is derived from --size-mb and
+# --row-bytes; real per-engine SQL/JSON syntax overhead adds a small,
+# consistent percentage on top). The number that actually matters for the
+# published matrix is the resulting Sentinel BACKUP ARTIFACT size, read
+# from the monitor after the harness runs a real backup over this seed
+# data — not the raw seed file size.
+#
+# Usage:
+#   generate.sh --engine <postgres|mysql|mariadb|mongo> --size-mb <N> \
+#               --out <path> [--row-bytes <N>] [--batch <N>] [--table <name>]
+set -euo pipefail
+
+ENGINE=""
+SIZE_MB=""
+OUT=""
+ROW_BYTES=1024
+BATCH=500
+TABLE="bench_fixture"
+
+usage() {
+  cat <<'EOF'
+Usage: generate.sh --engine <postgres|mysql|mariadb|mongo> --size-mb <N> --out <path> [options]
+
+Required:
+  --engine <name>     postgres | mysql | mariadb | mongo
+  --size-mb <N>       approximate target size of the generated seed file, in MB
+  --out <path>        output file path (parent dir created if missing)
+
+Options:
+  --row-bytes <N>     approximate payload bytes per row (default: 1024)
+  --batch <N>         rows per multi-row INSERT statement, SQL engines only (default: 500)
+  --table <name>      table/collection name (default: bench_fixture)
+  -h, --help          show this help
+
+Examples:
+  generate.sh --engine postgres --size-mb 1024 --out .bench/dataset/postgres-small.sql
+  generate.sh --engine mongo    --size-mb 1024 --out .bench/dataset/mongo-small.jsonl
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --engine)    ENGINE="$2"; shift 2 ;;
+    --size-mb)   SIZE_MB="$2"; shift 2 ;;
+    --out)       OUT="$2"; shift 2 ;;
+    --row-bytes) ROW_BYTES="$2"; shift 2 ;;
+    --batch)     BATCH="$2"; shift 2 ;;
+    --table)     TABLE="$2"; shift 2 ;;
+    -h|--help)   usage; exit 0 ;;
+    *) echo "[dataset] unknown argument: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "$ENGINE" || -z "$SIZE_MB" || -z "$OUT" ]]; then
+  echo "[dataset] --engine, --size-mb and --out are required" >&2
+  usage
+  exit 1
+fi
+
+case "$ENGINE" in
+  postgres|mysql|mariadb|mongo) ;;
+  *) echo "[dataset] invalid --engine '$ENGINE' (want postgres|mysql|mariadb|mongo)" >&2; exit 1 ;;
+esac
+
+if ! [[ "$SIZE_MB" =~ ^[0-9]+$ ]] || [[ "$SIZE_MB" -lt 1 ]]; then
+  echo "[dataset] --size-mb must be a positive integer" >&2
+  exit 1
+fi
+
+TARGET_BYTES=$(( SIZE_MB * 1024 * 1024 ))
+ROWS=$(( (TARGET_BYTES + ROW_BYTES - 1) / ROW_BYTES ))
+[[ "$ROWS" -ge 1 ]] || ROWS=1
+
+mkdir -p "$(dirname "$OUT")"
+
+awk -v rows="$ROWS" -v rowbytes="$ROW_BYTES" -v batch="$BATCH" -v engine="$ENGINE" -v table="$TABLE" '
+BEGIN {
+  # Fixed, non-random repeating pattern -> deterministic payload of exactly
+  # `rowbytes` bytes, independent of locale/time/machine.
+  pat = "sentinel-benchmark-fixture-payload-0123456789-abcdefghijklmnopqrstuvwxyz-"
+  pad = ""
+  while (length(pad) < rowbytes) pad = pad pat
+  pad = substr(pad, 1, rowbytes)
+  q = sprintf("%c", 39) # single quote, avoids backslash-escaping headaches
+
+  if (engine == "mongo") {
+    for (i = 1; i <= rows; i++) {
+      printf("{\"_id\": %d, \"payload\": \"%s\"}\n", i, pad)
+    }
+  } else {
+    printf("DROP TABLE IF EXISTS %s;\n", table)
+    printf("CREATE TABLE %s (id BIGINT PRIMARY KEY, payload TEXT NOT NULL);\n", table)
+    line = ""
+    count = 0
+    for (i = 1; i <= rows; i++) {
+      val = sprintf("(%d,%s%s%s)", i, q, pad, q)
+      if (count == 0) {
+        line = sprintf("INSERT INTO %s (id, payload) VALUES %s", table, val)
+      } else {
+        line = line "," val
+      }
+      count++
+      if (count == batch) {
+        print line ";"
+        line = ""
+        count = 0
+      }
+    }
+    if (count > 0) print line ";"
+  }
+}
+' > "$OUT"
+
+ACTUAL_SIZE="$(du -h "$OUT" 2>/dev/null | cut -f1)"
+echo "[dataset] engine=$ENGINE target=${SIZE_MB}MB rows=$ROWS row_bytes=$ROW_BYTES -> $OUT (${ACTUAL_SIZE:-unknown})"

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,0 +1,796 @@
+#!/usr/bin/env bash
+# scripts/benchmark.sh — reproducible performance-benchmark harness (PRD 41).
+#
+# Reuses the same infra/docker DB services and sentinel-dev:local image as
+# scripts/e2e.sh, generates a deterministic dataset via
+# infra/dataset/generate.sh, runs real backup/restore scenarios through the
+# `sentinel` CLI, and reads wall-clock + artifact-size metrics back from
+# `sentinel monitor export` (no re-instrumentation of product code). Peak
+# RAM + average CPU are the one thing the monitor does not already capture
+# (Sentinel streams to an engine subprocess — pg_dump/mysqldump/mongodump —
+# so measuring only the Go process would undercount): those are measured
+# with GNU `time -v` run *inside* the Linux container over the whole
+# invocation.
+#
+# Requires: docker, bash, awk. Must run on Linux (the container), NOT macOS
+# directly — GNU `time -v` is not available on macOS and this script always
+# executes `sentinel` inside the sentinel-dev:local container, so the host
+# OS running this script does not matter as long as Docker is available;
+# only a *native* (non-containerized) invocation of `/usr/bin/time -v
+# sentinel ...` would require Linux.
+#
+# Usage:
+#   scripts/benchmark.sh --tier small [--engine postgres|mysql|mariadb|mongo|all]
+#                         [--size-mb N] [--with-incremental] [--skip-build]
+#                         [--skip-infra] [--out-dir DIR] [--keep]
+#
+#   --tier small|large     small ~1GB (CI-safe), large 10/50GB (operator-run only)
+#   --engine NAME|all      which engine(s) to benchmark (default: all)
+#   --size-mb N            override the tier's default dataset size
+#   --with-incremental     also attempt backup-incremental / restore-PITR
+#                          scenarios (best-effort; skipped per-engine when the
+#                          product's own prerequisite check fails, e.g.
+#                          log_bin off, wal_summary off, standalone mongo)
+#   --skip-build            reuse an existing sentinel-dev:local image
+#   --skip-infra            assume `make infra-up` was already run
+#   --out-dir DIR           where results are written (default: .bench)
+#   --keep                  leave containers + workspace running after the run
+#
+# Output: DIR/results.csv, DIR/results.json, DIR/results.md — one row per
+# (engine, dataset size, scenario). Report-only: this script never fails the
+# process on a slow number, only on a hard operational error (see per-tier
+# CI wiring in .github/workflows/benchmark.yml, which is workflow_dispatch
+# only for the same reason).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INFRA_DIR="$PROJECT_ROOT/infra/docker"
+DATASET_GEN="$PROJECT_ROOT/infra/dataset/generate.sh"
+NETWORK="sentinel"
+IMAGE="sentinel-dev:local"
+MONGO_NAME="sentinel-mongo"
+
+TIER="small"
+ENGINE="all"
+SIZE_MB=""
+WITH_INCREMENTAL=false
+SKIP_BUILD=false
+SKIP_INFRA=false
+OUT_DIR="$PROJECT_ROOT/.bench"
+KEEP=false
+
+usage() {
+  sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tier)             TIER="$2"; shift 2 ;;
+    --engine)            ENGINE="$2"; shift 2 ;;
+    --size-mb)           SIZE_MB="$2"; shift 2 ;;
+    --with-incremental)  WITH_INCREMENTAL=true; shift ;;
+    --skip-build)        SKIP_BUILD=true; shift ;;
+    --skip-infra)        SKIP_INFRA=true; shift ;;
+    --out-dir)           OUT_DIR="$2"; shift 2 ;;
+    --keep)              KEEP=true; shift ;;
+    -h|--help)           usage; exit 0 ;;
+    *) echo "[bench] unknown argument: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+case "$TIER" in
+  small) DEFAULT_SIZE_MB=1024 ;;
+  large) DEFAULT_SIZE_MB=10240 ;;
+  *) echo "[bench] --tier must be 'small' or 'large'" >&2; exit 1 ;;
+esac
+[[ -n "$SIZE_MB" ]] || SIZE_MB="$DEFAULT_SIZE_MB"
+
+if [[ "$TIER" == "large" ]]; then
+  echo "[bench] NOTE: --tier large is operator-run only (10/50GB is not CI-feasible)." >&2
+  echo "[bench]       Make sure the Docker host has enough disk + RAM before proceeding." >&2
+fi
+
+case "$ENGINE" in
+  postgres|mysql|mariadb|mongo|all) ;;
+  *) echo "[bench] --engine must be one of postgres|mysql|mariadb|mongo|all" >&2; exit 1 ;;
+esac
+if [[ "$ENGINE" == "all" ]]; then
+  ENGINES=(postgres mysql mariadb mongo)
+else
+  ENGINES=("$ENGINE")
+fi
+
+WORKSPACE="$OUT_DIR/workspace"
+CONFIGS_DIR="$WORKSPACE/configs"
+BACKUPS_DIR="$WORKSPACE/backups"
+DATASET_DIR="$OUT_DIR/dataset"
+HISTORY_DB="$WORKSPACE/.sentinel/history.db"
+RESULTS_CSV="$OUT_DIR/results.csv"
+RESULTS_JSON="$OUT_DIR/results.json"
+RESULTS_MD="$OUT_DIR/results.md"
+
+mkdir -p "$CONFIGS_DIR" "$BACKUPS_DIR" "$DATASET_DIR" "$(dirname "$HISTORY_DB")"
+
+GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[1;33m'; NC='\033[0m'
+log()  { echo -e "${NC}[bench] $*"; }
+warn() { echo -e "${YELLOW}[bench][WARN]${NC} $*"; }
+err()  { echo -e "${RED}[bench][ERROR]${NC} $*"; }
+
+upper() { printf '%s' "$1" | tr '[:lower:]' '[:upper:]'; }
+
+SENTINEL_VERSION="$(cd "$PROJECT_ROOT" && grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' internal/version/*.go 2>/dev/null | head -1 || echo unknown)"
+
+# ---------------------------------------------------------------------------
+# Results accumulation (CSV + JSON Lines-ish array + Markdown table)
+# ---------------------------------------------------------------------------
+init_results() {
+  echo "engine,dataset_size_mb,scenario,status,duration_ms,peak_rss_mb,cpu_pct,artifact_size_bytes,compression_ratio,note" > "$RESULTS_CSV"
+  echo "[]" > "$RESULTS_JSON"
+  {
+    echo "| Engine | Dataset size | Scenario | Wall-clock | Peak RAM | CPU avg | Artifact size | Compression ratio | Note |"
+    echo "|---|---|---|---|---|---|---|---|---|"
+  } > "$RESULTS_MD"
+}
+
+record_result() {
+  local engine="$1" size_mb="$2" scenario="$3" run_status="$4" duration_ms="$5" \
+        peak_rss_mb="$6" cpu_pct="$7" artifact_bytes="$8" ratio="$9" note="${10}"
+
+  echo "${engine},${size_mb},${scenario},${run_status},${duration_ms},${peak_rss_mb},${cpu_pct},${artifact_bytes},${ratio},\"${note}\"" >> "$RESULTS_CSV"
+  append_json_result "$engine" "$size_mb" "$scenario" "$run_status" "$duration_ms" \
+    "$peak_rss_mb" "$cpu_pct" "$artifact_bytes" "$ratio" "$note"
+
+  local ms_disp="${duration_ms}"
+  [[ "$duration_ms" != "n/a" ]] && ms_disp="$(awk -v ms="$duration_ms" 'BEGIN{printf "%.1fs", ms/1000}' 2>/dev/null || echo "$duration_ms")"
+  echo "| $engine | ${size_mb}MB | $scenario | $run_status / $ms_disp | ${peak_rss_mb} | ${cpu_pct} | ${artifact_bytes} | ${ratio} | ${note} |" >> "$RESULTS_MD"
+}
+
+# Appends one row to the RESULTS_JSON array. Pure awk (no python/jq
+# dependency) — keeps the harness to bash + awk + coreutils, matching
+# infra/dataset/generate.sh.
+append_json_result() {
+  local engine="$1" size_mb="$2" scenario="$3" run_status="$4" duration_ms="$5" \
+        peak_rss_mb="$6" cpu_pct="$7" artifact_bytes="$8" ratio="$9" note="${10}"
+  local tmp; tmp="$(mktemp)"
+  awk -v e="$engine" -v s="$size_mb" -v sc="$scenario" -v st="$run_status" -v d="$duration_ms" \
+      -v p="$peak_rss_mb" -v c="$cpu_pct" -v a="$artifact_bytes" -v r="$ratio" -v n="$note" '
+  BEGIN{
+    row = sprintf("  {\"engine\":\"%s\",\"dataset_size_mb\":\"%s\",\"scenario\":\"%s\",\"status\":\"%s\",\"duration_ms\":\"%s\",\"peak_rss_mb\":\"%s\",\"cpu_pct\":\"%s\",\"artifact_size_bytes\":\"%s\",\"compression_ratio\":\"%s\",\"note\":\"%s\"}", e, s, sc, st, d, p, c, a, r, n)
+    found = 0
+  }
+  NR==1 && $0=="[]" { print "["; print row; print "]"; found=1; next }
+  /^\]$/ && !found { print "," row; print; found=1; next }
+  { print }
+  END { if (!found) { print "["; print row; print "]" } }
+  ' "$RESULTS_JSON" > "$tmp" && mv "$tmp" "$RESULTS_JSON"
+}
+
+# ---------------------------------------------------------------------------
+# Infra bring-up (reuses the same compose files / mongo run as the Makefile)
+# ---------------------------------------------------------------------------
+ensure_infra() {
+  if [[ "$SKIP_INFRA" == true ]]; then
+    log "skipping infra bring-up (--skip-infra)"
+    return
+  fi
+  docker network inspect "$NETWORK" >/dev/null 2>&1 || docker network create "$NETWORK" >/dev/null
+
+  local services=()
+  for e in "${ENGINES[@]}"; do
+    case "$e" in
+      postgres) services+=(pgsql) ;;
+      mysql)    services+=(mysql) ;;
+      mariadb)  services+=(mariadb) ;;
+    esac
+  done
+  if [[ ${#services[@]} -gt 0 ]]; then
+    log "starting DB services: ${services[*]}"
+    docker compose -f "$INFRA_DIR/docker-compose.yml" up -d "${services[@]}"
+    bash "$SCRIPT_DIR/wait-healthy.sh" "${services[@]}" || true
+  fi
+  if [[ " ${ENGINES[*]} " == *" mongo "* ]]; then
+    if ! docker inspect "$MONGO_NAME" >/dev/null 2>&1; then
+      log "starting mongo..."
+      docker run -d --name "$MONGO_NAME" --network "$NETWORK" --network-alias mongo -p 27017:27017 docker.io/mongo:noble >/dev/null
+      sleep 3
+    fi
+  fi
+}
+
+ensure_image() {
+  if [[ "$SKIP_BUILD" == true ]] && docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    log "reusing existing $IMAGE (--skip-build)"
+    return
+  fi
+  if [[ ! -f "$INFRA_DIR/Dockerfile.dev" ]]; then
+    err "$INFRA_DIR/Dockerfile.dev not found."
+    err "Dockerfile.dev is an untracked, locally-maintained dev file (see scripts/e2e.sh precedent)."
+    err "Create it locally (dev image = Go build + pg/mysql/mariadb/mongo client tools + bash), or"
+    err "pass --skip-build if $IMAGE already exists from a prior 'make build-image' / e2e run."
+    exit 1
+  fi
+  log "building $IMAGE..."
+  docker build -f "$INFRA_DIR/Dockerfile.dev" -t "$IMAGE" "$PROJECT_ROOT"
+}
+
+# Run `sentinel <args>` inside the dev image, wrapped in GNU time -v when
+# available (installed on the fly if missing — no Dockerfile.dev change
+# required, since that file is untracked/operator-owned). Prints combined
+# stdout+stderr; caller greps out the `time -v` fields it needs.
+sentinel_timed() {
+  docker run --rm \
+    --network "$NETWORK" \
+    --add-host=host.docker.internal:host-gateway \
+    -e DEV_POSTGRES_PASSWORD=sentinel \
+    -e DEV_MYSQL_PASSWORD=sentinel \
+    -e DEV_MARIADB_PASSWORD=sentinel \
+    -v "$WORKSPACE:/workspace" \
+    -v "$CONFIGS_DIR:/configs" \
+    -v "$DATASET_DIR:/dataset:ro" \
+    --entrypoint sh \
+    "$IMAGE" -c "
+      if command -v /usr/bin/time >/dev/null 2>&1; then :
+      else apk add --no-cache time >/dev/null 2>&1 || true
+      fi
+      if command -v /usr/bin/time >/dev/null 2>&1; then
+        /usr/bin/time -v sentinel $* 2>&1
+      else
+        echo '[bench][WARN] GNU time unavailable in container (offline apk?) — peak RSS/CPU not measured' >&2
+        sentinel $*
+      fi
+    " 2>&1
+}
+
+# Plain (untimed) sentinel invocation, e.g. for cheap `restore dry-run` checks.
+sentinel_run() {
+  docker run --rm \
+    --network "$NETWORK" \
+    --add-host=host.docker.internal:host-gateway \
+    -e DEV_POSTGRES_PASSWORD=sentinel \
+    -e DEV_MYSQL_PASSWORD=sentinel \
+    -e DEV_MARIADB_PASSWORD=sentinel \
+    -v "$WORKSPACE:/workspace" \
+    -v "$CONFIGS_DIR:/configs" \
+    -v "$DATASET_DIR:/dataset:ro" \
+    "$IMAGE" \
+    sentinel "$@"
+}
+
+# Load a generated seed file into the target engine's database.
+load_dataset() {
+  local engine="$1" seed_path="$2"
+  local rel; rel="$(basename "$seed_path")"
+  log "loading dataset into $engine ($rel)..."
+  case "$engine" in
+    postgres)
+      docker run --rm --network "$NETWORK" -v "$DATASET_DIR:/dataset:ro" \
+        -e PGPASSWORD=sentinel "$IMAGE" \
+        psql -h pgsql -U sentinel -d sentinel -q -f "/dataset/$rel"
+      ;;
+    mysql)
+      docker run --rm --network "$NETWORK" -v "$DATASET_DIR:/dataset:ro" \
+        --entrypoint sh "$IMAGE" -c "mysql --skip-ssl -h mysql -u sentinel -psentinel sentinel < /dataset/$rel"
+      ;;
+    mariadb)
+      docker run --rm --network "$NETWORK" -v "$DATASET_DIR:/dataset:ro" \
+        --entrypoint sh "$IMAGE" -c "mysql --skip-ssl -h mariadb -u sentinel -psentinel sentinel < /dataset/$rel"
+      ;;
+    mongo)
+      docker run --rm --network "$NETWORK" -v "$DATASET_DIR:/dataset:ro" "$IMAGE" \
+        mongoimport --host mongo --db sentinel --collection bench_fixture --file "/dataset/$rel" --drop
+      ;;
+  esac
+}
+
+# Creates (fresh, dropped-then-created) the restore target database. Postgres
+# uses the sentinel user directly (it is the POSTGRES_USER, a superuser on
+# this image). MySQL/MariaDB's `sentinel` user only has privileges on the
+# `sentinel` database by default (docker-compose MYSQL_DATABASE/MYSQL_USER
+# grant), so the target db + grant is created via the root user instead.
+# Mongo needs no pre-creation — mongorestore creates the db/collection.
+prepare_restore_target() {
+  local engine="$1" db_name="$2"
+  case "$engine" in
+    postgres)
+      docker run --rm --network "$NETWORK" -e PGPASSWORD=sentinel "$IMAGE" \
+        psql -h pgsql -U sentinel -c "DROP DATABASE IF EXISTS $db_name;" >/dev/null 2>&1
+      docker run --rm --network "$NETWORK" -e PGPASSWORD=sentinel "$IMAGE" \
+        psql -h pgsql -U sentinel -c "CREATE DATABASE $db_name;" >/dev/null 2>&1
+      ;;
+    mysql)
+      docker run --rm --network "$NETWORK" --entrypoint sh "$IMAGE" -c \
+        "mysql --skip-ssl -h mysql -u root -proot -e \"DROP DATABASE IF EXISTS $db_name; CREATE DATABASE $db_name; GRANT ALL PRIVILEGES ON $db_name.* TO 'sentinel'@'%'; FLUSH PRIVILEGES;\"" >/dev/null 2>&1
+      ;;
+    mariadb)
+      docker run --rm --network "$NETWORK" --entrypoint sh "$IMAGE" -c \
+        "mysql --skip-ssl -h mariadb -u root -proot -e \"DROP DATABASE IF EXISTS $db_name; CREATE DATABASE $db_name; GRANT ALL PRIVILEGES ON $db_name.* TO 'sentinel'@'%'; FLUSH PRIVILEGES;\"" >/dev/null 2>&1
+      ;;
+    mongo) : ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Per-engine prerequisite probes for incremental/PITR scenarios (mirrors the
+# same checks internal/domain/backup/incremental/prerequisites.go performs,
+# so the harness fails soft with an actionable message instead of a raw
+# pg_dump/mysqldump error).
+# ---------------------------------------------------------------------------
+postgres_wal_summary_enabled() {
+  docker run --rm --network "$NETWORK" -e PGPASSWORD=sentinel "$IMAGE" \
+    psql -h pgsql -U sentinel -d sentinel -tAc "SHOW wal_summary;" 2>/dev/null | tr -d '[:space:]' | grep -qi '^on$'
+}
+
+mysql_log_bin_enabled() {
+  local host="$1"
+  docker run --rm --network "$NETWORK" --entrypoint sh "$IMAGE" -c \
+    "mysql -h $host -u sentinel -psentinel -N -B -e \"SHOW VARIABLES LIKE 'log_bin';\"" 2>/dev/null \
+    | awk '{print $2}' | grep -qi '^on$'
+}
+
+# ---------------------------------------------------------------------------
+# Config templates (one database per file, so `monitor export --job` isolates
+# the run cleanly — mirrors the per-suite pattern in scripts/e2e.sh).
+# ---------------------------------------------------------------------------
+write_backup_config() {
+  local path="$1" engine="$2" job="$3" outfile="$4" incremental="$5"
+  local inc_block=""
+  if [[ "$incremental" == true ]]; then
+    case "$engine" in
+      postgres) inc_block=$'    incremental_backup:\n      enabled: true\n      wal_summary_check: true\n' ;;
+      mysql|mariadb) inc_block=$'    incremental_backup:\n      enabled: true\n      binlog_check: true\n    mysql:\n      binlog_path: /workspace/binlogs\n' ;;
+    esac
+  fi
+
+  case "$engine" in
+    postgres)
+      cat > "$path" <<EOF
+version: "1.0"
+log_format: text
+history_db_path: /workspace/.sentinel/history.db
+
+defaults:
+  storage:
+    type: local
+    local_path: /workspace/backups
+
+databases:
+  $job:
+    type: postgres
+    host: pgsql
+    port: 5432
+    username: sentinel
+    password_env: DEV_POSTGRES_PASSWORD
+    database: sentinel
+    output: $outfile
+$inc_block
+EOF
+      ;;
+    mysql|mariadb)
+      local host="mysql"
+      [[ "$engine" == "mariadb" ]] && host="mariadb"
+      cat > "$path" <<EOF
+version: "1.0"
+log_format: text
+history_db_path: /workspace/.sentinel/history.db
+
+defaults:
+  storage:
+    type: local
+    local_path: /workspace/backups
+
+databases:
+  $job:
+    type: $engine
+    host: $host
+    port: 3306
+    username: sentinel
+    password_env: DEV_$(upper "$engine")_PASSWORD
+    database: sentinel
+    output: $outfile
+$inc_block
+EOF
+      ;;
+    mongo)
+      cat > "$path" <<EOF
+version: "1.0"
+log_format: text
+history_db_path: /workspace/.sentinel/history.db
+
+defaults:
+  storage:
+    type: local
+    local_path: /workspace/backups
+
+databases:
+  $job:
+    type: mongodb
+    uri: "mongodb://mongo:27017"
+    database: sentinel
+    output: $outfile
+    # Local mongo backups default to mongodump's directory mode (--out=);
+    # Sentinel's mongo RESTORE path always invokes mongorestore --archive=
+    # (internal/adapters/restore/mongo/mongo_restore.go), so a local backup
+    # is only restorable if it was captured in single-file archive mode.
+    database_options:
+      archive: true
+EOF
+      ;;
+  esac
+}
+
+write_restore_config() {
+  local path="$1" engine="$2" backup_job="$3" restore_job="$4" outfile="$5" restore_db="$6"
+  case "$engine" in
+    postgres)
+      cat > "$path" <<EOF
+version: "1.0"
+log_format: text
+history_db_path: /workspace/.sentinel/history.db
+
+defaults:
+  storage:
+    type: local
+    local_path: /workspace/backups
+
+databases:
+  $backup_job:
+    type: postgres
+    host: pgsql
+    port: 5432
+    username: sentinel
+    password_env: DEV_POSTGRES_PASSWORD
+    database: sentinel
+    output: $outfile
+
+restores:
+  $restore_job:
+    enabled: true
+    schedule: "0 3 * * *"
+    type: postgres
+    host: pgsql
+    port: 5432
+    username: sentinel
+    password_env: DEV_POSTGRES_PASSWORD
+    database: $restore_db
+    staging_dir: /workspace/staging
+    backup_source:
+      type: local
+      local_path: /workspace/backups
+      backup_path: $outfile
+EOF
+      ;;
+    mysql|mariadb)
+      local host="mysql"
+      [[ "$engine" == "mariadb" ]] && host="mariadb"
+      cat > "$path" <<EOF
+version: "1.0"
+log_format: text
+history_db_path: /workspace/.sentinel/history.db
+
+defaults:
+  storage:
+    type: local
+    local_path: /workspace/backups
+
+databases:
+  $backup_job:
+    type: $engine
+    host: $host
+    port: 3306
+    username: sentinel
+    password_env: DEV_$(upper "$engine")_PASSWORD
+    database: sentinel
+    output: $outfile
+
+restores:
+  $restore_job:
+    enabled: true
+    schedule: "0 3 * * *"
+    type: $engine
+    host: $host
+    port: 3306
+    username: sentinel
+    password_env: DEV_$(upper "$engine")_PASSWORD
+    database: $restore_db
+    staging_dir: /workspace/staging
+    restore_options:
+      additional_args: "--skip-ssl"
+    backup_source:
+      type: local
+      local_path: /workspace/backups
+      backup_path: $outfile
+EOF
+      ;;
+    mongo)
+      cat > "$path" <<EOF
+version: "1.0"
+log_format: text
+history_db_path: /workspace/.sentinel/history.db
+
+defaults:
+  storage:
+    type: local
+    local_path: /workspace/backups
+
+databases:
+  $backup_job:
+    type: mongodb
+    uri: "mongodb://mongo:27017"
+    database: sentinel
+    output: $outfile
+
+restores:
+  $restore_job:
+    enabled: true
+    schedule: "0 3 * * *"
+    type: mongodb
+    uri: "mongodb://mongo:27017"
+    database: $restore_db
+    staging_dir: /workspace/staging
+    backup_source:
+      type: local
+      local_path: /workspace/backups
+      backup_path: $outfile
+EOF
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Metrics extraction
+# ---------------------------------------------------------------------------
+extract_peak_rss_mb() {
+  # GNU time -v: "Maximum resident set size (kbytes): NNN"
+  local kb
+  kb="$(grep -oE 'Maximum resident set size \(kbytes\): [0-9]+' <<<"$1" | grep -oE '[0-9]+$' || true)"
+  if [[ -n "$kb" ]]; then awk -v k="$kb" 'BEGIN{printf "%.1f", k/1024}'; else echo "n/a"; fi
+}
+
+extract_cpu_pct() {
+  # GNU time -v: "Percent of CPU this job got: NN%"
+  grep -oE 'Percent of CPU this job got: [0-9]+' <<<"$1" | grep -oE '[0-9]+$' || echo "n/a"
+}
+
+# Restore executions are recorded in the monitor's separate
+# `restore_executions` table (`sentinel restore history`, text-only, no
+# --format json/csv), not the `executions` table `monitor export` reads from
+# — so restore wall-clock is read from the same `time -v` wrapper already
+# used for peak RSS/CPU, rather than the monitor. Handles both time(1)
+# variants seen in practice: GNU coreutils "h:mm:ss.cc" / "m:ss.cc", and the
+# Alpine `time` package's "Xm Y.YYs".
+extract_elapsed_ms() {
+  local line
+  line="$(grep -oE 'Elapsed \(wall clock\) time \(h:mm:ss or m:ss\): [0-9:. ms]+' <<<"$1" | sed -E 's/.*\): //')"
+  [[ -n "$line" ]] || { echo "n/a"; return; }
+  if [[ "$line" =~ ^([0-9]+)m[[:space:]]+([0-9.]+)s$ ]]; then
+    awk -v m="${BASH_REMATCH[1]}" -v s="${BASH_REMATCH[2]}" 'BEGIN{printf "%.0f", (m*60+s)*1000}'
+  elif [[ "$line" =~ ^([0-9]+):([0-9]+):([0-9.]+)$ ]]; then
+    awk -v h="${BASH_REMATCH[1]}" -v m="${BASH_REMATCH[2]}" -v s="${BASH_REMATCH[3]}" 'BEGIN{printf "%.0f", (h*3600+m*60+s)*1000}'
+  elif [[ "$line" =~ ^([0-9]+):([0-9.]+)$ ]]; then
+    awk -v m="${BASH_REMATCH[1]}" -v s="${BASH_REMATCH[2]}" 'BEGIN{printf "%.0f", (m*60+s)*1000}'
+  else
+    echo "n/a"
+  fi
+}
+
+# Reads duration_ms + file_size_bytes for the most recent execution of `job`
+# from `sentinel monitor export --format csv --job <job>` (columns per
+# internal/adapters/monitor/export.go: id,backup_name,database_type,
+# timestamp,duration_ms,status,error_message,storage_backend,file_path,
+# file_size_bytes,checksum,backup_type,chain_id,chain_index,
+# delta_size_bytes,full_backup_size_bytes,created_at).
+#
+# NOTE: `sentinel monitor export` (no --output) prints its data via Cobra's
+# cmd.Println, which Cobra sends to OutOrStderr() — i.e. this CLI writes
+# export data to STDERR, not stdout (verified empirically; a pre-existing
+# CLI quirk, out of scope to change here). So we capture combined
+# stdout+stderr and pick the last well-formed CSV row rather than relying on
+# stdout alone.
+read_monitor_metrics() {
+  local job="$1" config_rel="$2"
+  local csv
+  csv="$(sentinel_run monitor export --config "$config_rel" --format csv --job "$job" 2>&1)"
+  # last data row (most recent execution), field 5 = duration_ms, field 10 = file_size_bytes
+  local last_row
+  last_row="$(echo "$csv" | grep -E '^[0-9a-f-]{36},' | tail -1)"
+  if [[ -z "$last_row" ]]; then
+    echo "n/a n/a"
+    return
+  fi
+  awk -F',' '{print $5, $10}' <<<"$last_row"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario runner
+# ---------------------------------------------------------------------------
+run_engine() {
+  local engine="$1"
+  local seed_ext="sql"
+  [[ "$engine" == "mongo" ]] && seed_ext="jsonl"
+  local seed_path="$DATASET_DIR/${engine}-${TIER}.${seed_ext}"
+  local tag="${engine}-${TIER}"
+
+  log "=== engine=$engine tier=$TIER size=${SIZE_MB}MB ==="
+
+  "$DATASET_GEN" --engine "$engine" --size-mb "$SIZE_MB" --out "$seed_path" || {
+    err "$engine: dataset generation failed"
+    record_result "$engine" "$SIZE_MB" "backup-full" "error" n/a n/a n/a n/a n/a "dataset generation failed"
+    return
+  }
+
+  if ! load_dataset "$engine" "$seed_path"; then
+    err "$engine: dataset load failed (is the DB service up? see --skip-infra)"
+    record_result "$engine" "$SIZE_MB" "backup-full" "error" n/a n/a n/a n/a n/a "dataset load failed"
+    return
+  fi
+
+  # --- backup full ---
+  local out_full="${tag}.sql"
+  [[ "$engine" == "mongo" ]] && out_full="${tag}.archive"
+  local cfg_full="$CONFIGS_DIR/${tag}-backup-full.yaml"
+  write_backup_config "$cfg_full" "$engine" "${tag}-full" "$out_full" false
+
+  local t_out
+  t_out="$(sentinel_timed backup --config "/configs/$(basename "$cfg_full")")"
+  local rc=$?
+  local peak cpu dur size
+  peak="$(extract_peak_rss_mb "$t_out")"
+  cpu="$(extract_cpu_pct "$t_out")"
+  read -r dur size < <(read_monitor_metrics "${tag}-full" "/configs/$(basename "$cfg_full")")
+
+  if [[ $rc -eq 0 && "$dur" != "n/a" ]]; then
+    record_result "$engine" "$SIZE_MB" "backup-full" "ok" "$dur" "$peak" "$cpu" "$size" "n/a" ""
+    ok_backup_full=true
+  else
+    warn "$engine: backup-full did not complete cleanly (rc=$rc)"
+    echo "$t_out" | tail -20 | sed 's/^/    /'
+    record_result "$engine" "$SIZE_MB" "backup-full" "error" n/a "$peak" "$cpu" n/a n/a "backup command failed, see harness log"
+    ok_backup_full=false
+  fi
+
+  # --- backup full, with pipeline compression enabled (PRD 33) — used to
+  # derive a compression ratio generically across all four engines, since
+  # spec-049 pipeline compression is engine-agnostic. ---
+  if [[ "$ok_backup_full" == true ]]; then
+    local out_comp="${tag}-zstd.sql"
+    [[ "$engine" == "mongo" ]] && out_comp="${tag}-zstd.archive"
+    local cfg_comp="$CONFIGS_DIR/${tag}-backup-compressed.yaml"
+    write_backup_config "$cfg_comp" "$engine" "${tag}-comp" "$out_comp" false
+    # append compression block
+    printf '    compression:\n      enabled: true\n      algorithm: zstd\n' >> "$cfg_comp"
+
+    local c_out
+    c_out="$(sentinel_timed backup --config "/configs/$(basename "$cfg_comp")")"
+    local crc=$?
+    local cdur csize
+    read -r cdur csize < <(read_monitor_metrics "${tag}-comp" "/configs/$(basename "$cfg_comp")")
+    if [[ $crc -eq 0 && "$csize" != "n/a" && "$size" != "n/a" && "$csize" -gt 0 ]]; then
+      local ratio
+      ratio="$(awk -v a="$size" -v b="$csize" 'BEGIN{printf "%.2fx", a/b}')"
+      record_result "$engine" "$SIZE_MB" "backup-full-compressed" "ok" "$cdur" "n/a" "n/a" "$csize" "$ratio" "ratio = uncompressed_artifact/compressed_artifact"
+    else
+      record_result "$engine" "$SIZE_MB" "backup-full-compressed" "error" n/a n/a n/a n/a n/a "compressed backup failed or produced empty artifact"
+    fi
+  fi
+
+  # --- backup incremental (best-effort, --with-incremental only) ---
+  if [[ "$WITH_INCREMENTAL" == true ]]; then
+    local can_incremental=false
+    local skip_reason=""
+    case "$engine" in
+      postgres)
+        if postgres_wal_summary_enabled; then can_incremental=true
+        else skip_reason="wal_summary is off on the pgsql service (needs summarize_wal=on in postgresql.conf, PG17+); not enabled by infra/docker/docker-compose.yml by default"
+        fi
+        ;;
+      mysql)
+        if mysql_log_bin_enabled mysql; then can_incremental=true
+        else skip_reason="log_bin is off on the mysql service; not enabled by infra/docker/docker-compose.yml by default (needs --log-bin server arg + a locally-mounted binlog_path)"
+        fi
+        ;;
+      mariadb)
+        if mysql_log_bin_enabled mariadb; then can_incremental=true
+        else skip_reason="log_bin is off on the mariadb service; not enabled by infra/docker/docker-compose.yml by default (needs --log-bin server arg + a locally-mounted binlog_path)"
+        fi
+        ;;
+      mongo)
+        skip_reason="mongo service is a standalone node (no replica set); oplog-based incremental backup requires a replica set (ValidateMongoIncrementalPrerequisites)"
+        ;;
+    esac
+
+    if [[ "$can_incremental" == true ]]; then
+      local out_inc="${tag}-inc.sql"
+      local cfg_inc="$CONFIGS_DIR/${tag}-backup-incremental.yaml"
+      write_backup_config "$cfg_inc" "$engine" "${tag}-inc" "$out_inc" true
+      local i_out
+      i_out="$(sentinel_timed backup --config "/configs/$(basename "$cfg_inc")")"
+      local irc=$?
+      local idur isize
+      read -r idur isize < <(read_monitor_metrics "${tag}-inc" "/configs/$(basename "$cfg_inc")")
+      if [[ $irc -eq 0 && "$idur" != "n/a" ]]; then
+        record_result "$engine" "$SIZE_MB" "backup-incremental" "ok" "$idur" "n/a" "n/a" "$isize" "n/a" ""
+      else
+        record_result "$engine" "$SIZE_MB" "backup-incremental" "error" n/a n/a n/a n/a n/a "prerequisites reported enabled but the run failed; see harness log"
+      fi
+    else
+      warn "$engine: skipping backup-incremental — $skip_reason"
+      record_result "$engine" "$SIZE_MB" "backup-incremental" "skipped" n/a n/a n/a n/a n/a "$skip_reason"
+    fi
+  fi
+
+  # --- restore full ---
+  if [[ "$ok_backup_full" == true ]]; then
+    local restore_db="sentinel_bench_restore"
+    prepare_restore_target "$engine" "$restore_db"
+    local cfg_restore="$CONFIGS_DIR/${tag}-restore-full.yaml"
+    write_restore_config "$cfg_restore" "$engine" "${tag}-full" "${tag}-restore" "$out_full" "$restore_db"
+
+    local r_out
+    r_out="$(sentinel_timed restore run "${tag}-restore" --config "/configs/$(basename "$cfg_restore")")"
+    local rrc=$?
+    local rpeak rcpu
+    rpeak="$(extract_peak_rss_mb "$r_out")"
+    rcpu="$(extract_cpu_pct "$r_out")"
+    # restore_executions has no CSV/JSON export (sentinel restore history is
+    # text-only) — wall-clock comes from the same time -v wrapper instead.
+    local rdur="$(extract_elapsed_ms "$r_out")" rsize="n/a"
+
+    if [[ $rrc -eq 0 ]]; then
+      record_result "$engine" "$SIZE_MB" "restore-full" "ok" "${rdur:-n/a}" "$rpeak" "$rcpu" "${rsize:-n/a}" "n/a" "duration measured via time -v (restore_executions has no CSV export)"
+    else
+      warn "$engine: restore-full did not complete cleanly (rc=$rrc)"
+      echo "$r_out" | tail -20 | sed 's/^/    /'
+      local rnote="restore command failed, see harness log"
+      if grep -q 'mongosh.*not found' <<<"$r_out"; then
+        rnote="mongo restore preflight requires 'mongosh' in the runtime image; Alpine (sentinel-dev:local's base) has no mongosh package — add it to Dockerfile.dev (e.g. a Debian-based variant, or the mongosh tarball) to exercise this scenario"
+      fi
+      record_result "$engine" "$SIZE_MB" "restore-full" "error" n/a "$rpeak" "$rcpu" n/a n/a "$rnote"
+    fi
+  else
+    record_result "$engine" "$SIZE_MB" "restore-full" "skipped" n/a n/a n/a n/a n/a "backup-full did not succeed"
+  fi
+
+  # --- restore PITR (postgres) / restore incremental (mysql/mariadb) ---
+  if [[ "$WITH_INCREMENTAL" == true ]]; then
+    case "$engine" in
+      postgres)
+        record_result "$engine" "$SIZE_MB" "restore-pitr" "skipped" n/a n/a n/a n/a n/a \
+          "requires continuous WAL archiving (archive_mode=on + archive_command) on the pgsql service, beyond generic docker-compose infra; operator-run only"
+        ;;
+      mysql|mariadb)
+        record_result "$engine" "$SIZE_MB" "restore-pitr" "skipped" n/a n/a n/a n/a n/a \
+          "requires archived binlog artifacts (mysql.binlog_path) + log_bin enabled on the server, beyond generic docker-compose infra; operator-run only"
+        ;;
+      mongo)
+        record_result "$engine" "$SIZE_MB" "restore-pitr" "skipped" n/a n/a n/a n/a n/a \
+          "requires a replica set for oplog replay; standalone mongo service does not support it; operator-run only"
+        ;;
+    esac
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+init_results
+ensure_infra
+ensure_image
+
+for e in "${ENGINES[@]}"; do
+  run_engine "$e"
+done
+
+log "results written to:"
+log "  $RESULTS_CSV"
+log "  $RESULTS_JSON"
+log "  $RESULTS_MD"
+cat "$RESULTS_MD"
+
+if [[ "$KEEP" == false && "$SKIP_INFRA" == false ]]; then
+  log "tearing down infra (pass --keep to leave it running)..."
+  docker compose -f "$INFRA_DIR/docker-compose.yml" down >/dev/null 2>&1 || true
+  docker rm -f "$MONGO_NAME" >/dev/null 2>&1 || true
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
Recovered M2/F-05 roadmap item (spec/PRD 41): a committed, re-runnable benchmark harness + a published `docs/benchmarks/` matrix, so a DBA evaluating Sentinel finds real size/wall-clock/RAM numbers in <30s. Near-zero product-code change — docs + harness + fixtures only.

## Deliverables
- `scripts/benchmark.sh` — harness reusing the `infra/docker` DB services + `sentinel monitor export` metrics, `/usr/bin/time -v` wrapper for peak-RAM/CPU, `--tier small|large`, backup (full + incremental) / restore (full + PITR), emits Markdown + JSON/CSV.
- `infra/dataset/generate.sh` — deterministic bash+awk generator (no Python/venv; replaces the untracked `.venv` the PRD flagged), byte-identical across runs, size-targeted per engine.
- `docs/benchmarks/README.md` (methodology/index + explicit note distinguishing these real-DB benchmarks from `tests/benchmarks/` Go micro-benchmarks) + `docs/benchmarks/v1.3.0.md` (initial matrix).
- README performance section; `.github/workflows/benchmark.yml` (`workflow_dispatch`-only, report-only — does not touch existing push/PR CI signal); `make bench-small` / `bench-matrix`.

## Numbers are real, not fabricated
Small tier (~1GB/engine) was actually run against real Docker infra. **Measured**: pg/mysql/mariadb backup-full + zstd + restore-full; mongo backup-full + zstd. **Documented-skipped** (each with the real prerequisite reason): all incremental/PITR (stock compose doesn't enable `summarize_wal`/`log_bin`/archiving) + mongo restore (`mongosh` absent from Alpine dev image). **Operator-run/pending**: 10/50GB tiers.

## Honest caveats (footnoted in the matrix, not hidden)
- Peak-RAM ~4.15GB uniform at 1GB and scales ~4× with size (not O(1)) — measured, flagged; native-Linux re-run recommended before treating as final.
- Compression ratios (~370–560×) are real but inflated by the synthetic repetitive payload — flagged so they aren't read as real-world expectations.
- `sentinel monitor export` writes via Cobra `cmd.Println` → stderr (harness captures both streams); `restore_executions` has no CSV/JSON export, so restore wall-clock comes from the harness `time -v` wrapper (documented deviation).

## Decisions (PRD "Recommend" defaults)
Q1 smallest committed reproducible generator (bash/awk); Q2 small tier all engines now, large operator-run; Q3 small tier CI report-only; Q4 publish now (compression PRD 33 shipped); Q5 per-version files + index.

## Green
`go build/vet/test ./...` clean, `golangci-lint run` 0 issues. Release notes intentionally omitted (separate docs PR).