### PR TITLE
fix: windows cross-compile build failures

### DIFF
--- a/internal/adapters/mongo_tls/process_other.go
+++ b/internal/adapters/mongo_tls/process_other.go
@@ -1,0 +1,10 @@
+//go:build !(linux || darwin)
+
+package mongo_tls
+
+// processAlive has no liveness check on non-POSIX targets, so it
+// conservatively reports every pid as alive: SweepOrphanMaterial then never
+// removes material, which is safe (a missed cleanup, not a data-loss risk).
+func processAlive(_ int) bool {
+	return true
+}

--- a/internal/adapters/mongo_tls/process_unix.go
+++ b/internal/adapters/mongo_tls/process_unix.go
@@ -1,0 +1,22 @@
+//go:build linux || darwin
+
+package mongo_tls
+
+import (
+	"errors"
+	"syscall"
+)
+
+// processAlive returns true iff pid is a currently-running process.
+// Uses syscall.Kill(pid, 0): a successful return or EPERM means alive;
+// ESRCH means dead.
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return true
+	}
+	return errors.Is(err, syscall.EPERM)
+}

--- a/internal/adapters/mongo_tls/sweep.go
+++ b/internal/adapters/mongo_tls/sweep.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
-	"syscall"
 )
 
 var materialPIDRegex = regexp.MustCompile(`sentinel-mongo-tls-(\d+)-`)
@@ -59,18 +58,4 @@ func SweepOrphanMaterial(dir string) (int, error) {
 		return removed, errors.Join(errs...)
 	}
 	return removed, nil
-}
-
-// processAlive returns true iff pid is a currently-running process.
-// Uses syscall.Kill(pid, 0): a successful return or EPERM means alive;
-// ESRCH means dead.
-func processAlive(pid int) bool {
-	if pid <= 0 {
-		return false
-	}
-	err := syscall.Kill(pid, 0)
-	if err == nil {
-		return true
-	}
-	return errors.Is(err, syscall.EPERM)
 }

--- a/internal/adapters/restore/runtime/diskspace_other.go
+++ b/internal/adapters/restore/runtime/diskspace_other.go
@@ -1,0 +1,9 @@
+//go:build !(linux || darwin)
+
+package runtime
+
+// availableStagingBytes has no capacity-check support on non-POSIX targets;
+// ok=false tells ensureStagingCapacity to skip the check rather than fail.
+func availableStagingBytes(_ string) (available int64, ok bool, err error) {
+	return 0, false, nil
+}

--- a/internal/adapters/restore/runtime/diskspace_unix.go
+++ b/internal/adapters/restore/runtime/diskspace_unix.go
@@ -1,0 +1,15 @@
+//go:build linux || darwin
+
+package runtime
+
+import "syscall"
+
+// availableStagingBytes reports free space on the filesystem holding dir.
+// ok is always true on POSIX targets.
+func availableStagingBytes(dir string) (available int64, ok bool, err error) {
+	var stats syscall.Statfs_t
+	if statErr := syscall.Statfs(dir, &stats); statErr != nil {
+		return 0, false, statErr
+	}
+	return int64(stats.Bavail) * int64(stats.Bsize), true, nil
+}

--- a/internal/adapters/restore/runtime/staging.go
+++ b/internal/adapters/restore/runtime/staging.go
@@ -16,7 +16,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/denisakp/sentinel/internal/adapters/storage"
@@ -329,11 +328,15 @@ func ensureStagingCapacity(dir string, required int64) error {
 	if required <= 0 {
 		return nil
 	}
-	var stats syscall.Statfs_t
-	if err := syscall.Statfs(dir, &stats); err != nil {
+	available, ok, err := availableStagingBytes(dir)
+	if err != nil {
 		return fmt.Errorf("failed to inspect staging dir capacity: %w", err)
 	}
-	available := int64(stats.Bavail) * int64(stats.Bsize)
+	if !ok {
+		// No capacity-check support on this platform (e.g. Windows) — skip
+		// rather than block the restore on an advisory preflight check.
+		return nil
+	}
 	if available < required {
 		return fmt.Errorf("%w: need=%d available=%d", ErrInsufficientStagingSpace, required, available)
 	}


### PR DESCRIPTION
## Summary
- GoReleaser's first real run (tag v1.3.0, since deleted and about to be recut) failed cross-compiling for windows/amd64 — the target was never actually exercised before this tag existed.
- Fixes two POSIX-only syscalls (`syscall.Kill` in `internal/adapters/mongo_tls`, `syscall.Statfs` in `internal/adapters/restore/runtime`) by splitting into `_unix.go` / `_other.go` build-tagged files, following the existing pattern in `internal/adapters/lock/flock_{unix,other}.go`.
- Both non-POSIX fallbacks degrade gracefully (skip cleanup / skip advisory capacity check) rather than fail to build or block functionality.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` (native, darwin)
- [x] Cross-compiled clean for all 5 GoReleaser targets: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64