### PR TITLE
feat(security): guided envelope re-encryption & key rotation (sentinel security reencrypt)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,5 +1,5 @@
 name: Benchmark (small tier, report-only)
-# PRD 41 — reproducible performance harness. Manual-dispatch only: unlike
+# reproducible performance harness. Manual-dispatch only: unlike
 # lint.yml/integration.yml this job stands up a multi-container DB stack
 # (pg/mysql/mariadb/mongo) and moves ~4GB of generated seed data through
 # real dump/restore tools, which is a meaningfully heavier and slower job

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: '1.24'
       - name: Cache Go modules

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.24'
       - uses: golangci/golangci-lint-action@v7   # v7 required for golangci-lint v2 (v6 only supports v1)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ jobs:
           # GoReleaser needs full history + tags for changelog/version resolution.
           fetch-depth: 0
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: '1.24'
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: '~> v2'
           args: release --clean

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,5 +113,5 @@ Every new feature MUST run these skills in this exact order — no skipping, no 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/052-scheduled-integrity-check/plan.md`
+`specs/054-envelope-reencryption/plan.md`
 <!-- SPECKIT END -->

--- a/docs/runbooks/recover-legacy-envelope.md
+++ b/docs/runbooks/recover-legacy-envelope.md
@@ -37,13 +37,42 @@ This emits a WARNING line to stderr and a `crypto.legacy_envelope_decrypt` log r
 
 ### Re-encrypt under the current envelope
 
-Treat the recovered plaintext as transient. Immediately:
+**Preferred remediation — re-backup from source.** Treat the recovered plaintext as transient. Immediately:
 
 1. Take a fresh dump from the source DB using the current Sentinel build (writes v2 envelope automatically).
 2. Or, restore the recovered artifact to a scratch DB and re-backup it.
 3. Delete the recovered plaintext.
 
-See [key-rotation](./key-rotation.md) if you also need a new key.
+This is the only remediation that restores the confidentiality guarantee — a fresh ciphertext under the v2 envelope with no nonce-reuse exposure.
+
+### Guided migration when you cannot re-backup from source — `sentinel security reencrypt`
+
+When the source DB state is gone, the PITR window has closed, or the legacy artifact is the only surviving copy, use the guided command to re-wrap it into the v2 envelope so it stops requiring `--allow-legacy-envelope`:
+
+```bash
+# Preview what would migrate (mutates nothing):
+sentinel security reencrypt --all --dry-run --config sentinel.yaml
+
+# Migrate one backup (single id needs no --yes):
+sentinel security reencrypt <backup-id> --config sentinel.yaml
+
+# Migrate all legacy backups (bulk needs --yes; scope with --job / --since):
+sentinel security reencrypt --all --yes --config sentinel.yaml
+```
+
+> ⚠ **Confidentiality limit.** `security reencrypt` migrates the artifact's
+> **format/availability** — it does **NOT** undo the legacy envelope's
+> confidentiality weakness. A pre-v2 ciphertext may already be compromised;
+> re-wrapping the same plaintext cannot change that. Re-backup from source
+> (above) wherever possible. Use `reencrypt` only when you can't, to get off the
+> `--allow-legacy-envelope` dependency. The command prints this caveat on every
+> legacy run.
+
+The command never destroys a recoverable artifact: it writes the new artifact, verifies it (decrypt-back + hash), and only then retires the original (`--keep-original` retains it for a manual cutover). It is idempotent — an already-v2 backup is skipped.
+
+### Rotating the key at the same time
+
+`security reencrypt --mode rotate --new-key-env <VAR>` re-encrypts **current-format** backups under a new master key (compromised/retired key). See [key-rotation](./key-rotation.md). Rotation has no confidentiality caveat — the v2 envelope is sound.
 
 ## Verification
 

--- a/internal/cli/security_reencrypt.go
+++ b/internal/cli/security_reencrypt.go
@@ -1,0 +1,753 @@
+package cli
+
+// `sentinel security reencrypt` — guided envelope re-encryption & key rotation
+// (spec 054 / PRD 43). It re-wraps an encrypted backup into the current v2
+// envelope (legacy-migration mode) or re-encrypts it under a new master key
+// (key-rotation mode) using a write-new → verify → swap pipeline so a
+// recoverable artifact is never lost (FR-005/006/018, SC-003).
+//
+// Pure CLI composition: it reuses encryptBackupFile (backup_factory.go),
+// runtime.PreRestoreVerifyAndDecryptWithOptions (restore pre-flight),
+// manifest_store, monitor, and the storage registry through existing entry
+// points. No new port; no change to the domain backup/restore Executors
+// (FR-015).
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"text/tabwriter"
+	"time"
+
+	"github.com/denisakp/sentinel/internal/adapters/crypto"
+	manifest "github.com/denisakp/sentinel/internal/adapters/manifest_store"
+	"github.com/denisakp/sentinel/internal/adapters/monitor"
+	"github.com/denisakp/sentinel/internal/adapters/restore/runtime"
+	"github.com/denisakp/sentinel/internal/adapters/storage"
+	"github.com/denisakp/sentinel/internal/config"
+	"github.com/denisakp/sentinel/internal/ports"
+	"github.com/spf13/cobra"
+)
+
+// EventReencrypt is the structured slog event name emitted once per successful
+// re-encryption (FR-016, SC-010). It mirrors the log-event audit convention of
+// crypto.EventLegacyEnvelopeDecrypt.
+const EventReencrypt = "security.reencrypt"
+
+// reencryptListLimit bounds the number of executions the `--all` sweep
+// enumerates, mirroring verifyAllListLimit.
+const reencryptListLimit = 100000
+
+// keepOriginalSuffix names the sibling artifact written under --keep-original.
+const keepOriginalSuffix = ".reencrypted"
+
+// Re-encryption outcomes (data-model.md). Any value with the "skipped_" prefix
+// is tallied in the report's "skipped" bucket.
+const (
+	outMigrated            = "migrated"
+	outRotated             = "rotated"
+	outWouldMigrate        = "would_migrate"
+	outWouldRotate         = "would_rotate"
+	outSkippedCurrent      = "skipped_already_current"
+	outSkippedUnencrypted  = "skipped_unencrypted"
+	outSkippedUnmigratable = "skipped_unmigratable"
+	outSkippedLegacyRotate = "skipped_legacy"
+	outFailed              = "failed"
+)
+
+// ReencryptLegacyCaveat is the mandatory confidentiality caveat banner printed
+// before the report in legacy-migration mode (FR-004, SC-005). It MUST NEVER be
+// printed in pure key-rotation mode (the v2 envelope is sound).
+const ReencryptLegacyCaveat = "" +
+	"WARNING: legacy -> v2 migration re-wraps the artifact's FORMAT so it no longer needs\n" +
+	"--allow-legacy-envelope. It does NOT undo the confidentiality weakness of the legacy\n" +
+	"envelope -- a pre-v2 ciphertext may already be compromised. The real remediation is to\n" +
+	"re-run the backup FROM SOURCE where possible. See docs/runbooks/recover-legacy-envelope.md."
+
+// Test seams over the effectful primitives, mirroring newVerifyBackend in
+// backup_verify.go. Tests override these to inject re-encrypt / swap failures
+// (T014) and to fake a backend.
+var (
+	reencryptEncryptFile = encryptBackupFile
+	reencryptRenameFile  = os.Rename
+	newReencryptBackend  = func(p *storage.BackendParams) (ports.StorageBackend, error) {
+		return storage.NewBackend(p)
+	}
+)
+
+// reencryptResult is the per-backup outcome surfaced in the text/json report.
+type reencryptResult struct {
+	BackupID     string `json:"id"`
+	Job          string `json:"job"`
+	Mode         string `json:"mode"`
+	FromEnvelope int    `json:"from_envelope"`
+	ToEnvelope   int    `json:"to_envelope"`
+	Backend      string `json:"backend"`
+	Outcome      string `json:"outcome"`
+	Err          error  `json:"-"`
+}
+
+// MarshalJSON surfaces an operational Err as a string "error" field.
+func (r reencryptResult) MarshalJSON() ([]byte, error) {
+	type alias reencryptResult
+	aux := struct {
+		alias
+		Error string `json:"error,omitempty"`
+	}{alias: alias(r)}
+	if r.Err != nil {
+		aux.Error = r.Err.Error()
+	}
+	return json.Marshal(aux)
+}
+
+// reencryptSummary holds the report tally.
+type reencryptSummary struct {
+	Processed int `json:"processed"`
+	Migrated  int `json:"migrated"`
+	Rotated   int `json:"rotated"`
+	Skipped   int `json:"skipped"`
+	Failed    int `json:"failed"`
+}
+
+// pipelineOpts carries the resolved per-run knobs into reencryptOne.
+type pipelineOpts struct {
+	legacyMode   bool
+	keepOriginal bool
+	newKeyHint   string
+}
+
+var securityReencryptCmd = &cobra.Command{
+	Use:   "reencrypt [backup-id]",
+	Short: "Re-encrypt a backup into the current envelope, or rotate its master key",
+	Long: "Re-wrap an encrypted backup into the current v2 envelope (legacy-migration mode) so it no\n" +
+		"longer needs --allow-legacy-envelope, or re-encrypt it under a new master key (rotation mode).\n" +
+		"Uses write-new -> verify -> swap so a recoverable artifact is never lost. Pass a single\n" +
+		"<backup-id>, or --all to process every recorded successful backup in scope.",
+	Args: cobra.MaximumNArgs(1),
+	RunE: runSecurityReencrypt,
+}
+
+func runSecurityReencrypt(cmd *cobra.Command, args []string) error {
+	all, _ := cmd.Flags().GetBool("all")
+	job, _ := cmd.Flags().GetString("job")
+	sinceStr, _ := cmd.Flags().GetString("since")
+	mode, _ := cmd.Flags().GetString("mode")
+	newKeyEnv, _ := cmd.Flags().GetString("new-key-env")
+	keepOriginal, _ := cmd.Flags().GetBool("keep-original")
+	yes, _ := cmd.Flags().GetBool("yes")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	outputFmt, _ := cmd.Flags().GetString("output")
+
+	hasID := len(args) == 1
+	var backupID string
+	if hasID {
+		backupID = args[0]
+	}
+
+	// --- Validation (exit 4; nothing is mutated) -------------------------
+	// Exactly one of {<backup-id>, --all}.
+	if hasID == all {
+		reencryptPrintError(outputFmt, "provide exactly one of <backup-id> or --all")
+		return fmt.Errorf("reencrypt: %w", ErrVerifyInternal)
+	}
+	if mode != "legacy" && mode != "rotate" {
+		reencryptPrintError(outputFmt, fmt.Sprintf("invalid --mode %q (want 'legacy' or 'rotate')", mode))
+		return fmt.Errorf("reencrypt: %w", ErrVerifyInternal)
+	}
+	if mode == "rotate" && newKeyEnv == "" {
+		reencryptPrintError(outputFmt, "rotate mode requires --new-key-env (the env var holding the new master key)")
+		return fmt.Errorf("reencrypt: %w", ErrVerifyInternal)
+	}
+	// A bulk (--all) mutation requires --yes unless it is a --dry-run (FR-017).
+	if all && !yes && !dryRun {
+		reencryptPrintError(outputFmt,
+			"refusing to re-encrypt every backup without confirmation; re-run with --yes to proceed, or --dry-run to preview")
+		return fmt.Errorf("reencrypt: %w", ErrVerifyInternal)
+	}
+
+	cfgPath, _ := cmd.Flags().GetString("config")
+	if cfgPath == "" {
+		cfgPath = os.ExpandEnv("$HOME/.sentinel/config.yaml")
+	}
+
+	cfg, err := config.LoadConfig(cfgPath)
+	if err != nil {
+		reencryptPrintError(outputFmt, fmt.Sprintf("failed to load config: %v", err))
+		return fmt.Errorf("reencrypt: %w", ErrVerifyInternal)
+	}
+	if outputFmt == "" {
+		outputFmt = cfg.LogFormat
+	}
+	if outputFmt == "" {
+		outputFmt = "text"
+	}
+
+	// The old key must be resolvable to decrypt the source artifacts.
+	if !encryptionConfigured(cfg) {
+		reencryptPrintError(outputFmt,
+			"no encryption key configured (set encryption_key_env or encryption_key_file); nothing to re-encrypt")
+		return fmt.Errorf("reencrypt: %w", ErrVerifyInternal)
+	}
+
+	legacyMode := mode == "legacy"
+
+	// Target config: same key for legacy migration; a shallow clone with
+	// EncryptionKeyEnv overridden when a new key is supplied (rotation, or a
+	// legacy migrate-and-rekey pass). Env-only — never a raw key value (FR-013).
+	targetCfg := cfg
+	if newKeyEnv != "" {
+		clone := *cfg
+		clone.EncryptionKeyEnv = newKeyEnv
+		clone.EncryptionKeyFile = ""
+		targetCfg = &clone
+	}
+	opts := pipelineOpts{
+		legacyMode:   legacyMode,
+		keepOriginal: keepOriginal,
+		newKeyHint:   targetCfg.EncryptionKeyEnv,
+	}
+
+	mon, err := monitor.NewMonitor(cfg.HistoryDBPath)
+	if err != nil {
+		reencryptPrintError(outputFmt, fmt.Sprintf("failed to open history db: %v", err))
+		return fmt.Errorf("reencrypt: %w", ErrVerifyInternal)
+	}
+	defer mon.Close()
+
+	ctx := context.Background()
+
+	execs, err := resolveReencryptExecutions(ctx, mon, hasID, backupID, all, job, sinceStr)
+	if err != nil {
+		reencryptPrintError(outputFmt, err.Error())
+		return fmt.Errorf("reencrypt: %w", ErrVerifyInternal)
+	}
+
+	// Confidentiality caveat: printed before the report in legacy mode only.
+	if legacyMode && outputFmt != "json" {
+		fmt.Fprintln(os.Stderr, ReencryptLegacyCaveat)
+	}
+
+	results := make([]reencryptResult, 0, len(execs))
+	for i := range execs {
+		results = append(results, processOneReencrypt(ctx, cfg, targetCfg, mon, &execs[i], mode, dryRun, opts))
+	}
+
+	if outputFmt == "json" {
+		reencryptPrintJSON(results, legacyMode, dryRun)
+	} else {
+		reencryptPrintText(results, dryRun)
+	}
+
+	// Exit 5 if any backup failed; otherwise 0 (FR-012, SC-006).
+	for _, r := range results {
+		if r.Outcome == outFailed {
+			return fmt.Errorf("reencrypt: %w", ErrVerifyIntegrityFailed)
+		}
+	}
+	return nil
+}
+
+// resolveReencryptExecutions mirrors verify --all enumeration: a single id via
+// GetExecution, or the whole repository via ListExecutions scoped by job and
+// recency.
+func resolveReencryptExecutions(ctx context.Context, mon *monitor.Monitor, hasID bool, backupID string, all bool, job, sinceStr string) ([]ports.Execution, error) {
+	if hasID {
+		exec, err := mon.GetExecution(ctx, backupID)
+		if err != nil || exec == nil {
+			return nil, fmt.Errorf("backup ID %q not found in history (run 'sentinel monitor list' to see available IDs)", backupID)
+		}
+		return []ports.Execution{*exec}, nil
+	}
+
+	filter := &ports.Filter{Status: ports.StatusSuccess}
+	if job != "" {
+		filter.BackupName = job
+	}
+	execs, err := mon.ListExecutions(ctx, filter, reencryptListLimit, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list executions: %v", err)
+	}
+
+	var cutoff time.Time
+	if sinceStr != "" {
+		window, perr := parseSince(sinceStr)
+		if perr != nil {
+			return nil, perr
+		}
+		cutoff = time.Now().UTC().Add(-window)
+	}
+	if cutoff.IsZero() {
+		return execs, nil
+	}
+	filtered := execs[:0]
+	for i := range execs {
+		if execs[i].Timestamp.After(cutoff) {
+			filtered = append(filtered, execs[i])
+		}
+	}
+	return filtered, nil
+}
+
+// processOneReencrypt resolves + classifies one backup, decides the action for
+// the active mode, and (unless dry-run) runs the pipeline. It never returns an
+// error; every outcome is captured in the result so an --all batch continues.
+func processOneReencrypt(ctx context.Context, cfg, targetCfg *config.Configuration, rec ports.Recorder, exec *ports.Execution, mode string, dryRun bool, opts pipelineOpts) reencryptResult {
+	res := reencryptResult{
+		BackupID: exec.ID,
+		Job:      exec.BackupName,
+		Mode:     mode,
+		Backend:  exec.StorageBackend,
+	}
+
+	ref, err := resolveArtifact(cfg, exec)
+	if err != nil {
+		res.Outcome = outFailed
+		res.Err = err
+		return res
+	}
+
+	m, mErr := loadReencryptManifest(ctx, ref)
+	if mErr != nil && !errors.Is(mErr, ports.ErrNoManifest) {
+		res.Outcome = outFailed
+		res.Err = fmt.Errorf("read manifest: %w", mErr)
+		return res
+	}
+
+	class := classifyManifest(m, mErr)
+	res.FromEnvelope = envelopeVersionOf(m, class)
+	res.ToEnvelope = res.FromEnvelope
+
+	// Decide the action for the active mode.
+	eligible := false
+	switch class {
+	case classUnmigratable:
+		res.Outcome = outSkippedUnmigratable
+	case classUnencrypted:
+		res.Outcome = outSkippedUnencrypted
+	case classCurrent:
+		if opts.legacyMode {
+			res.Outcome = outSkippedCurrent // idempotent (FR-007)
+		} else {
+			eligible = true // rotate a current artifact
+		}
+	case classLegacy:
+		if opts.legacyMode {
+			eligible = true // migrate legacy -> v2
+		} else {
+			res.Outcome = outSkippedLegacyRotate // rotate targets current-format
+		}
+	}
+
+	if !eligible {
+		return res
+	}
+
+	res.ToEnvelope = 2
+
+	if dryRun {
+		// Preview only — stop before any staging/mutation (I2, SC-004).
+		if opts.legacyMode {
+			res.Outcome = outWouldMigrate
+		} else {
+			res.Outcome = outWouldRotate
+		}
+		return res
+	}
+
+	if err := reencryptOne(ctx, cfg, targetCfg, rec, ref, m, opts); err != nil {
+		res.Outcome = outFailed
+		res.ToEnvelope = res.FromEnvelope
+		res.Err = err
+		return res
+	}
+
+	if opts.legacyMode {
+		res.Outcome = outMigrated
+	} else {
+		res.Outcome = outRotated
+	}
+
+	// Audit: exactly one structured event per successful re-encryption
+	// (FR-016, SC-010).
+	slog.InfoContext(ctx, EventReencrypt,
+		"event", EventReencrypt,
+		"backup_id", exec.ID,
+		"job", exec.BackupName,
+		"mode", mode,
+		"from_envelope", res.FromEnvelope,
+		"to_envelope", res.ToEnvelope,
+		"backend", exec.StorageBackend,
+		"keep_original", opts.keepOriginal,
+		"outcome", res.Outcome,
+	)
+	return res
+}
+
+// reencryptOne runs the safety-critical write-new -> verify -> swap pipeline for
+// a single classified-eligible backup (contracts/reencrypt-pipeline.md steps
+// 1-9). It returns nil on success; on any error the original artifact is left
+// intact and restorable (SC-003).
+func reencryptOne(ctx context.Context, cfg, targetCfg *config.Configuration, rec ports.Recorder, ref *artifactRef, m *ports.BackupManifest, opts pipelineOpts) error {
+	// Scratch dir for the staged source (remote) and re-verify download. The
+	// new-artifact temp lives in the destination directory for local backups so
+	// the final swap is an atomic same-filesystem os.Rename.
+	scratch, err := os.MkdirTemp("", "sentinel-reencrypt-*")
+	if err != nil {
+		return fmt.Errorf("create scratch dir: %w", err)
+	}
+	defer os.RemoveAll(scratch)
+
+	// 1. Stage the source to a local, readable path. Local backups are read in
+	//    place (no copy) so the original is untouched.
+	sourcePath := ref.localArtifactPath
+	if ref.remote {
+		sourcePath = filepath.Join(scratch, "source")
+		if err := ref.backend.Download(ctx, ref.object, sourcePath); err != nil {
+			return fmt.Errorf("stage source: %w", err)
+		}
+	}
+
+	// 2. Decrypt the source (old key; AllowLegacy in legacy mode) and stream the
+	//    plaintext into a temp in the destination directory, hashing as we go.
+	oldKP := &crypto.FileKeyProvider{EnvVar: cfg.EncryptionKeyEnv, FilePath: cfg.EncryptionKeyFile}
+	plainReader, err := runtime.PreRestoreVerifyAndDecryptWithOptions(ctx, m, sourcePath, oldKP,
+		ports.DecryptOptions{AllowLegacy: opts.legacyMode, BackupID: m.BackupID, Source: sourcePath})
+	if err != nil {
+		return fmt.Errorf("decrypt source: %w", err)
+	}
+
+	workDir := scratch
+	if !ref.remote {
+		workDir = filepath.Dir(ref.localArtifactPath)
+	}
+	tmpFile, err := os.CreateTemp(workDir, "sentinel-reencrypt-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create work temp: %w", err)
+	}
+	artifactTemp := tmpFile.Name()
+	manifestTemp := artifactTemp + ".manifest.json"
+	defer func() {
+		_ = os.Remove(artifactTemp)
+		_ = os.Remove(manifestTemp)
+	}()
+
+	plainHasher := crypto.NewHashingWriter(tmpFile)
+	if _, err := io.Copy(plainHasher, plainReader); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("stage plaintext: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("close plaintext temp: %w", err)
+	}
+	plaintextHash := plainHasher.Sum()
+
+	// 3. Re-encrypt in place (fresh v2 envelope, target key). artifactTemp now
+	//    holds ciphertext; encHash is the SHA-256 of the encrypted bytes.
+	_, encInfo, encHash, err := reencryptEncryptFile(targetCfg, artifactTemp, m.BackupID)
+	if err != nil {
+		return fmt.Errorf("re-encrypt: %w", err)
+	}
+
+	// 4. Build the new manifest (fresh EncryptionInfo, recomputed Hash).
+	newM := *m
+	newM.Encryption = encInfo
+	newM.Hash = ports.HashInfo{Algorithm: "sha256", Value: encHash, PlaintextValue: plaintextHash}
+	if fi, statErr := os.Stat(artifactTemp); statErr == nil {
+		newM.SizeBytes = fi.Size()
+	}
+
+	// 5. LOCAL VERIFY before any storage mutation: hash-check + decrypt-back the
+	//    new temp with the target key and confirm the plaintext round-trips.
+	targetKP := &crypto.FileKeyProvider{EnvVar: targetCfg.EncryptionKeyEnv, FilePath: targetCfg.EncryptionKeyFile}
+	verifyReader, err := runtime.PreRestoreVerifyAndDecryptWithOptions(ctx, &newM, artifactTemp, targetKP,
+		ports.DecryptOptions{BackupID: m.BackupID, Source: artifactTemp})
+	if err != nil {
+		return fmt.Errorf("verify new artifact: %w", err)
+	}
+	roundTripHasher := crypto.NewHashingWriter(io.Discard)
+	if _, err := io.Copy(roundTripHasher, verifyReader); err != nil {
+		return fmt.Errorf("verify new artifact (decrypt-back): %w", err)
+	}
+	if roundTripHasher.Sum() != plaintextHash {
+		return fmt.Errorf("verify new artifact: plaintext hash mismatch after re-encrypt")
+	}
+
+	// 6. Persist the new manifest to a temp beside the artifact.
+	if err := manifest.WriteManifest(manifestTemp, &newM); err != nil {
+		return fmt.Errorf("write manifest: %w", err)
+	}
+
+	// 7. Swap at the original path (or a sibling under --keep-original). Nothing
+	//    in storage has been mutated before this point (SC-003).
+	newManifestRef, err := swapArtifact(ctx, ref, artifactTemp, manifestTemp, encHash, opts.keepOriginal, scratch)
+	if err != nil {
+		return err
+	}
+
+	// 8. Update the monitor row so future verify/restore see the new
+	//    hash/manifest (FR-010). Under --keep-original the new artifact went to a
+	//    sibling path and the original row still describes the untouched
+	//    original, so the row is left alone (manual cutover).
+	if !opts.keepOriginal {
+		if err := rec.RecordSecurityInfo(ctx, ref.exec.ID, "sha256", encHash, plaintextHash, newManifestRef, true, opts.newKeyHint); err != nil {
+			return fmt.Errorf("record security info: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// swapArtifact performs the path-preserving swap (research D3). It returns the
+// new manifest reference (local path or remote object key) for the monitor row.
+func swapArtifact(ctx context.Context, ref *artifactRef, artifactTemp, manifestTemp, encHash string, keepOriginal bool, scratch string) (string, error) {
+	if ref.remote {
+		destObject := ref.object
+		if keepOriginal {
+			destObject = ref.object + keepOriginalSuffix
+		}
+		destManifestObject := destObject + ".manifest.json"
+
+		// Overwrite happens only after the local verify above. The verified
+		// local temp is retained (in scratch/workDir, removed by the caller's
+		// defer) until the stored object re-verifies, so an interrupted upload
+		// is recoverable by re-running.
+		if err := ref.backend.Upload(ctx, artifactTemp, destObject); err != nil {
+			return "", fmt.Errorf("swap upload artifact: %w", err)
+		}
+		reDL := filepath.Join(scratch, "reverify")
+		if err := ref.backend.Download(ctx, destObject, reDL); err != nil {
+			return "", fmt.Errorf("swap re-verify download: %w", err)
+		}
+		reHash, err := verifyComputeFileHash(reDL)
+		if err != nil {
+			return "", fmt.Errorf("swap re-verify hash: %w", err)
+		}
+		if reHash != encHash {
+			return "", fmt.Errorf("swap re-verify: stored object hash mismatch (stored=%s want=%s)", reHash, encHash)
+		}
+		if err := ref.backend.Upload(ctx, manifestTemp, destManifestObject); err != nil {
+			return "", fmt.Errorf("swap upload manifest: %w", err)
+		}
+		return destObject, nil
+	}
+
+	// Local: atomic os.Rename over the original (or to a sibling).
+	destArtifact := ref.localArtifactPath
+	if keepOriginal {
+		destArtifact = ref.localArtifactPath + keepOriginalSuffix
+	}
+	destManifest := destArtifact + ".manifest.json"
+
+	if err := reencryptRenameFile(artifactTemp, destArtifact); err != nil {
+		return "", fmt.Errorf("swap artifact: %w", err)
+	}
+	if err := reencryptRenameFile(manifestTemp, destManifest); err != nil {
+		return "", fmt.Errorf("swap manifest: %w", err)
+	}
+	return destManifest, nil
+}
+
+// --- Resolution / classification ------------------------------------------
+
+// artifactRef locates a backup's artifact + manifest on its own storage
+// backend. Local backups reference on-disk paths directly; remote backups carry
+// a constructed backend + object keys.
+type artifactRef struct {
+	exec              *ports.Execution
+	remote            bool
+	localArtifactPath string
+	localManifestPath string
+	backend           ports.StorageBackend
+	object            string
+	manifestObject    string
+}
+
+// resolveArtifact builds an artifactRef for exec, constructing the remote
+// backend + object keys via the verify helpers when needed.
+func resolveArtifact(cfg *config.Configuration, exec *ports.Execution) (*artifactRef, error) {
+	if exec.FilePath == "" {
+		return nil, fmt.Errorf("no artifact path recorded for backup %q", exec.ID)
+	}
+	ref := &artifactRef{exec: exec}
+
+	if !isRemoteStorageBackend(exec.StorageBackend) {
+		ref.localArtifactPath = exec.FilePath
+		ref.localManifestPath = exec.FilePath + ".manifest.json"
+		return ref, nil
+	}
+
+	var storageCfg config.StorageConfig
+	if job, ok := cfg.Databases[exec.BackupName]; ok {
+		storageCfg = job.Storage
+	}
+	params, object, err := verifyBackendParamsAndObject(exec.StorageBackend, exec.FilePath, storageCfg)
+	if err != nil {
+		return nil, err
+	}
+	backend, err := newReencryptBackend(params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize %s backend: %w", exec.StorageBackend, err)
+	}
+	ref.remote = true
+	ref.backend = backend
+	ref.object = object
+	ref.manifestObject = object + ".manifest.json"
+	return ref, nil
+}
+
+// loadReencryptManifest reads the backup's manifest sidecar without reading any
+// artifact bytes (so it is safe for dry-run classification). Returns
+// ports.ErrNoManifest when the sidecar is absent (→ unmigratable).
+func loadReencryptManifest(ctx context.Context, ref *artifactRef) (*ports.BackupManifest, error) {
+	if !ref.remote {
+		return manifest.ReadManifest(ref.localManifestPath)
+	}
+
+	exists, err := ref.backend.Exists(ctx, ref.manifestObject)
+	if err != nil {
+		return nil, fmt.Errorf("check manifest sidecar: %w", err)
+	}
+	if !exists {
+		return nil, ports.ErrNoManifest
+	}
+	tmpDir, err := os.MkdirTemp("", "sentinel-reencrypt-manifest-*")
+	if err != nil {
+		return nil, fmt.Errorf("create manifest temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	local := filepath.Join(tmpDir, "manifest.json")
+	if err := ref.backend.Download(ctx, ref.manifestObject, local); err != nil {
+		return nil, fmt.Errorf("download manifest sidecar: %w", err)
+	}
+	return manifest.ReadManifest(local)
+}
+
+// reencryptClass is the classification of an in-scope backup (data-model.md).
+type reencryptClass int
+
+const (
+	classCurrent reencryptClass = iota
+	classLegacy
+	classUnencrypted
+	classUnmigratable
+)
+
+// classifyManifest maps a (manifest, read-error) pair to a class.
+func classifyManifest(m *ports.BackupManifest, mErr error) reencryptClass {
+	if errors.Is(mErr, ports.ErrNoManifest) {
+		return classUnmigratable
+	}
+	if m == nil || m.Encryption == nil {
+		return classUnencrypted
+	}
+	if m.Encryption.EnvelopeVersion >= 2 {
+		return classCurrent
+	}
+	return classLegacy
+}
+
+// envelopeVersionOf reports the source envelope version for the report. A
+// legacy artifact (no/old version marker) is surfaced as v1; unencrypted /
+// unmigratable have no envelope (0).
+func envelopeVersionOf(m *ports.BackupManifest, class reencryptClass) int {
+	switch class {
+	case classCurrent:
+		return 2
+	case classLegacy:
+		if m != nil && m.Encryption != nil && m.Encryption.EnvelopeVersion > 0 {
+			return m.Encryption.EnvelopeVersion
+		}
+		return 1
+	default:
+		return 0
+	}
+}
+
+// --- Report ----------------------------------------------------------------
+
+func summarizeReencrypt(results []reencryptResult) reencryptSummary {
+	s := reencryptSummary{Processed: len(results)}
+	for _, r := range results {
+		switch r.Outcome {
+		case outMigrated, outWouldMigrate:
+			s.Migrated++
+		case outRotated, outWouldRotate:
+			s.Rotated++
+		case outFailed:
+			s.Failed++
+		default: // skipped_*
+			s.Skipped++
+		}
+	}
+	return s
+}
+
+func envelopeTransition(r reencryptResult) string {
+	if r.FromEnvelope == 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("v%d->v%d", r.FromEnvelope, r.ToEnvelope)
+}
+
+func reencryptPrintText(results []reencryptResult, dryRun bool) {
+	if dryRun {
+		fmt.Println("DRY RUN — no artifacts or metadata were modified")
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tJOB\tMODE\tFROM->TO\tOUTCOME")
+	for _, r := range results {
+		outcome := r.Outcome
+		if r.Err != nil {
+			outcome = fmt.Sprintf("%s (%v)", r.Outcome, r.Err)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", r.BackupID, r.Job, r.Mode, envelopeTransition(r), outcome)
+	}
+	_ = w.Flush()
+
+	s := summarizeReencrypt(results)
+	fmt.Printf("%d processed · %d migrated · %d rotated · %d skipped · %d failed\n",
+		s.Processed, s.Migrated, s.Rotated, s.Skipped, s.Failed)
+}
+
+func reencryptPrintJSON(results []reencryptResult, legacyMode, dryRun bool) {
+	payload := map[string]interface{}{
+		"results": results,
+		"summary": summarizeReencrypt(results),
+		"dry_run": dryRun,
+	}
+	if legacyMode {
+		payload["caveat"] = ReencryptLegacyCaveat
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(payload)
+}
+
+func reencryptPrintError(format, msg string) {
+	if format == "json" {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(map[string]interface{}{"result": "error", "error": msg})
+		return
+	}
+	fmt.Fprintf(os.Stderr, "Error: %s\n", msg)
+}
+
+func init() {
+	SecurityCmd.AddCommand(securityReencryptCmd)
+	securityReencryptCmd.Flags().String("config", "", "Path to sentinel YAML config")
+	securityReencryptCmd.Flags().Bool("all", false, "Re-encrypt every recorded successful backup in scope; mutually exclusive with <backup-id>")
+	securityReencryptCmd.Flags().String("job", "", "With --all: restrict to a single named backup job")
+	securityReencryptCmd.Flags().String("since", "", "With --all: only process backups newer than this age (e.g. 30d, 4w, 720h)")
+	securityReencryptCmd.Flags().String("mode", "legacy", "Re-encryption mode: 'legacy' (v1->v2 migration) or 'rotate' (re-key under --new-key-env)")
+	securityReencryptCmd.Flags().String("new-key-env", "", "Env var holding the new master key (base64, 32 bytes); required in rotate mode (env-only)")
+	securityReencryptCmd.Flags().Bool("keep-original", false, "Write the re-encrypted artifact to a sibling path and leave the original in place (manual cutover)")
+	securityReencryptCmd.Flags().Bool("yes", false, "Confirm a bulk (--all) mutation; not needed for a single <backup-id> or --dry-run")
+	securityReencryptCmd.Flags().Bool("dry-run", false, "Classify and report only; mutate nothing")
+	securityReencryptCmd.Flags().String("output", "", "Output format: text or json")
+}

--- a/internal/cli/security_reencrypt_test.go
+++ b/internal/cli/security_reencrypt_test.go
@@ -1,0 +1,714 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/denisakp/sentinel/internal/adapters/crypto"
+	manifest "github.com/denisakp/sentinel/internal/adapters/manifest_store"
+	"github.com/denisakp/sentinel/internal/adapters/monitor"
+	"github.com/denisakp/sentinel/internal/adapters/restore/runtime"
+	"github.com/denisakp/sentinel/internal/config"
+	"github.com/denisakp/sentinel/internal/ports"
+	"github.com/spf13/cobra"
+	_ "modernc.org/sqlite"
+)
+
+// --- test harness ----------------------------------------------------------
+
+const reencKeyEnv = "SENTINEL_TEST_REENCRYPT_KEY"
+const reencKeyEnvB = "SENTINEL_TEST_REENCRYPT_KEY_B"
+
+// reencFlags configures a runReencrypt invocation.
+type reencFlags struct {
+	all          bool
+	job          string
+	since        string
+	mode         string
+	newKeyEnv    string
+	keepOriginal bool
+	yes          bool
+	dryRun       bool
+	output       string
+	args         []string
+}
+
+// runReencrypt invokes securityReencryptCmd.RunE with the given flags, capturing
+// stdout + stderr. It returns (stdout, stderr, err).
+func runReencrypt(t *testing.T, cfgPath string, f reencFlags) (string, string, error) {
+	t.Helper()
+	cmd := &cobra.Command{Use: "reencrypt-test"}
+	cmd.Flags().String("config", cfgPath, "")
+	cmd.Flags().Bool("all", false, "")
+	cmd.Flags().String("job", "", "")
+	cmd.Flags().String("since", "", "")
+	cmd.Flags().String("mode", "legacy", "")
+	cmd.Flags().String("new-key-env", "", "")
+	cmd.Flags().Bool("keep-original", false, "")
+	cmd.Flags().Bool("yes", false, "")
+	cmd.Flags().Bool("dry-run", false, "")
+	cmd.Flags().String("output", "", "")
+
+	if f.all {
+		_ = cmd.Flags().Set("all", "true")
+	}
+	if f.job != "" {
+		_ = cmd.Flags().Set("job", f.job)
+	}
+	if f.since != "" {
+		_ = cmd.Flags().Set("since", f.since)
+	}
+	if f.mode != "" {
+		_ = cmd.Flags().Set("mode", f.mode)
+	}
+	if f.newKeyEnv != "" {
+		_ = cmd.Flags().Set("new-key-env", f.newKeyEnv)
+	}
+	if f.keepOriginal {
+		_ = cmd.Flags().Set("keep-original", "true")
+	}
+	if f.yes {
+		_ = cmd.Flags().Set("yes", "true")
+	}
+	if f.dryRun {
+		_ = cmd.Flags().Set("dry-run", "true")
+	}
+	if f.output != "" {
+		_ = cmd.Flags().Set("output", f.output)
+	}
+
+	var err error
+	stdout, stderr := captureStdoutStderr(t, func() { err = securityReencryptCmd.RunE(cmd, f.args) })
+	return stdout, stderr, err
+}
+
+// captureStdoutStderr redirects both os.Stdout and os.Stderr for the duration
+// of fn and returns what was written to each.
+func captureStdoutStderr(t *testing.T, fn func()) (string, string) {
+	t.Helper()
+	oldOut, oldErr := os.Stdout, os.Stderr
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout, os.Stderr = wOut, wErr
+
+	outCh, errCh := make(chan string, 1), make(chan string, 1)
+	go func() { var b bytes.Buffer; _, _ = io.Copy(&b, rOut); outCh <- b.String() }()
+	go func() { var b bytes.Buffer; _, _ = io.Copy(&b, rErr); errCh <- b.String() }()
+
+	fn()
+	_ = wOut.Close()
+	_ = wErr.Close()
+	os.Stdout, os.Stderr = oldOut, oldErr
+	return <-outCh, <-errCh
+}
+
+// testMasterKey sets keyEnv to a fresh random base64 32-byte key for the test
+// and returns the raw key bytes.
+func testMasterKey(t *testing.T, keyEnv string) []byte {
+	t.Helper()
+	raw := make([]byte, 32)
+	for i := range raw {
+		raw[i] = byte((i*7 + len(keyEnv)) % 251)
+	}
+	t.Setenv(keyEnv, base64.StdEncoding.EncodeToString(raw))
+	return raw
+}
+
+// readRowSecurity reads the security columns for a backup row directly (they
+// are persisted by RecordSecurityInfo but not projected by GetExecution).
+func readRowSecurity(t *testing.T, historyPath, id string) (string, bool) {
+	t.Helper()
+	db, err := sql.Open("sqlite", historyPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	var hashValue string
+	var encrypted int
+	if err := db.QueryRow(`SELECT hash_value, encrypted FROM backup_executions WHERE id = ?`, id).
+		Scan(&hashValue, &encrypted); err != nil {
+		t.Fatalf("read row security: %v", err)
+	}
+	return hashValue, encrypted == 1
+}
+
+func sha256hex(b []byte) string {
+	s := sha256.Sum256(b)
+	return hex.EncodeToString(s[:])
+}
+
+// writeReencCfg writes a minimal config referencing keyEnv and a local job.
+func writeReencCfg(t *testing.T, dir, historyPath, keyEnv string) string {
+	t.Helper()
+	return writeYAML(t, dir, "history_db_path: "+historyPath+`
+encryption_key_env: `+keyEnv+`
+databases:
+  job1:
+    type: postgres
+    storage:
+      type: local
+`)
+}
+
+// seedLocalExecution records a successful local backup row and returns its id.
+func seedLocalExecution(t *testing.T, historyPath, job, artifactPath string, size int64) string {
+	t.Helper()
+	mon, err := monitor.NewMonitor(historyPath)
+	if err != nil {
+		t.Fatalf("new monitor: %v", err)
+	}
+	defer mon.Close()
+	exec := &ports.Execution{
+		BackupName:     job,
+		DatabaseType:   "postgres",
+		Timestamp:      time.Now().UTC(),
+		Status:         ports.StatusSuccess,
+		StorageBackend: "local",
+		FilePath:       artifactPath,
+		FileSizeBytes:  size,
+	}
+	if err := mon.RecordExecution(context.Background(), exec); err != nil {
+		t.Fatalf("record execution: %v", err)
+	}
+	return exec.ID
+}
+
+// writeV2Backup writes plaintext to path, encrypts it in place under keyEnv
+// (fresh v2 envelope), and writes the manifest sidecar. Returns the manifest
+// backup id (AAD).
+func writeV2Backup(t *testing.T, path, keyEnv string, plaintext []byte, backupID string) {
+	t.Helper()
+	if err := os.WriteFile(path, plaintext, 0o600); err != nil {
+		t.Fatalf("write plaintext: %v", err)
+	}
+	plainHash := sha256hex(plaintext)
+	cfg := &config.Configuration{EncryptionKeyEnv: keyEnv}
+	_, encInfo, encHash, err := encryptBackupFile(cfg, path, backupID)
+	if err != nil {
+		t.Fatalf("encrypt v2 backup: %v", err)
+	}
+	m := &ports.BackupManifest{
+		BackupID:     backupID,
+		Database:     "job1",
+		DatabaseType: "postgres",
+		CreatedAt:    time.Now().UTC(),
+		Hash:         ports.HashInfo{Algorithm: "sha256", Value: encHash, PlaintextValue: plainHash},
+		Encryption:   encInfo,
+	}
+	if err := manifest.WriteManifest(path+".manifest.json", m); err != nil {
+		t.Fatalf("write v2 manifest: %v", err)
+	}
+}
+
+// writeLegacyBackup writes a pre-v2 (legacy, header-stripped) encrypted artifact
+// to path under keyEnv and its manifest (EnvelopeVersion absent). Mirrors the
+// crypto package's writeLegacyV1 test helper.
+func writeLegacyBackup(t *testing.T, path, keyEnv string, plaintext []byte, backupID string) {
+	t.Helper()
+	master := os.Getenv(keyEnv)
+	masterKey, err := base64.StdEncoding.DecodeString(master)
+	if err != nil {
+		t.Fatalf("decode key: %v", err)
+	}
+	salt, err := crypto.GenerateSalt()
+	if err != nil {
+		t.Fatalf("salt: %v", err)
+	}
+	derived := crypto.DeriveKey(masterKey, salt)
+
+	var buf bytes.Buffer
+	enc, err := crypto.NewChunkEncryptWriter(&buf, derived, backupID)
+	if err != nil {
+		t.Fatalf("enc writer: %v", err)
+	}
+	if _, err := enc.Write(plaintext); err != nil {
+		t.Fatalf("enc write: %v", err)
+	}
+	if err := enc.Flush(); err != nil {
+		t.Fatalf("enc flush: %v", err)
+	}
+	baseNonce := enc.BaseNonce()
+	authTag := enc.LastAuthTag()
+
+	full := buf.Bytes()
+	if len(full) < 5 {
+		t.Fatalf("encrypt produced %d bytes", len(full))
+	}
+	legacy := append([]byte{}, full[5:]...) // strip the 5-byte v2 header
+	if err := os.WriteFile(path, legacy, 0o600); err != nil {
+		t.Fatalf("write legacy artifact: %v", err)
+	}
+
+	m := &ports.BackupManifest{
+		BackupID:     backupID,
+		Database:     "job1",
+		DatabaseType: "postgres",
+		CreatedAt:    time.Now().UTC(),
+		Hash:         ports.HashInfo{Algorithm: "sha256", Value: sha256hex(legacy), PlaintextValue: sha256hex(plaintext)},
+		Encryption: &ports.EncryptionInfo{
+			Algorithm:       "AES-256-GCM",
+			KeyDerivation:   "PBKDF2-HMAC-SHA256",
+			Iterations:      100_000,
+			Salt:            base64.StdEncoding.EncodeToString(salt),
+			IV:              hex.EncodeToString(baseNonce),
+			AuthTag:         hex.EncodeToString(authTag),
+			EnvelopeVersion: 0, // legacy: no v2 marker
+		},
+	}
+	if err := manifest.WriteManifest(path+".manifest.json", m); err != nil {
+		t.Fatalf("write legacy manifest: %v", err)
+	}
+}
+
+// decryptArtifact decrypts the artifact at path under keyEnv using its manifest.
+func decryptArtifact(t *testing.T, path, keyEnv string, allowLegacy bool) ([]byte, error) {
+	t.Helper()
+	m, err := manifest.ReadManifest(path + ".manifest.json")
+	if err != nil {
+		return nil, err
+	}
+	kp := &crypto.FileKeyProvider{EnvVar: keyEnv}
+	r, err := runtime.PreRestoreVerifyAndDecryptWithOptions(context.Background(), m, path, kp,
+		ports.DecryptOptions{AllowLegacy: allowLegacy, BackupID: m.BackupID, Source: path})
+	if err != nil {
+		return nil, err
+	}
+	return io.ReadAll(r)
+}
+
+// recordingHandler captures slog records for audit-event assertions.
+type recordingHandler struct {
+	mu   *sync.Mutex
+	msgs *[]string
+}
+
+func (h recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	*h.msgs = append(*h.msgs, r.Message)
+	return nil
+}
+func (h recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h recordingHandler) WithGroup(string) slog.Handler      { return h }
+
+// captureSlog installs a recording slog handler for the test and returns a
+// function yielding the count of EventReencrypt events seen.
+func captureSlog(t *testing.T) func() int {
+	t.Helper()
+	var mu sync.Mutex
+	var msgs []string
+	prev := slog.Default()
+	slog.SetDefault(slog.New(recordingHandler{mu: &mu, msgs: &msgs}))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		n := 0
+		for _, m := range msgs {
+			if m == EventReencrypt {
+				n++
+			}
+		}
+		return n
+	}
+}
+
+// --- T012 / SC-001: legacy -> migrated, verifies under default policy -------
+
+func TestReencrypt_LegacyMigratesAndVerifies(t *testing.T) {
+	keyEnv := reencKeyEnv
+	testMasterKey(t, keyEnv)
+	dir := t.TempDir()
+	historyPath := filepath.Join(dir, "history.db")
+	cfgPath := writeReencCfg(t, dir, historyPath, keyEnv)
+
+	plaintext := []byte("-- legacy dump payload\nSELECT 1;\n")
+	artifact := filepath.Join(dir, "legacy.sql")
+	writeLegacyBackup(t, artifact, keyEnv, plaintext, "job1-legacy")
+	id := seedLocalExecution(t, historyPath, "job1", artifact, int64(0))
+
+	events := captureSlog(t)
+	_, _, err := runReencrypt(t, cfgPath, reencFlags{args: []string{id}, mode: "legacy", output: "text"})
+	if err != nil {
+		t.Fatalf("legacy migrate should succeed, got: %v (code %d)", err, Code(err))
+	}
+
+	// Manifest now advertises the current envelope.
+	m, err := manifest.ReadManifest(artifact + ".manifest.json")
+	if err != nil {
+		t.Fatalf("read migrated manifest: %v", err)
+	}
+	if m.Encryption == nil || m.Encryption.EnvelopeVersion != 2 {
+		t.Fatalf("migrated manifest EnvelopeVersion: want 2, got %+v", m.Encryption)
+	}
+
+	// Decrypts under the DEFAULT policy (no AllowLegacy) and round-trips.
+	got, err := decryptArtifact(t, artifact, keyEnv, false)
+	if err != nil {
+		t.Fatalf("migrated artifact must decrypt under default policy: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("plaintext mismatch after migrate: got %q", got)
+	}
+
+	// Row hash updated to the new artifact hash (FR-010). GetExecution does not
+	// project the security columns, so read them directly.
+	rowHash, rowEncrypted := readRowSecurity(t, historyPath, id)
+	if rowHash != m.Hash.Value {
+		t.Fatalf("row hash not updated: row=%s manifest=%s", rowHash, m.Hash.Value)
+	}
+	if !rowEncrypted {
+		t.Fatalf("row should be marked encrypted")
+	}
+
+	// Exactly one audit event for one success (SC-010).
+	if n := events(); n != 1 {
+		t.Fatalf("want exactly 1 security.reencrypt event, got %d", n)
+	}
+}
+
+// --- T013: idempotency + skip-with-reason ----------------------------------
+
+func TestReencrypt_IdempotentAndSkips(t *testing.T) {
+	keyEnv := reencKeyEnv
+	testMasterKey(t, keyEnv)
+	dir := t.TempDir()
+	historyPath := filepath.Join(dir, "history.db")
+	cfgPath := writeReencCfg(t, dir, historyPath, keyEnv)
+
+	// current (v2), unencrypted (manifest w/o Encryption), unmigratable (no manifest)
+	current := filepath.Join(dir, "current.sql")
+	writeV2Backup(t, current, keyEnv, []byte("current payload"), "job1-current")
+	curID := seedLocalExecution(t, historyPath, "job1", current, 0)
+
+	plainArt := filepath.Join(dir, "plain.sql")
+	if err := os.WriteFile(plainArt, []byte("plain payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pm := &ports.BackupManifest{
+		BackupID: "job1-plain", Database: "job1", DatabaseType: "postgres",
+		Hash: ports.HashInfo{Algorithm: "sha256", Value: sha256hex([]byte("plain payload"))},
+	}
+	if err := manifest.WriteManifest(plainArt+".manifest.json", pm); err != nil {
+		t.Fatal(err)
+	}
+	plainID := seedLocalExecution(t, historyPath, "job1", plainArt, 0)
+
+	noManifest := filepath.Join(dir, "old.sql")
+	if err := os.WriteFile(noManifest, []byte("ancient payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	noManID := seedLocalExecution(t, historyPath, "job1", noManifest, 0)
+
+	beforeCurrent, _ := os.ReadFile(current)
+
+	out, _, err := runReencrypt(t, cfgPath, reencFlags{all: true, yes: true, mode: "legacy", output: "json"})
+	if err != nil {
+		t.Fatalf("legacy sweep over non-legacy set should exit 0, got: %v (code %d)", err, Code(err))
+	}
+
+	var got struct {
+		Results []reencryptResult `json:"results"`
+		Summary reencryptSummary  `json:"summary"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("json parse: %v\n%s", err, out)
+	}
+	byID := map[string]string{}
+	for _, r := range got.Results {
+		byID[r.BackupID] = r.Outcome
+	}
+	if byID[curID] != outSkippedCurrent {
+		t.Errorf("current backup: want %s, got %s", outSkippedCurrent, byID[curID])
+	}
+	if byID[plainID] != outSkippedUnencrypted {
+		t.Errorf("unencrypted backup: want %s, got %s", outSkippedUnencrypted, byID[plainID])
+	}
+	if byID[noManID] != outSkippedUnmigratable {
+		t.Errorf("unmigratable backup: want %s, got %s", outSkippedUnmigratable, byID[noManID])
+	}
+	if got.Summary.Skipped != 3 || got.Summary.Migrated != 0 || got.Summary.Failed != 0 {
+		t.Fatalf("summary: %+v", got.Summary)
+	}
+
+	// The current backup was not mutated (idempotent).
+	afterCurrent, _ := os.ReadFile(current)
+	if !bytes.Equal(beforeCurrent, afterCurrent) {
+		t.Fatalf("current backup must be byte-identical after a legacy no-op run")
+	}
+}
+
+// --- T014 / SC-003: safety on injected failures ----------------------------
+
+func TestReencrypt_SafetyOnFailure(t *testing.T) {
+	cases := []struct {
+		name   string
+		break_ func(t *testing.T)
+	}{
+		{
+			name: "fail_at_reencrypt",
+			break_: func(t *testing.T) {
+				prev := reencryptEncryptFile
+				reencryptEncryptFile = func(_ *config.Configuration, _, _ string) (bool, *ports.EncryptionInfo, string, error) {
+					return false, nil, "", errors.New("injected re-encrypt failure")
+				}
+				t.Cleanup(func() { reencryptEncryptFile = prev })
+			},
+		},
+		{
+			name: "fail_at_swap",
+			break_: func(t *testing.T) {
+				prev := reencryptRenameFile
+				reencryptRenameFile = func(_, _ string) error {
+					return errors.New("injected swap failure")
+				}
+				t.Cleanup(func() { reencryptRenameFile = prev })
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			keyEnv := reencKeyEnv
+			testMasterKey(t, keyEnv)
+			dir := t.TempDir()
+			historyPath := filepath.Join(dir, "history.db")
+			cfgPath := writeReencCfg(t, dir, historyPath, keyEnv)
+
+			plaintext := []byte("-- irreplaceable legacy payload\n")
+			artifact := filepath.Join(dir, "legacy.sql")
+			writeLegacyBackup(t, artifact, keyEnv, plaintext, "job1-legacy")
+			id := seedLocalExecution(t, historyPath, "job1", artifact, 0)
+
+			before, _ := os.ReadFile(artifact)
+			beforeManifest, _ := os.ReadFile(artifact + ".manifest.json")
+
+			tc.break_(t)
+
+			_, _, err := runReencrypt(t, cfgPath, reencFlags{args: []string{id}, mode: "legacy", output: "text"})
+			if !errors.Is(err, ErrVerifyIntegrityFailed) {
+				t.Fatalf("failed re-encrypt should return ErrVerifyIntegrityFailed, got: %v", err)
+			}
+			if Code(err) != 5 {
+				t.Fatalf("failure exit code: want 5, got %d", Code(err))
+			}
+
+			// The original artifact + manifest are byte-for-byte intact.
+			after, _ := os.ReadFile(artifact)
+			afterManifest, _ := os.ReadFile(artifact + ".manifest.json")
+			if !bytes.Equal(before, after) {
+				t.Fatalf("original artifact must be untouched after failure")
+			}
+			if !bytes.Equal(beforeManifest, afterManifest) {
+				t.Fatalf("original manifest must be untouched after failure")
+			}
+
+			// And still decryptable (as legacy, its original form).
+			got, derr := decryptArtifact(t, artifact, keyEnv, true)
+			if derr != nil {
+				t.Fatalf("original must remain decryptable after failure: %v", derr)
+			}
+			if !bytes.Equal(got, plaintext) {
+				t.Fatalf("original plaintext corrupted after failure")
+			}
+
+			// No stray temp files left behind in the backup dir.
+			entries, _ := os.ReadDir(dir)
+			for _, e := range entries {
+				if strings.HasPrefix(e.Name(), "sentinel-reencrypt-") {
+					t.Fatalf("leftover temp file after failure: %s", e.Name())
+				}
+			}
+		})
+	}
+}
+
+// --- T017 / SC-002: key rotation, new key works / old fails, no caveat ------
+
+func TestReencrypt_RotateKey(t *testing.T) {
+	keyEnv := reencKeyEnv
+	keyEnvB := reencKeyEnvB
+	testMasterKey(t, keyEnv)
+	testMasterKey(t, keyEnvB)
+	dir := t.TempDir()
+	historyPath := filepath.Join(dir, "history.db")
+	cfgPath := writeReencCfg(t, dir, historyPath, keyEnv)
+
+	plaintext := []byte("-- v2 payload to re-key\n")
+	artifact := filepath.Join(dir, "current.sql")
+	writeV2Backup(t, artifact, keyEnv, plaintext, "job1-current")
+	id := seedLocalExecution(t, historyPath, "job1", artifact, 0)
+
+	beforeManifest, _ := manifest.ReadManifest(artifact + ".manifest.json")
+
+	_, stderr, err := runReencrypt(t, cfgPath, reencFlags{
+		args: []string{id}, mode: "rotate", newKeyEnv: keyEnvB, output: "text",
+	})
+	if err != nil {
+		t.Fatalf("rotate should succeed, got: %v", err)
+	}
+
+	// No confidentiality caveat in rotate mode (US2 AS-3, SC-005 boundary).
+	if strings.Contains(stderr, "confidentiality") || strings.Contains(stderr, "migration re-wraps") {
+		t.Fatalf("rotate mode must NOT print the legacy caveat; stderr=\n%s", stderr)
+	}
+
+	// New key decrypts; old key fails.
+	got, derr := decryptArtifact(t, artifact, keyEnvB, false)
+	if derr != nil {
+		t.Fatalf("re-keyed artifact must decrypt with the NEW key: %v", derr)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("plaintext mismatch after rotate")
+	}
+	if _, derr := decryptArtifact(t, artifact, keyEnv, false); derr == nil {
+		t.Fatalf("re-keyed artifact must FAIL to decrypt with the OLD key")
+	}
+
+	// Fresh salt/IV (envelope re-generated).
+	afterManifest, _ := manifest.ReadManifest(artifact + ".manifest.json")
+	if afterManifest.Encryption.Salt == beforeManifest.Encryption.Salt {
+		t.Fatalf("rotate should generate a fresh salt")
+	}
+	if afterManifest.Encryption.IV == beforeManifest.Encryption.IV {
+		t.Fatalf("rotate should generate a fresh IV")
+	}
+	if afterManifest.Encryption.EnvelopeVersion != 2 {
+		t.Fatalf("rotated manifest EnvelopeVersion should stay 2")
+	}
+}
+
+// --- T020 / SC-004 / SC-009: dry-run no-op + --all gate + json shape --------
+
+func TestReencrypt_DryRunAndGate(t *testing.T) {
+	keyEnv := reencKeyEnv
+	testMasterKey(t, keyEnv)
+	dir := t.TempDir()
+	historyPath := filepath.Join(dir, "history.db")
+	cfgPath := writeReencCfg(t, dir, historyPath, keyEnv)
+
+	legacy := filepath.Join(dir, "legacy.sql")
+	writeLegacyBackup(t, legacy, keyEnv, []byte("legacy payload"), "job1-legacy")
+	seedLocalExecution(t, historyPath, "job1", legacy, 0)
+
+	current := filepath.Join(dir, "current.sql")
+	writeV2Backup(t, current, keyEnv, []byte("current payload"), "job1-current")
+	seedLocalExecution(t, historyPath, "job1", current, 0)
+
+	// Snapshot all files.
+	snapshot := func() map[string][]byte {
+		m := map[string][]byte{}
+		entries, _ := os.ReadDir(dir)
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			b, _ := os.ReadFile(filepath.Join(dir, e.Name()))
+			m[e.Name()] = b
+		}
+		return m
+	}
+	before := snapshot()
+
+	// --dry-run mutates nothing, and does not require --yes.
+	out, _, err := runReencrypt(t, cfgPath, reencFlags{all: true, dryRun: true, mode: "legacy", output: "json"})
+	if err != nil {
+		t.Fatalf("dry-run should exit 0, got: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(out), &raw); err != nil {
+		t.Fatalf("json parse: %v\n%s", err, out)
+	}
+	for _, k := range []string{"results", "summary", "dry_run", "caveat"} {
+		if _, ok := raw[k]; !ok {
+			t.Fatalf("dry-run json missing %q:\n%s", k, out)
+		}
+	}
+	after := snapshot()
+	for name, b := range before {
+		if !bytes.Equal(b, after[name]) {
+			t.Fatalf("dry-run mutated %s", name)
+		}
+	}
+	if len(before) != len(after) {
+		t.Fatalf("dry-run changed the file set: before=%d after=%d", len(before), len(after))
+	}
+
+	// --all without --yes (and not dry-run) refuses and mutates nothing (SC-009).
+	before2 := snapshot()
+	_, _, err = runReencrypt(t, cfgPath, reencFlags{all: true, mode: "legacy", output: "text"})
+	if !errors.Is(err, ErrVerifyInternal) || Code(err) != 4 {
+		t.Fatalf("--all without --yes must be exit 4 (ErrVerifyInternal), got: %v (code %d)", err, Code(err))
+	}
+	after2 := snapshot()
+	for name, b := range before2 {
+		if !bytes.Equal(b, after2[name]) {
+			t.Fatalf("unconfirmed --all mutated %s", name)
+		}
+	}
+}
+
+// --- validation matrix (exit 4) --------------------------------------------
+
+func TestReencrypt_ValidationExit4(t *testing.T) {
+	keyEnv := reencKeyEnv
+	testMasterKey(t, keyEnv)
+	dir := t.TempDir()
+	historyPath := filepath.Join(dir, "history.db")
+	cfgPath := writeReencCfg(t, dir, historyPath, keyEnv)
+
+	cases := []struct {
+		name string
+		f    reencFlags
+	}{
+		{"both id and --all", reencFlags{all: true, args: []string{"someid"}, mode: "legacy"}},
+		{"neither id nor --all", reencFlags{mode: "legacy"}},
+		{"rotate without new-key-env", reencFlags{args: []string{"someid"}, mode: "rotate"}},
+		{"bad mode", reencFlags{args: []string{"someid"}, mode: "bogus"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := runReencrypt(t, cfgPath, tc.f)
+			if !errors.Is(err, ErrVerifyInternal) || Code(err) != 4 {
+				t.Fatalf("%s: want exit 4 (ErrVerifyInternal), got: %v (code %d)", tc.name, err, Code(err))
+			}
+		})
+	}
+}
+
+// --- T010 / SC-005: legacy caveat banner printed ---------------------------
+
+func TestReencrypt_LegacyCaveatPrinted(t *testing.T) {
+	keyEnv := reencKeyEnv
+	testMasterKey(t, keyEnv)
+	dir := t.TempDir()
+	historyPath := filepath.Join(dir, "history.db")
+	cfgPath := writeReencCfg(t, dir, historyPath, keyEnv)
+
+	legacy := filepath.Join(dir, "legacy.sql")
+	writeLegacyBackup(t, legacy, keyEnv, []byte("legacy payload"), "job1-legacy")
+	id := seedLocalExecution(t, historyPath, "job1", legacy, 0)
+
+	_, stderr, err := runReencrypt(t, cfgPath, reencFlags{args: []string{id}, mode: "legacy", output: "text"})
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if !strings.Contains(stderr, "does NOT undo the confidentiality") {
+		t.Fatalf("legacy mode must print the confidentiality caveat; stderr=\n%s", stderr)
+	}
+}

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,37 @@
 # Sentinel Release Notes
 
