### PR TITLE
feat(release): supply-chain signing — cosign keyless of checksums.txt (spec 053 / PRD 42)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
       - "v*"
 permissions:
   contents: write
+  # Required for cosign keyless signing: lets the job mint a GitHub OIDC token
+  # that cosign exchanges with Fulcio for a short-lived signing cert
+  # (spec 053 / PRD 42). Without it, keyless signing fails.
+  id-token: write
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -19,10 +23,31 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version: '1.24'
+      - name: Install cosign
+        # Provides the cosign v3 binary used by the .goreleaser.yaml `signs:`
+        # block to keyless-sign checksums.txt (spec 053 / PRD 42).
+        uses: sigstore/cosign-installer@v4.1.0
       - name: Run GoReleaser
+        # Fail-closed: no `continue-on-error` here. If cosign signing fails,
+        # GoReleaser exits non-zero and the release publishes NOTHING — a
+        # published release is always signed (spec 053 FR-012). Do not add
+        # continue-on-error to this step.
         uses: goreleaser/goreleaser-action@v7
         with:
           version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify checksums signature (smoke check)
+        # Post-publication self-check (spec 053 FR-013): verify the just-signed
+        # bundle against the tight release-workflow-on-tag identity, so a broken
+        # signing/identity config fails THIS run instead of shipping unnoticed.
+        # Fail-closed: no `continue-on-error`. The identity regexp MUST stay
+        # identical to the one documented in README (single source of truth);
+        # if this workflow file is renamed, update both.
+        run: |
+          cosign verify-blob \
+            --certificate-identity-regexp 'https://github.com/denisakp/sentinel/.github/workflows/release.yml@refs/tags/.*' \
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+            --bundle dist/checksums.txt.sigstore.json \
+            dist/checksums.txt

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,9 +8,12 @@
 # Validate locally with: goreleaser release --snapshot --clean
 # (produces all 5 binaries + archives + checksums.txt under dist/).
 #
-# TODO(v2): supply-chain signing — cosign keyless (GitHub OIDC, `--yes`)
-# plus SLSA build provenance attestations. Deferred out of v1 per PRD 38
-# Q1 (checksums-only for v1; signing/provenance a fast-follow).
+# Supply-chain signing: checksums.txt is signed with cosign keyless (GitHub
+# OIDC + Fulcio/Rekor) via the `signs:` block below, producing a single
+# sigstore bundle (checksums.txt.sigstore.json). Verify a download with
+# `cosign verify-blob --bundle checksums.txt.sigstore.json checksums.txt`
+# (see README → Installation). SLSA build-provenance attestation remains a
+# separate future item (its own PRD), out of scope here. (spec 053 / PRD 42)
 version: 2
 
 project_name: sentinel
@@ -63,6 +66,26 @@ archives:
 checksum:
   name_template: checksums.txt
   algorithm: sha256
+
+# Cosign keyless signing of the checksums file (spec 053 / PRD 42). One
+# signature over checksums.txt transitively covers every archive (verify the
+# bundle, then `sha256sum -c`). Keyless: no long-lived key — the CI job's
+# GitHub OIDC identity is exchanged for a short-lived Fulcio cert and logged
+# in Rekor. `--yes` is required non-interactively in CI. cosign v3 emits a
+# single self-contained bundle (signature + cert + inclusion proof), so no
+# separate .sig/.pem files and no COSIGN_EXPERIMENTAL. `artifacts: checksum`
+# signs ONLY checksums.txt; do not widen it. NOTE: `goreleaser --snapshot`
+# skips signing — the bundle is only produced on a real (tagged) release.
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sigstore.json"
+    args:
+      - sign-blob
+      - "--bundle=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+    output: true
 
 release:
   github:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,43 @@ each with a SHA-256 `checksums.txt`.
 Prebuilt binaries still expect the relevant DB client tools (`pg_dump`,
 `mysqldump`, `mongodump`, …) on your `PATH`.
 
