### PR TITLE
feat(config): MySQL/MariaDB credential loading from a my.cnf defaults file (spec 056 / PRD 44)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,5 +113,5 @@ Every new feature MUST run these skills in this exact order — no skipping, no 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/055-slsa-provenance/plan.md`
+`specs/056-mysql-defaults-file/plan.md`
 <!-- SPECKIT END -->

--- a/docs/runbooks/credentials.md
+++ b/docs/runbooks/credentials.md
@@ -45,9 +45,34 @@ export DB_PWD='hunter2'
 sentinel backup --config sentinel.yaml
 ```
 
+### 4. MySQL/MariaDB defaults file (my.cnf) — `defaults_file`
+
+For MySQL/MariaDB jobs only, `defaults_file` points at a standard my.cnf-format option file and seeds `host`/`user`/`password`/`port` from its `[client]` section for **every** part of the pipeline that needs them — the pre-backup connectivity check, `database: "*"` auto-discovery, and the dump itself (spec 056 / PRD 44, closing GitHub issue #28).
+
+```yaml
+databases:
+  mydb:
+    type: mysql
+    database: "*"
+    defaults_file: /etc/sentinel/.my.cnf
+```
+
+```ini
+# /etc/sentinel/.my.cnf  (chmod 0600)
+[client]
+host = 127.0.0.1
+user = sentinel_backup
+password = s3cr3t
+port = 3306
+```
+
+Only the `[client]` section is read; other sections (e.g. `[mysqldump]`) and `!include`/`!includedir` directives are ignored. Any explicit config field (`host`, `username`, `password_env`) always overrides the file's corresponding value — the file only fills in what's left unset. A missing, unreadable, or malformed `defaults_file` fails **at config-load time**, not partway through a backup run. Same group/world-readable permission warning as the `--password-file` channel above.
+
+This is unrelated to (and can be combined with) `additional_args: "--defaults-extra-file=..."`, which forwards a raw flag to `mysqldump`/`mariadb-dump` directly — that dump-only passthrough still works exactly as before, but on its own it does not reach the Go-side connectivity check or discovery, which is exactly the gap `defaults_file` closes.
+
 ## Precedence
 
-CLI flag > config `password_env`. The override is silent (no warning), enabling one-off drills:
+CLI flag > config `password_env` > `defaults_file` (MySQL/MariaDB only). The CLI-flag override is silent (no warning), enabling one-off drills:
 
 ```bash
 export OPS_PWD='different'

--- a/internal/adapters/mysqlargs/defaults_file.go
+++ b/internal/adapters/mysqlargs/defaults_file.go
@@ -1,0 +1,128 @@
+package mysqlargs
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ClientCreds holds the credential fields read from a my.cnf-format option
+// file's [client] section (spec 056 / PRD 44).
+type ClientCreds struct {
+	Host, User, Password, Port string
+}
+
+// ErrDefaultsFileUnreadable indicates the defaults file could not be opened,
+// stat'd, or parsed as a valid option file.
+var ErrDefaultsFileUnreadable = errors.New("mysqlargs: cannot read defaults file")
+
+// ErrDefaultsFileNoClientSection indicates the file parsed cleanly but has no
+// [client] section, or the section is empty. Callers treat this as "nothing
+// to contribute" rather than a hard failure on its own (spec 056 edge cases).
+var ErrDefaultsFileNoClientSection = errors.New("mysqlargs: defaults file has no [client] section")
+
+// ParseDefaultsFile reads path (a my.cnf-format option file) and returns the
+// [client] section's host/user/password/port, plus the file's stat mode so
+// the caller can apply a group/world-readable permission warning. Only the
+// [client] section is parsed; other sections (e.g. [mysqldump]) and
+// !include/!includedir directives are ignored, not errors.
+func ParseDefaultsFile(path string) (ClientCreds, os.FileMode, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return ClientCreds{}, 0, fmt.Errorf("%w '%s': %v", ErrDefaultsFileUnreadable, path, err)
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return ClientCreds{}, 0, fmt.Errorf("%w '%s': %v", ErrDefaultsFileUnreadable, path, err)
+	}
+
+	creds, sawClient, err := parseClientSection(f)
+	if err != nil {
+		return ClientCreds{}, info.Mode(), fmt.Errorf("%w '%s': %v", ErrDefaultsFileUnreadable, path, err)
+	}
+	if !sawClient || creds == (ClientCreds{}) {
+		return ClientCreds{}, info.Mode(), fmt.Errorf("%w: '%s'", ErrDefaultsFileNoClientSection, path)
+	}
+	return creds, info.Mode(), nil
+}
+
+func parseClientSection(f *os.File) (ClientCreds, bool, error) {
+	var creds ClientCreds
+	inClient := false
+	sawClient := false
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") {
+			if !strings.HasSuffix(line, "]") {
+				return ClientCreds{}, false, fmt.Errorf("malformed section header: %q", line)
+			}
+			section := strings.TrimSpace(line[1 : len(line)-1])
+			inClient = strings.EqualFold(section, "client")
+			if inClient {
+				sawClient = true
+			}
+			continue
+		}
+		if !inClient {
+			continue
+		}
+
+		key, value, ok := splitOptionLine(line)
+		if !ok {
+			continue
+		}
+		value = unquote(value)
+		switch strings.ToLower(key) {
+		case "host":
+			creds.Host = value
+		case "user":
+			creds.User = value
+		case "password":
+			creds.Password = value
+		case "port":
+			creds.Port = value
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return ClientCreds{}, false, err
+	}
+	return creds, sawClient, nil
+}
+
+// splitOptionLine splits "key=value" or "key = value" into trimmed key/value.
+// A bare "key" (no '=') is a valid my.cnf option but carries no value we care
+// about here, so it is skipped (ok=false).
+func splitOptionLine(line string) (key, value string, ok bool) {
+	idx := strings.Index(line, "=")
+	if idx < 0 {
+		return "", "", false
+	}
+	key = strings.TrimSpace(line[:idx])
+	value = strings.TrimSpace(line[idx+1:])
+	if key == "" {
+		return "", "", false
+	}
+	return key, value, true
+}
+
+func unquote(v string) string {
+	if len(v) >= 2 {
+		if (v[0] == '"' && v[len(v)-1] == '"') || (v[0] == '\'' && v[len(v)-1] == '\'') {
+			return v[1 : len(v)-1]
+		}
+	}
+	return v
+}

--- a/internal/adapters/mysqlargs/defaults_file_test.go
+++ b/internal/adapters/mysqlargs/defaults_file_test.go
@@ -1,0 +1,123 @@
+package mysqlargs
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTempDefaultsFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".my.cnf")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write temp defaults file: %v", err)
+	}
+	return path
+}
+
+func TestParseDefaultsFile_AllFieldsUnquoted(t *testing.T) {
+	path := writeTempDefaultsFile(t, "[client]\nhost=127.0.0.1\nuser=sentinel\npassword=s3cr3t\nport=3306\n")
+	creds, _, err := ParseDefaultsFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := ClientCreds{Host: "127.0.0.1", User: "sentinel", Password: "s3cr3t", Port: "3306"}
+	if creds != want {
+		t.Fatalf("got %+v, want %+v", creds, want)
+	}
+}
+
+func TestParseDefaultsFile_QuotedValues(t *testing.T) {
+	path := writeTempDefaultsFile(t, "[client]\nhost = \"127.0.0.1\"\nuser = 'sentinel'\npassword = \"s3c#r3t\"\n")
+	creds, _, err := ParseDefaultsFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creds.Host != "127.0.0.1" || creds.User != "sentinel" || creds.Password != "s3c#r3t" {
+		t.Fatalf("got %+v", creds)
+	}
+}
+
+func TestParseDefaultsFile_CommentsInterspersed(t *testing.T) {
+	path := writeTempDefaultsFile(t, "# leading comment\n; another style\n[client]\n# inline-ish comment line\nhost=127.0.0.1\n; separator\nuser=sentinel\n")
+	creds, _, err := ParseDefaultsFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creds.Host != "127.0.0.1" || creds.User != "sentinel" {
+		t.Fatalf("got %+v", creds)
+	}
+}
+
+func TestParseDefaultsFile_NoClientSection(t *testing.T) {
+	path := writeTempDefaultsFile(t, "[mysqldump]\nquick\n")
+	_, _, err := ParseDefaultsFile(path)
+	if !errors.Is(err, ErrDefaultsFileNoClientSection) {
+		t.Fatalf("got err=%v, want ErrDefaultsFileNoClientSection", err)
+	}
+}
+
+func TestParseDefaultsFile_EmptyClientSection(t *testing.T) {
+	path := writeTempDefaultsFile(t, "[client]\n[mysqldump]\nquick\n")
+	_, _, err := ParseDefaultsFile(path)
+	if !errors.Is(err, ErrDefaultsFileNoClientSection) {
+		t.Fatalf("got err=%v, want ErrDefaultsFileNoClientSection", err)
+	}
+}
+
+func TestParseDefaultsFile_MultipleSectionsOnlyClientExtracted(t *testing.T) {
+	path := writeTempDefaultsFile(t, "[mysqldump]\nquick\nmax_allowed_packet=512M\n[client]\nhost=127.0.0.1\nuser=sentinel\n[mysql]\nprompt=x\n")
+	creds, _, err := ParseDefaultsFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creds.Host != "127.0.0.1" || creds.User != "sentinel" {
+		t.Fatalf("got %+v (expected only [client] values)", creds)
+	}
+}
+
+func TestParseDefaultsFile_MissingFile(t *testing.T) {
+	_, _, err := ParseDefaultsFile(filepath.Join(t.TempDir(), "nonexistent.my.cnf"))
+	if !errors.Is(err, ErrDefaultsFileUnreadable) {
+		t.Fatalf("got err=%v, want ErrDefaultsFileUnreadable", err)
+	}
+}
+
+func TestParseDefaultsFile_UnreadableFile(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root; permission checks are ineffective")
+	}
+	path := writeTempDefaultsFile(t, "[client]\nhost=127.0.0.1\n")
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	defer os.Chmod(path, 0o600)
+	_, _, err := ParseDefaultsFile(path)
+	if !errors.Is(err, ErrDefaultsFileUnreadable) {
+		t.Fatalf("got err=%v, want ErrDefaultsFileUnreadable", err)
+	}
+}
+
+func TestParseDefaultsFile_PermissionModeReturned(t *testing.T) {
+	path := writeTempDefaultsFile(t, "[client]\nhost=127.0.0.1\nuser=sentinel\n")
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	_, mode, err := ParseDefaultsFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mode.Perm()&0o044 == 0 {
+		t.Fatalf("expected group/world-readable bits set, got mode %v", mode.Perm())
+	}
+}
+
+func TestParseDefaultsFile_MalformedSectionHeader(t *testing.T) {
+	path := writeTempDefaultsFile(t, "[client\nhost=127.0.0.1\n")
+	_, _, err := ParseDefaultsFile(path)
+	if !errors.Is(err, ErrDefaultsFileUnreadable) {
+		t.Fatalf("got err=%v, want ErrDefaultsFileUnreadable (malformed section)", err)
+	}
+}

--- a/internal/cli/backup.go
+++ b/internal/cli/backup.go
@@ -632,7 +632,7 @@ func runScheduledRetention(cmd *cobra.Command, cfg *config.Configuration, job co
 func listDatabases(job config.BackupJob) ([]string, error) {
 	switch job.Type {
 	case "postgres", "mysql", "mariadb":
-		password, err := config.PasswordFromEnv(job.PasswordEnv)
+		password, err := config.ResolveJobPassword(job)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/config/defaults_file_resolve.go
+++ b/internal/config/defaults_file_resolve.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/denisakp/sentinel/internal/adapters/mysqlargs"
+)
+
+// applyDefaultsFile parses job.DefaultsFile and fills any of Host/Username/
+// Port left empty by explicit config, and caches a resolved password (read
+// only via ResolveJobPassword) when password_env is unset (spec 056 / PRD
+// 44). Called only for mysql/mariadb jobs with a non-empty DefaultsFile; any
+// problem reading or parsing the file is a hard config-load error (FR-006) —
+// except "no [client] section", which means the file simply has nothing to
+// contribute (spec Edge Cases), not a failure.
+func applyDefaultsFile(job *BackupJob) error {
+	creds, mode, err := mysqlargs.ParseDefaultsFile(job.DefaultsFile)
+	if err != nil {
+		if errors.Is(err, mysqlargs.ErrDefaultsFileNoClientSection) {
+			return nil
+		}
+		return fmt.Errorf("defaults_file: %w", err)
+	}
+
+	if mode.Perm()&0o044 != 0 {
+		fmt.Fprintf(os.Stderr,
+			"warning: defaults_file '%s' has permissions 0o%03o (group- or world-readable); recommend chmod 0600\n",
+			job.DefaultsFile, mode.Perm())
+	}
+
+	if job.Host == "" && creds.Host != "" {
+		job.Host = creds.Host
+	}
+	if job.Username == "" && creds.User != "" {
+		job.Username = creds.User
+	}
+	if job.PasswordEnv == "" && creds.Password != "" {
+		job.myCnfPassword = creds.Password
+	}
+	if job.Port == 0 && creds.Port != "" {
+		port, err := strconv.Atoi(creds.Port)
+		if err != nil {
+			return fmt.Errorf("defaults_file '%s': invalid port %q: %w", job.DefaultsFile, creds.Port, err)
+		}
+		job.Port = port
+	}
+	return nil
+}

--- a/internal/config/defaults_file_resolve_test.go
+++ b/internal/config/defaults_file_resolve_test.go
@@ -1,0 +1,258 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTestDefaultsFile(t *testing.T, content string, mode os.FileMode) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, ".my.cnf")
+	if err := os.WriteFile(p, []byte(content), mode); err != nil {
+		t.Fatalf("write defaults file: %v", err)
+	}
+	if err := os.Chmod(p, mode); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	return p
+}
+
+// T010 (US1): credentials only in defaults_file — Host/Username resolved,
+// ResolveJobPassword returns the file's password.
+func TestLoadConfig_DefaultsFileOnlySource(t *testing.T) {
+	dfPath := writeTestDefaultsFile(t, "[client]\nhost=127.0.0.1\nuser=sentinel_backup\npassword=s3cr3t\nport=3306\n", 0o600)
+
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mydb:\n    type: mysql\n    database: app\n"+
+		"    defaults_file: \""+dfPath+"\"\n")
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	job := cfg.Databases["mydb"]
+	if job.Host != "127.0.0.1" {
+		t.Fatalf("Host = %q, want 127.0.0.1", job.Host)
+	}
+	if job.Username != "sentinel_backup" {
+		t.Fatalf("Username = %q, want sentinel_backup", job.Username)
+	}
+	if job.Port != 3306 {
+		t.Fatalf("Port = %d, want 3306", job.Port)
+	}
+	pw, err := ResolveJobPassword(job)
+	if err != nil {
+		t.Fatalf("ResolveJobPassword error = %v", err)
+	}
+	if pw != "s3cr3t" {
+		t.Fatalf("password = %q, want s3cr3t", pw)
+	}
+
+	if err := ValidateConfig(cfg); err != nil {
+		t.Fatalf("ValidateConfig() error = %v (defaults_file-only config should validate)", err)
+	}
+}
+
+// T012 (US2): explicit host wins over the file's host; other fields still
+// come from the file.
+func TestLoadConfig_DefaultsFileExplicitFieldWins(t *testing.T) {
+	dfPath := writeTestDefaultsFile(t, "[client]\nhost=file-host\nuser=file-user\npassword=file-pass\n", 0o600)
+
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mydb:\n    type: mysql\n    database: app\n"+
+		"    host: explicit-host\n"+
+		"    defaults_file: \""+dfPath+"\"\n")
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	job := cfg.Databases["mydb"]
+	if job.Host != "explicit-host" {
+		t.Fatalf("Host = %q, want explicit-host (explicit must win)", job.Host)
+	}
+	if job.Username != "file-user" {
+		t.Fatalf("Username = %q, want file-user (fallback should still apply)", job.Username)
+	}
+	pw, err := ResolveJobPassword(job)
+	if err != nil || pw != "file-pass" {
+		t.Fatalf("password = %q err=%v, want file-pass", pw, err)
+	}
+}
+
+// T013 (US2): explicit credentials cover every field — file present but
+// unused, no error from its mere presence.
+func TestLoadConfig_DefaultsFilePresentButFullyOverridden(t *testing.T) {
+	dfPath := writeTestDefaultsFile(t, "[client]\nhost=file-host\nuser=file-user\npassword=file-pass\n", 0o600)
+
+	t.Setenv("MYDB_PW", "explicit-secret")
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mydb:\n    type: mysql\n    database: app\n"+
+		"    host: explicit-host\n    username: explicit-user\n    password_env: MYDB_PW\n"+
+		"    defaults_file: \""+dfPath+"\"\n")
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	job := cfg.Databases["mydb"]
+	if job.Host != "explicit-host" || job.Username != "explicit-user" {
+		t.Fatalf("got Host=%q Username=%q, want explicit values unchanged", job.Host, job.Username)
+	}
+	pw, err := ResolveJobPassword(job)
+	if err != nil || pw != "explicit-secret" {
+		t.Fatalf("password = %q err=%v, want explicit-secret (password_env must win)", pw, err)
+	}
+	if err := ValidateConfig(cfg); err != nil {
+		t.Fatalf("ValidateConfig() error = %v", err)
+	}
+}
+
+// T015 (US3): nonexistent defaults_file path fails fast at load time.
+func TestLoadConfig_DefaultsFileMissingPathFailsFast(t *testing.T) {
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mydb:\n    type: mysql\n    database: app\n"+
+		"    defaults_file: /nonexistent/path/.my.cnf\n")
+
+	_, err := LoadConfig(cfgPath)
+	if err == nil {
+		t.Fatal("LoadConfig() expected error for missing defaults_file, got nil")
+	}
+	if !strings.Contains(err.Error(), "/nonexistent/path/.my.cnf") {
+		t.Fatalf("error %q does not name the file", err.Error())
+	}
+}
+
+// T016 (US3): malformed defaults_file fails fast at load time.
+func TestLoadConfig_DefaultsFileMalformedFailsFast(t *testing.T) {
+	dfPath := writeTestDefaultsFile(t, "[client\nhost=127.0.0.1\n", 0o600)
+
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mydb:\n    type: mysql\n    database: app\n"+
+		"    defaults_file: \""+dfPath+"\"\n")
+
+	_, err := LoadConfig(cfgPath)
+	if err == nil {
+		t.Fatal("LoadConfig() expected error for malformed defaults_file, got nil")
+	}
+}
+
+// T016 (US3): a defaults_file with no [client] section at all, and no other
+// credential source, still surfaces the standard missing-password error at
+// validation time (not silently accepted, not a parse failure either).
+func TestLoadConfig_DefaultsFileNoClientSectionFallsThroughToMissingError(t *testing.T) {
+	dfPath := writeTestDefaultsFile(t, "[mysqldump]\nquick\n", 0o600)
+
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mydb:\n    type: mysql\n    database: app\n"+
+		"    defaults_file: \""+dfPath+"\"\n")
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v (no [client] section should not be a load error)", err)
+	}
+	if err := ValidateConfig(cfg); err == nil {
+		t.Fatal("ValidateConfig() expected error: no credential source supplied host/username/password")
+	}
+}
+
+// T018: a mysql job with NO defaults_file at all — confirm zero regression.
+func TestLoadConfig_NoDefaultsFileUnchangedBehavior(t *testing.T) {
+	t.Setenv("MYDB_PW_NOREGRESSION", "secret")
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mydb:\n    type: mysql\n    database: app\n"+
+		"    host: localhost\n    username: sentinel\n    password_env: MYDB_PW_NOREGRESSION\n")
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	job := cfg.Databases["mydb"]
+	if job.Host != "localhost" || job.Username != "sentinel" {
+		t.Fatalf("got Host=%q Username=%q", job.Host, job.Username)
+	}
+	pw, err := ResolveJobPassword(job)
+	if err != nil || pw != "secret" {
+		t.Fatalf("password = %q err=%v, want secret", pw, err)
+	}
+	if err := ValidateConfig(cfg); err != nil {
+		t.Fatalf("ValidateConfig() error = %v", err)
+	}
+
+	// Missing password_env entirely (and no defaults_file) must still be
+	// rejected at ValidateConfig, exactly as before this feature (loader.go's
+	// own requireEnvValue is a no-op on an empty env name; the real
+	// enforcement lives in validateConnection).
+	cfgPath2 := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mydb:\n    type: mysql\n    database: app\n"+
+		"    host: localhost\n    username: sentinel\n")
+	cfg2, err := LoadConfig(cfgPath2)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v (should load; validation happens separately)", err)
+	}
+	if err := ValidateConfig(cfg2); err == nil || !strings.Contains(err.Error(), "password_env") {
+		t.Fatalf("got err=%v, want a password_env-required error (unchanged behavior)", err)
+	}
+}
+
+// T017: defaults_file on a non-mysql/mariadb job is rejected by ValidateConfig.
+func TestValidateConfig_DefaultsFileRejectedForWrongType(t *testing.T) {
+	t.Setenv("PG_PW_REJECT_TEST", "secret")
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  pgjob:\n    type: postgres\n    database: app\n"+
+		"    host: localhost\n    username: sentinel\n    password_env: PG_PW_REJECT_TEST\n"+
+		"    defaults_file: /etc/sentinel/.my.cnf\n")
+
+	// LoadConfig itself must not error just from the presence of an
+	// unreadable/irrelevant defaults_file on a postgres job (loader.go skips
+	// resolution entirely for non-mysql/mariadb types) — the rejection is
+	// ValidateConfig's job.
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v (loader must skip defaults_file for non-mysql/mariadb types)", err)
+	}
+	err = ValidateConfig(cfg)
+	if err == nil || !strings.Contains(err.Error(), "defaults_file is only valid for mysql or mariadb backup jobs") {
+		t.Fatalf("got err=%v, want the defaults_file type-rejection error", err)
+	}
+}
+
+// T020 (Polish): group/world-readable defaults_file triggers a warning,
+// without blocking config load.
+func TestLoadConfig_DefaultsFilePermissionWarning(t *testing.T) {
+	dfPath := writeTestDefaultsFile(t, "[client]\nhost=127.0.0.1\nuser=sentinel\npassword=s3cr3t\n", 0o644)
+
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mydb:\n    type: mysql\n    database: app\n"+
+		"    defaults_file: \""+dfPath+"\"\n")
+
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	_, err := LoadConfig(cfgPath)
+	w.Close()
+	os.Stderr = oldStderr
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v (permission issue must warn, not fail)", err)
+	}
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	captured := string(buf[:n])
+	if !strings.Contains(captured, "group- or world-readable") {
+		t.Fatalf("expected a permission warning on stderr, got: %q", captured)
+	}
+}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -229,6 +229,12 @@ func applyEnvOverrides(cfg *Configuration) error {
 			return fmt.Errorf("backup '%s': %w", name, err)
 		}
 
+		if job.DefaultsFile != "" && (job.Type == "mysql" || job.Type == "mariadb") {
+			if err := applyDefaultsFile(&job); err != nil {
+				return fmt.Errorf("backup '%s': %w", name, err)
+			}
+		}
+
 		for i := range job.Notifications {
 			channel := &job.Notifications[i]
 			enabled := channel.Enabled == nil || *channel.Enabled
@@ -251,7 +257,7 @@ func applyEnvOverrides(cfg *Configuration) error {
 			}
 		}
 
-		if job.Type != "mongodb" {
+		if job.Type != "mongodb" && job.myCnfPassword == "" {
 			if err := requireEnvValue(job.PasswordEnv); err != nil {
 				return fmt.Errorf("backup '%s': %w", name, err)
 			}

--- a/internal/config/password_source.go
+++ b/internal/config/password_source.go
@@ -118,11 +118,30 @@ func Resolve(flags ResolveFlags, job BackupJob) (Resolution, error) {
 		return Resolution{Source: SourceNone}, nil
 	}
 
-	pw, err := PasswordFromEnv(job.PasswordEnv)
+	pw, err := ResolveJobPassword(job)
 	if err != nil {
 		return Resolution{}, err
 	}
 	return Resolution{Password: pw, Source: SourceConfigEnv}, nil
+}
+
+// ResolveJobPassword resolves a backup job's password from password_env,
+// falling back to the password parsed from defaults_file (spec 056 / PRD 44)
+// when password_env is unset. Both existing independent password-resolution
+// call sites (Resolve above, and internal/cli/backup.go's listDatabases)
+// converge on this single function so my.cnf-sourced credentials are visible
+// consistently across the dump build, its in-dump connectivity check, and
+// discovery — without either consumer needing its own edit.
+func ResolveJobPassword(job BackupJob) (string, error) {
+	if job.PasswordEnv != "" {
+		return PasswordFromEnv(job.PasswordEnv)
+	}
+	if job.myCnfPassword != "" {
+		return job.myCnfPassword, nil
+	}
+	// Same error shape PasswordFromEnv("") would have produced — preserves
+	// today's exact "nothing supplied" error when defaults_file is unset.
+	return "", fmt.Errorf("password_env is required")
 }
 
 func suppliedFlagNames(f ResolveFlags) []string {

--- a/internal/config/password_source_test.go
+++ b/internal/config/password_source_test.go
@@ -222,4 +222,48 @@ func TestResolve(t *testing.T) {
 			t.Fatalf("got %+v", res)
 		}
 	})
+
+	t.Run("defaults_file password used when no CLI flags and password_env unset", func(t *testing.T) {
+		job := BackupJob{Type: "mysql", myCnfPassword: "fromfile"}
+		res, err := Resolve(ResolveFlags{}, job)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if res.Source != SourceConfigEnv || res.Password != "fromfile" {
+			t.Fatalf("got %+v", res)
+		}
+	})
+}
+
+func TestResolveJobPassword(t *testing.T) {
+	t.Run("password_env set takes precedence, unchanged behavior", func(t *testing.T) {
+		t.Setenv("RJP_ENV_VAR", "envvalue")
+		job := BackupJob{PasswordEnv: "RJP_ENV_VAR", myCnfPassword: "fromfile"}
+		got, err := ResolveJobPassword(job)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if got != "envvalue" {
+			t.Fatalf("got %q, want envvalue (password_env must win)", got)
+		}
+	})
+
+	t.Run("myCnfPassword used when password_env unset", func(t *testing.T) {
+		job := BackupJob{myCnfPassword: "fromfile"}
+		got, err := ResolveJobPassword(job)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if got != "fromfile" {
+			t.Fatalf("got %q, want fromfile", got)
+		}
+	})
+
+	t.Run("neither set produces the same error as before this feature", func(t *testing.T) {
+		job := BackupJob{}
+		_, err := ResolveJobPassword(job)
+		if err == nil || !strings.Contains(err.Error(), "password_env is required") {
+			t.Fatalf("got err=%v, want 'password_env is required'", err)
+		}
+	})
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -275,6 +275,19 @@ type BackupJob struct {
 	// Password connection parameters (env-only, never inline)
 	PasswordEnv string `yaml:"password_env,omitempty"`
 
+	// DefaultsFile is a path to a MySQL/MariaDB option file (my.cnf). Its
+	// [client] section seeds host/user/password for BOTH the dump subprocess
+	// and Sentinel's own preflight/discovery when the corresponding field is
+	// not explicitly configured. Explicit fields always take precedence;
+	// valid only for mysql/mariadb (spec 056 / PRD 44).
+	DefaultsFile string `yaml:"defaults_file,omitempty"`
+
+	// myCnfPassword caches the password resolved from DefaultsFile at config
+	// load time (internal/config/loader.go). Not part of the YAML schema —
+	// mirrors Name's yaml:"-" pattern for a runtime-computed field. Read only
+	// via ResolveJobPassword to keep resolution centralized in one place.
+	myCnfPassword string
+
 	// MongoDB URI (env-only variant)
 	URI    string `yaml:"uri,omitempty"`
 	URIEnv string `yaml:"uri_env,omitempty"`

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -178,6 +178,9 @@ func warnPlaintextCredentials(name string, job BackupJob) {
 }
 
 func validateConnection(job BackupJob) error {
+	if job.DefaultsFile != "" && job.Type != "mysql" && job.Type != "mariadb" {
+		return fmt.Errorf("defaults_file is only valid for mysql or mariadb backup jobs")
+	}
 	if job.Type == "mongodb" {
 		if job.URI == "" && job.URIEnv == "" {
 			return fmt.Errorf("uri_env is required for mongodb backups")
@@ -191,7 +194,10 @@ func validateConnection(job BackupJob) error {
 	if job.Username == "" && job.UsernameEnv == "" {
 		return fmt.Errorf("username or username_env is required")
 	}
-	if job.PasswordEnv == "" {
+	// myCnfPassword is resolved from defaults_file at load time (loader.go);
+	// its presence means password_env's requirement is satisfied by the file
+	// instead (spec 056 / PRD 44).
+	if job.PasswordEnv == "" && job.myCnfPassword == "" {
 		return fmt.Errorf("password_env is required")
 	}
 	return nil

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,6 +2,31 @@
 
 ## [Unreleased]
 
+### Added
+
+- **MySQL/MariaDB credential loading from a my.cnf defaults file** (`defaults_file`):
+  a new per-job config field, valid only for `mysql`/`mariadb`, that seeds
+  `host`/`user`/`password`/`port` from a standard option file's `[client]`
+  section for the **entire** backup pipeline — the pre-backup connectivity
+  check, `database: "*"` auto-discovery, and the dump itself — not just the
+  dump subprocess (closing GitHub issue #28). Previously, the existing
+  `additional_args: "--defaults-extra-file=..."` passthrough only reached
+  `mysqldump`/`mariadb-dump` directly; Sentinel's own Go-side preflight and
+  discovery never saw those credentials, so `database: "*"` auto-discovery
+  was entirely blocked when credentials lived only in a my.cnf file.
+  Precedence: explicit job fields (`host`/`host_env`, `username`/
+  `username_env`, `password_env`) always win; `defaults_file` only fills
+  fields left unset. A missing, unreadable, or malformed `defaults_file`
+  fails at **configuration-load time**, never partway through a live backup
+  run. A group- or world-readable file emits the same permission warning as
+  the existing `--password-file` channel. Only the `[client]` section is
+  parsed (no `[mysqldump]`-style tool sections, no `!include`/`!includedir`
+  directives) — a documented v1 limitation, not a gap. Rejected by config
+  validation on any non-mysql/mariadb job. No new port; zero behavior change
+  for jobs that don't set `defaults_file`. Runbook:
+  [`docs/runbooks/credentials.md`](docs/runbooks/credentials.md).
+  (spec 056 / PRD 44)
+
 ### Security / Supply chain
 
 - **signed release checksums (cosign keyless)**: each release now signs its


### PR DESCRIPTION
## Summary

Adds `defaults_file` — MySQL/MariaDB credential loading from a standard my.cnf-format option file, closing GitHub issue #28. **spec 056 / PRD 44.**

The new field seeds `host`/`user`/`password`/`port` for the **whole** backup pipeline — the pre-backup connectivity check, `database: "*"` auto-discovery, and the dump itself — not just the dump subprocess. Previously, credentials living only in a my.cnf file made the dump succeed (via the existing `additional_args: "--defaults-extra-file=..."` passthrough to `mysqldump`/`mariadb-dump`) but left discovery and the connectivity check without credentials, since neither ever saw the file. This PR closes that gap.

## A real-code correction along the way

Research traced the actual call graph rather than assuming the PRD's stated wiring: the connectivity check for a live backup run happens **inside** the engine dump adapters (`mysql.Backup`/`mariadb.Backup`), reading already-resolved dump-arg fields — not via `ports.DatabaseConfig`/`db_probe`, which is unwired on this path today (`PingBeforeDump` is never set `true` anywhere in the codebase). So `db_probe` and the dump builders need **zero edits**; the real fix is upstream, at exactly two password-resolution call sites.

## Changes

- `internal/config/types.go`: `DefaultsFile string` (authorable) + unexported `myCnfPassword string` (runtime-computed cache, mirrors the existing `Name string \`yaml:"-"\`` pattern — no plaintext `password:` field ever enters the YAML schema).
- `internal/adapters/mysqlargs/defaults_file.go` (new): stdlib-only `[client]`-section parser. Only `[client]` is read; other sections and include directives are ignored, not errors.
- `internal/config/defaults_file_resolve.go` (new): applies the file's fallback (explicit config always wins) + the group/world-readable permission warning (mirrors the existing `--password-file` channel's `0o044` check).
- `internal/config/password_source.go`: new shared `ResolveJobPassword(job)` — `password_env` wins if set, else the file's cached password, else the same error as today. `Resolve()`'s fallback line now calls this instead of `PasswordFromEnv` directly.
- `internal/config/validator.go`: rejects `defaults_file` on non-mysql/mariadb jobs. **Also fixes a real latent bug this feature surfaces**: `validateConnection` unconditionally required `password_env` even when a file already supplied a password — now skipped when the file resolved one.
- `internal/cli/backup.go`: `listDatabases` (auto-discovery) now calls `ResolveJobPassword` instead of `PasswordFromEnv` directly — the second and last call site that needed to converge.

## Safety / no-regression

Zero behavior change for jobs that don't set `defaults_file` — traced every affected call site to confirm the unset path is byte-for-byte the pre-feature code, not just asserted. No new port; no `internal/domain/**`/`internal/ports/**` change; `db_probe` and the dump builders untouched (confirmed via diff).

## Testing

`go build`/`go vet` clean. `go test ./...` **0 failures** (23 new tests: parser edge cases, resolver precedence, load-time fail-fast, explicit-override, wrong-type rejection, permission warning, explicit no-regression proof). `golangci-lint run` **0 issues**.

Runbook (`docs/runbooks/credentials.md`) and `release-notes.md` updated.

## Known gap (documented, not a regression)

`listDatabases`'s one-line call-site swap isn't covered by a literal unit test — it opens a real MySQL/MariaDB connection with no existing mock (integration/docker territory). The swap itself is fully covered transitively via `ResolveJobPassword`'s unit tests plus the `LoadConfig`-level test exercising the identical resolver on the CLI-flag path.