+## [Unreleased]
+
+### Security
+
+- **`sentinel security reencrypt` (guided envelope migration + key rotation)**: a
+  new command that re-encrypts existing backups, closing the forward-reference
+  the v1.3.0 Envelope-v2 advisory opened ("a dedicated `sentinel security
+  reencrypt` helper is tracked under a separate PRD"). Two modes: **legacy → v2
+  migration** (`--mode legacy`, default) re-wraps a pre-v2 (legacy) artifact into
+  the current envelope so it restores/verifies under the default refuse-legacy
+  policy **without** `--allow-legacy-envelope` — for operators who cannot
+  re-backup from source (source DB gone, PITR window closed, artifact is the only
+  copy); and **key rotation** (`--mode rotate --new-key-env <VAR>`) re-encrypts a
+  current-format backup under a new master key (compromised/retired key), new key
+  read **env-only**, never from argv. Addressable by single `<backup-id>` or
+  `--all` (scoped by `--job` / `--since`); `--all` requires `--yes`; `--dry-run`
+  classifies (legacy / current / unencrypted / unmigratable) and mutates nothing;
+  `--output json` for automation. **Safety**: write-new → verify (decrypt-back +
+  SHA-256) → swap — the original artifact is never destroyed until a verified
+  replacement exists (`--keep-original` retains it), the operation is idempotent,
+  and a manifest-less backup is skipped with "cannot migrate — re-backup from
+  source" rather than corrupted. In `--all`, one backup's failure doesn't abort
+  the batch (exit `5` if any failed, `4` for invalid invocation, `0` otherwise).
+  Each success emits a `security.reencrypt` audit log event and updates the
+  monitor row. **Honest scope**: legacy migration fixes format/availability, it
+  does **NOT** remediate the legacy envelope's confidentiality weakness — a loud
+  caveat prints on every legacy run and re-backup-from-source remains the true
+  remediation. Pure composition of existing crypto/storage/manifest/monitor code
+  — no new port, no change to the backup/restore executors. Runbook:
+  [`docs/runbooks/recover-legacy-envelope.md`](docs/runbooks/recover-legacy-envelope.md).
+  (spec 054 / PRD 43)
+
 ## [v1.3.0] - August 3, 2026
 
 ### Performance


### PR DESCRIPTION
## Summary

Adds `sentinel security reencrypt` — a guided command to re-encrypt existing backups. Closes the forward-reference the v1.3.0 Envelope-v2 security advisory opened ("a dedicated `sentinel security reencrypt` helper is tracked under a separate PRD"). **spec 054 / PRD 43.**

Two modes:
- **`--mode legacy` (default)** — re-wrap a pre-v2 (legacy) envelope artifact into the current v2 envelope so it restores/verifies under the default refuse-legacy policy **without** `--allow-legacy-envelope`. For operators who cannot re-backup from source (source DB gone, PITR window closed, artifact is the only copy).
- **`--mode rotate --new-key-env <VAR>`** — re-encrypt a current-format backup under a **new** master key (compromised/retired key). New key read **env-only**, never argv.

Addressable by `<backup-id>` or `--all` (`--job` / `--since` scope). `--all` requires `--yes`. `--dry-run` classifies (legacy / current / unencrypted / unmigratable) and mutates nothing. `--output json` for automation. Exit codes `0/4/5` matching `backup verify`.

## Safety (the headline invariant)

**write-new → verify (decrypt-back + SHA-256) → swap.** The original artifact is never destroyed until a verified replacement exists (`--keep-original` retains it for manual cutover). Idempotent (already-v2 skipped). A manifest-less backup is skipped with "cannot migrate — re-backup from source", never corrupted. In `--all`, one backup's failure doesn't abort the batch. Each success emits a `security.reencrypt` audit log event and updates the monitor row.

## Honest scope

Legacy migration fixes **format/availability**, it does **NOT** remediate the legacy envelope's confidentiality weakness — a loud caveat prints on every legacy run; re-backup-from-source remains the true remediation. (Rotate mode has no caveat — the v2 envelope is sound.)

## Architecture

Pure composition of existing crypto / storage / manifest / monitor code — **no new port, no change to the backup/restore executors** (verified: no `internal/ports/**` or `internal/domain/**` diff). Command self-registers in its own `init()`.

## Testing

`go build` / `go vet` / `go test ./...` pass (0 failures); `golangci-lint` 0 issues (depguard clean); gofmt clean. 7 test funcs incl. injected-failure-leaves-original-intact (the safety invariant), key-rotation old-key-fails/new-key-works, dry-run byte-identical, `--all`-without-`--yes` no-op.

## Known residual (not a blocker)

The artifact+manifest swap is two renames/uploads — a narrow non-atomic window if the manifest step fails right after the artifact step. Matches the existing artifact+sidecar write pattern; a `.bak`-guarded swap is a candidate follow-up.

## Note

Includes an incidental CI chore commit (`setup-go`/`goreleaser-action` v6→v7 + a benchmark.yml comment strip) that landed on this branch; harmless and unrelated to the feature.

Docs: runbook `docs/runbooks/recover-legacy-envelope.md` extended; `release-notes.md` `[Unreleased]` entry added.