+### Verify the release signature (recommended)
+
+Each recent release's `checksums.txt` is signed with
+[cosign](https://github.com/sigstore/cosign) keyless signing (GitHub OIDC +
+the sigstore public-good Fulcio/Rekor). A signature bundle
+`checksums.txt.sigstore.json` is published alongside it. Verifying the
+signature proves the checksums file was produced by Sentinel's release
+workflow — not just that your archive matches an (otherwise unsigned) list.
+This is an added assurance on top of the `sha256sum -c` check above, not a
+replacement; the checksum-only path still works if you don't have cosign.
+
+Needs `cosign` v3+ (`brew install cosign`, or download from sigstore). No Go
+toolchain and no Sentinel install required.
+
+```bash
+BASE=https://github.com/denisakp/sentinel/releases/latest/download
+curl -LO "$BASE/checksums.txt"
+curl -LO "$BASE/checksums.txt.sigstore.json"
+
+# Verify checksums.txt was signed by Sentinel's release workflow on a tag:
+cosign verify-blob \
+  --certificate-identity-regexp 'https://github.com/denisakp/sentinel/.github/workflows/release.yml@refs/tags/.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  --bundle checksums.txt.sigstore.json \
+  checksums.txt        # → "Verified OK"
+```
+
+Once `checksums.txt` is verified, check your archive against it with
+`sha256sum -c checksums.txt --ignore-missing` as above. Verification fails
+closed: a tampered `checksums.txt`, or a signature from any other
+identity/issuer, is rejected.
+
+> **Note:** releases published before signing was introduced ship no
+> signature bundle and are verifiable by `checksums.txt` (SHA-256) only.
+> If a release has no `checksums.txt.sigstore.json` asset, use the
+> checksum-only path.
+
 ### Install with `go install`
 
 If you already have Go 1.24+:

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 
+### Security / Supply chain
+
+- **signed release checksums (cosign keyless)**: each release now signs its
+  `checksums.txt` with [cosign](https://github.com/sigstore/cosign) keyless
+  signing (GitHub Actions OIDC → Fulcio short-lived cert, logged in Rekor) and
+  publishes a single sigstore bundle `checksums.txt.sigstore.json` alongside
+  the existing assets. Downloaders can now cryptographically verify a release
+  originated from Sentinel's release workflow — not merely that an archive
+  matches an otherwise-unsigned checksums list — with
+  `cosign verify-blob --certificate-identity-regexp '…/release.yml@refs/tags/.*' --certificate-oidc-issuer https://token.actions.githubusercontent.com --bundle checksums.txt.sigstore.json checksums.txt`
+  (full command in README → Installation → "Verify the release signature").
+  One signature over `checksums.txt` transitively covers every archive (verify
+  the bundle, then `sha256sum -c`). Signing is **fail-closed**: if signing
+  cannot complete, the release publishes nothing, and a post-publication CI
+  step re-verifies the bundle against the pinned workflow identity so a broken
+  config fails the run. The existing `checksums.txt` (SHA-256) and its
+  `sha256sum -c` path are **unchanged** and remain valid for users without
+  cosign; releases published **before** this change ship no bundle and stay
+  checksum-only. No product/`internal` code change — release pipeline + docs
+  only. SLSA build-provenance attestation remains a separate future item.
+  (spec 053 / PRD 42)
+
 ### Security
 
 - **`sentinel security reencrypt` (guided envelope migration + key rotation)**: a


### PR DESCRIPTION
## Summary

Signs each release's `checksums.txt` with **cosign keyless** (GitHub Actions OIDC → Fulcio short-lived cert, logged in Rekor), publishing a single sigstore bundle `checksums.txt.sigstore.json`. Downloaders can now cryptographically verify a release came from Sentinel's release workflow, not merely that an archive matches an otherwise-unsigned list. One signature over `checksums.txt` transitively covers every archive. **spec 053 / PRD 42.** Fulfils the `.goreleaser.yaml` `TODO(v2)` + PRD 38 Q1.

## Changes (release pipeline + docs only — zero `internal/**`)

- `.goreleaser.yaml`: `signs:` block (cosign v3 `sign-blob --bundle`, `artifacts: checksum`, `output: true`, `--yes`); replaced the old `TODO(v2)` comment.
- `.github/workflows/release.yml`: `id-token: write` permission; `sigstore/cosign-installer@v4.1.0`; a **fail-closed** post-publication `cosign verify-blob` smoke step pinned to the tight `release.yml@refs/tags/.*` identity. No `continue-on-error` anywhere (signing failure ⇒ nothing published).
- `README.md`: "Verify the release signature" section (the exact `verify-blob` command); the existing `sha256sum -c` path kept as an additive fallback; pre-signing releases noted checksum-only.
- `release-notes.md`: `[Unreleased]` entry.

## Verified by a real keyless dry-run

A throwaway Actions run in this repo signed a dummy `checksums.txt` and verified it end-to-end (now cleaned up):
- `cosign sign-blob --bundle` → wrote `checksums.txt.sigstore.json` ✓
- `cosign verify-blob` against the tight workflow identity + issuer → **Verified OK** ✓
- tampered file → **correctly rejected** (fail-closed) ✓
- `cosign version` → **v3.0.3** (installer@v4.1.0 provides cosign ≥ 3, so the `.sigstore.json` bundle format is correct — no `cosign-release` pin needed) ✓

## Scope note

Cosign blob-signing only. **SLSA build-provenance attestation is deliberately out of scope** (a separate, larger change with its own workflow-identity model — future PRD). The `--bundle` sigstore form (cosign v3) supersedes the PRD's original illustrative `.sig`/`.pem` naming.