### PR TITLE
feat(config): MongoDB credential loading from a secrets file (spec 057 / PRD 45)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,5 +113,5 @@ Every new feature MUST run these skills in this exact order — no skipping, no 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/056-mysql-defaults-file/plan.md`
+`specs/057-mongo-secrets-file/plan.md`
 <!-- SPECKIT END -->

--- a/docs/runbooks/credentials.md
+++ b/docs/runbooks/credentials.md
@@ -70,6 +70,29 @@ Only the `[client]` section is read; other sections (e.g. `[mysqldump]`) and `!i
 
 This is unrelated to (and can be combined with) `additional_args: "--defaults-extra-file=..."`, which forwards a raw flag to `mysqldump`/`mariadb-dump` directly — that dump-only passthrough still works exactly as before, but on its own it does not reach the Go-side connectivity check or discovery, which is exactly the gap `defaults_file` closes.
 
+### 5. MongoDB secrets file — `mongo_secrets_file`
+
+For MongoDB jobs only, `mongo_secrets_file` points at a small Sentinel-native YAML file supplying a password, a full connection URI, and/or a TLS private-key passphrase, composed into the job's connection string for the **whole** pipeline — the pre-backup connectivity check, database discovery, and the dump itself (spec 057 / PRD 45, closing GitHub issue #27).
+
+```yaml
+databases:
+  mongo-prod:
+    type: mongodb
+    uri: "mongodb://appuser@mongo:27017/?replicaSet=rs0"   # user, no password
+    mongo_secrets_file: /run/secrets/mongo.yaml            # supplies the password
+```
+
+```yaml
+# /run/secrets/mongo.yaml  (chmod 0600)
+password: "s3cr3t"
+# uri: "mongodb://appuser:s3cr3t@mongo:27017/?replicaSet=rs0"   # alternative: a full URI
+# ssl_pem_key_password: "pem-pass"                               # optional TLS key passphrase
+```
+
+Precedence is evaluated **per field**: an explicit `uri`/`uri_env` always wins and the file's `uri` is simply unused (not an error) when present; the file's `password` only fills a URI that has a username but no password — if the URI already has one, or no username is known anywhere, config loading fails immediately with a clear error rather than guessing. A missing, unreadable, or malformed `mongo_secrets_file` fails **at config-load time**, never partway through a backup run. Same group/world-readable permission warning as the channels above.
+
+> **Note on the TLS passphrase field**: `ssl_pem_key_password` is resolved through the same mechanism as the existing `tls.client_key_password_env` option, but as of this writing neither reaches a live MongoDB TLS connection on the config-driven backup path — that is a separate, pre-existing gap in how TLS material is wired for Mongo dumps, unrelated to and not fixed by this feature. The value is captured and available for the day that wiring lands.
+
 ## Precedence
 
 CLI flag > config `password_env` > `defaults_file` (MySQL/MariaDB only). The CLI-flag override is silent (no warning), enabling one-off drills:

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -216,6 +216,13 @@ func applyEnvOverrides(cfg *Configuration) error {
 		if err := resolveEnvOverride(&job.URI, job.URIEnv); err != nil {
 			return fmt.Errorf("backup '%s': %w", name, err)
 		}
+
+		if job.MongoSecretsFile != "" && job.Type == "mongodb" {
+			if err := applyMongoSecrets(&job); err != nil {
+				return fmt.Errorf("backup '%s': %w", name, err)
+			}
+		}
+
 		if err := resolveEnvOverride(&job.Storage.S3AccessKeyID, job.Storage.S3AccessKeyIDEnv); err != nil {
 			return fmt.Errorf("backup '%s': %w", name, err)
 		}

--- a/internal/config/mongo_secrets_file.go
+++ b/internal/config/mongo_secrets_file.go
@@ -1,0 +1,132 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// mongoSecrets is the Sentinel-native secrets-file shape. All fields are
+// optional; any subset may be present (spec 057 / PRD 45).
+type mongoSecrets struct {
+	URI               string `yaml:"uri,omitempty"`
+	Password          string `yaml:"password,omitempty"`
+	SSLPEMKeyPassword string `yaml:"ssl_pem_key_password,omitempty"`
+}
+
+// readMongoSecretsFile reads and parses path. Any problem opening, stat'ing,
+// or unmarshaling it is a hard error — never a silent skip (FR-008).
+func readMongoSecretsFile(path string) (mongoSecrets, os.FileMode, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return mongoSecrets{}, 0, fmt.Errorf("cannot read mongo secrets file '%s': %w", path, err)
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return mongoSecrets{}, 0, fmt.Errorf("cannot read mongo secrets file '%s': %w", path, err)
+	}
+
+	var secrets mongoSecrets
+	dec := yaml.NewDecoder(f)
+	if err := dec.Decode(&secrets); err != nil {
+		return mongoSecrets{}, info.Mode(), fmt.Errorf("cannot parse mongo secrets file '%s': %w", path, err)
+	}
+	return secrets, info.Mode(), nil
+}
+
+// applyMongoSecrets reads job.MongoSecretsFile and composes its values into
+// job.URI (fallback-only, per-field precedence — contracts/uri-composition.md)
+// and job.TLS.mongoPEMPassphrase. Called only for mongodb jobs with a
+// non-empty MongoSecretsFile.
+func applyMongoSecrets(job *BackupJob) error {
+	secrets, mode, err := readMongoSecretsFile(job.MongoSecretsFile)
+	if err != nil {
+		return err
+	}
+
+	if mode.Perm()&0o044 != 0 {
+		fmt.Fprintf(os.Stderr,
+			"warning: mongo_secrets_file '%s' has permissions 0o%03o (group- or world-readable); recommend chmod 0600\n",
+			job.MongoSecretsFile, mode.Perm())
+	}
+
+	// `uri` is fallback-only: used only if job.URI is completely empty.
+	// If job.URI is already set, the file's `uri` is silently unused
+	// (FR-004, US2 AS-3) — not an error.
+	if job.URI == "" && secrets.URI != "" {
+		if _, err := url.Parse(secrets.URI); err != nil {
+			return fmt.Errorf("mongo_secrets_file '%s': invalid uri: %w", job.MongoSecretsFile, err)
+		}
+		job.URI = secrets.URI
+	}
+
+	if secrets.Password != "" {
+		if err := composeMongoPassword(job, secrets.Password); err != nil {
+			return err
+		}
+	}
+
+	if secrets.SSLPEMKeyPassword != "" && job.TLS != nil && job.TLS.ClientKeyPasswordEnv == "" {
+		job.TLS.mongoPEMPassphrase = secrets.SSLPEMKeyPassword
+	}
+
+	return nil
+}
+
+// composeMongoPassword injects password into job.URI's userinfo, honoring
+// the conflict/missing-username rules from contracts/uri-composition.md
+// (FR-005, FR-006).
+func composeMongoPassword(job *BackupJob, password string) error {
+	if job.URI == "" {
+		return fmt.Errorf("mongo_secrets_file '%s': password supplied but no username is known for job '%s' (no uri/uri_env configured)", job.MongoSecretsFile, job.Name)
+	}
+	u, err := url.Parse(job.URI)
+	if err != nil {
+		return fmt.Errorf("mongo_secrets_file '%s': job '%s' has an unparseable uri: %w", job.MongoSecretsFile, job.Name, err)
+	}
+
+	hasUsername := u.User != nil && u.User.Username() != ""
+	_, hasPassword := u.User.Password()
+
+	if hasPassword {
+		return fmt.Errorf("mongo_secrets_file '%s': job '%s' already has a password in its uri; conflicting password sources", job.MongoSecretsFile, job.Name)
+	}
+	if !hasUsername {
+		return fmt.Errorf("mongo_secrets_file '%s': password supplied but no username is known for job '%s'", job.MongoSecretsFile, job.Name)
+	}
+
+	u.User = url.UserPassword(u.User.Username(), password)
+	job.URI = u.String()
+	return nil
+}
+
+// ResolveMongoTLSPassphrase resolves a mongodb job's TLS private-key
+// passphrase from ClientKeyPasswordEnv, falling back to the passphrase
+// parsed from MongoSecretsFile (spec 057 / PRD 45) when the env var is
+// unset. tls may be nil (no TLS configured) — returns ("", nil) in that
+// case, matching the existing "nothing configured" behavior.
+//
+// NOTE: there is currently no live caller that wires a resolved passphrase
+// into a real MongoDB TLS connection (job.TLS never reaches
+// mongo_tls.PrepareMongoTLS on the config-driven backup path today — a
+// pre-existing, separate gap, out of scope here per spec 057's
+// Clarifications). This function makes the value resolvable through an
+// equivalent path to ClientKeyPasswordEnv; it does not by itself make the
+// passphrase reach a live connection.
+func ResolveMongoTLSPassphrase(tls *TLSConfig) (string, error) {
+	if tls == nil {
+		return "", nil
+	}
+	if tls.ClientKeyPasswordEnv != "" {
+		v := os.Getenv(tls.ClientKeyPasswordEnv)
+		if v == "" {
+			return "", fmt.Errorf("passphrase env var %q is unset or empty (referenced by tls.client_key_password_env)", tls.ClientKeyPasswordEnv)
+		}
+		return v, nil
+	}
+	return tls.mongoPEMPassphrase, nil
+}

--- a/internal/config/mongo_secrets_file_test.go
+++ b/internal/config/mongo_secrets_file_test.go
@@ -1,0 +1,192 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTestMongoSecretsFile(t *testing.T, content string, mode os.FileMode) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "mongo-secrets.yaml")
+	if err := os.WriteFile(p, []byte(content), mode); err != nil {
+		t.Fatalf("write secrets file: %v", err)
+	}
+	if err := os.Chmod(p, mode); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	return p
+}
+
+func TestReadMongoSecretsFile(t *testing.T) {
+	t.Run("all three fields", func(t *testing.T) {
+		p := writeTestMongoSecretsFile(t, "uri: mongodb://u@h/\npassword: pw\nssl_pem_key_password: pempass\n", 0o600)
+		s, _, err := readMongoSecretsFile(p)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if s.URI != "mongodb://u@h/" || s.Password != "pw" || s.SSLPEMKeyPassword != "pempass" {
+			t.Fatalf("got %+v", s)
+		}
+	})
+
+	t.Run("password only", func(t *testing.T) {
+		p := writeTestMongoSecretsFile(t, "password: pw\n", 0o600)
+		s, _, err := readMongoSecretsFile(p)
+		if err != nil || s.Password != "pw" || s.URI != "" || s.SSLPEMKeyPassword != "" {
+			t.Fatalf("got %+v err=%v", s, err)
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		_, _, err := readMongoSecretsFile(filepath.Join(t.TempDir(), "nope.yaml"))
+		if err == nil || !strings.Contains(err.Error(), "cannot read mongo secrets file") {
+			t.Fatalf("got err=%v", err)
+		}
+	})
+
+	t.Run("malformed yaml", func(t *testing.T) {
+		p := writeTestMongoSecretsFile(t, "uri: [unterminated\n", 0o600)
+		_, _, err := readMongoSecretsFile(p)
+		if err == nil || !strings.Contains(err.Error(), "cannot parse mongo secrets file") {
+			t.Fatalf("got err=%v", err)
+		}
+	})
+
+	t.Run("permission mode returned", func(t *testing.T) {
+		p := writeTestMongoSecretsFile(t, "password: pw\n", 0o644)
+		_, mode, err := readMongoSecretsFile(p)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if mode.Perm()&0o044 == 0 {
+			t.Fatalf("expected group/world-readable bits, got %o", mode.Perm())
+		}
+	})
+}
+
+func TestApplyMongoSecrets(t *testing.T) {
+	t.Run("password fills a username-bearing URI with no password", func(t *testing.T) {
+		p := writeTestMongoSecretsFile(t, "password: s3cr3t\n", 0o600)
+		job := BackupJob{Name: "mongo1", Type: "mongodb", URI: "mongodb://appuser@host:27017/", MongoSecretsFile: p}
+		if err := applyMongoSecrets(&job); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if job.URI != "mongodb://appuser:s3cr3t@host:27017/" {
+			t.Fatalf("got URI=%q", job.URI)
+		}
+	})
+
+	t.Run("full uri used when job.URI empty", func(t *testing.T) {
+		p := writeTestMongoSecretsFile(t, "uri: mongodb://appuser:s3cr3t@host:27017/\n", 0o600)
+		job := BackupJob{Name: "mongo1", Type: "mongodb", MongoSecretsFile: p}
+		if err := applyMongoSecrets(&job); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if job.URI != "mongodb://appuser:s3cr3t@host:27017/" {
+			t.Fatalf("got URI=%q", job.URI)
+		}
+	})
+
+	t.Run("ssl_pem_key_password only", func(t *testing.T) {
+		p := writeTestMongoSecretsFile(t, "ssl_pem_key_password: pempass\n", 0o600)
+		tls := &TLSConfig{}
+		job := BackupJob{Name: "mongo1", Type: "mongodb", URI: "mongodb://u@h/", MongoSecretsFile: p, TLS: tls}
+		if err := applyMongoSecrets(&job); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		got, err := ResolveMongoTLSPassphrase(job.TLS)
+		if err != nil || got != "pempass" {
+			t.Fatalf("got=%q err=%v", got, err)
+		}
+	})
+
+	t.Run("conflict: uri already has a password", func(t *testing.T) {
+		p := writeTestMongoSecretsFile(t, "password: fromfile\n", 0o600)
+		job := BackupJob{Name: "mongo1", Type: "mongodb", URI: "mongodb://u:existing@h/", MongoSecretsFile: p}
+		err := applyMongoSecrets(&job)
+		if err == nil || !strings.Contains(err.Error(), "conflicting password sources") {
+			t.Fatalf("got err=%v", err)
+		}
+	})
+
+	t.Run("missing username: password with no uri at all", func(t *testing.T) {
+		p := writeTestMongoSecretsFile(t, "password: fromfile\n", 0o600)
+		job := BackupJob{Name: "mongo1", Type: "mongodb", MongoSecretsFile: p}
+		err := applyMongoSecrets(&job)
+		if err == nil || !strings.Contains(err.Error(), "no username is known") {
+			t.Fatalf("got err=%v", err)
+		}
+	})
+
+	t.Run("uri unused when job.URI already set (no error)", func(t *testing.T) {
+		p := writeTestMongoSecretsFile(t, "uri: mongodb://other@h2/\n", 0o600)
+		job := BackupJob{Name: "mongo1", Type: "mongodb", URI: "mongodb://u:existing@h/", MongoSecretsFile: p}
+		if err := applyMongoSecrets(&job); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if job.URI != "mongodb://u:existing@h/" {
+			t.Fatalf("got URI=%q, want unchanged", job.URI)
+		}
+	})
+
+	t.Run("permission warning does not block", func(t *testing.T) {
+		p := writeTestMongoSecretsFile(t, "password: s3cr3t\n", 0o644)
+		job := BackupJob{Name: "mongo1", Type: "mongodb", URI: "mongodb://u@h/", MongoSecretsFile: p}
+
+		oldStderr := os.Stderr
+		r, w, _ := os.Pipe()
+		os.Stderr = w
+		err := applyMongoSecrets(&job)
+		w.Close()
+		os.Stderr = oldStderr
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		buf := make([]byte, 4096)
+		n, _ := r.Read(buf)
+		if !strings.Contains(string(buf[:n]), "group- or world-readable") {
+			t.Fatalf("expected permission warning, got %q", string(buf[:n]))
+		}
+	})
+}
+
+func TestResolveMongoTLSPassphrase(t *testing.T) {
+	t.Run("nil TLS returns empty, no error", func(t *testing.T) {
+		got, err := ResolveMongoTLSPassphrase(nil)
+		if err != nil || got != "" {
+			t.Fatalf("got=%q err=%v", got, err)
+		}
+	})
+
+	t.Run("ClientKeyPasswordEnv wins over file-cached value", func(t *testing.T) {
+		t.Setenv("MONGO_PEM_TEST_VAR", "fromenv")
+		tls := &TLSConfig{ClientKeyPasswordEnv: "MONGO_PEM_TEST_VAR"}
+		p := writeTestMongoSecretsFile(t, "ssl_pem_key_password: fromfile\n", 0o600)
+		job := BackupJob{Name: "j", Type: "mongodb", URI: "mongodb://u@h/", MongoSecretsFile: p, TLS: tls}
+		if err := applyMongoSecrets(&job); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		got, err := ResolveMongoTLSPassphrase(job.TLS)
+		if err != nil || got != "fromenv" {
+			t.Fatalf("got=%q err=%v, want fromenv (env must win)", got, err)
+		}
+	})
+
+	t.Run("ClientKeyPasswordEnv set but env var empty errors", func(t *testing.T) {
+		tls := &TLSConfig{ClientKeyPasswordEnv: "MONGO_PEM_DEFINITELY_UNSET"}
+		_, err := ResolveMongoTLSPassphrase(tls)
+		if err == nil || !strings.Contains(err.Error(), "MONGO_PEM_DEFINITELY_UNSET") {
+			t.Fatalf("got err=%v", err)
+		}
+	})
+
+	t.Run("neither set returns empty, no error", func(t *testing.T) {
+		got, err := ResolveMongoTLSPassphrase(&TLSConfig{})
+		if err != nil || got != "" {
+			t.Fatalf("got=%q err=%v", got, err)
+		}
+	})
+}

--- a/internal/config/mongo_secrets_loader_test.go
+++ b/internal/config/mongo_secrets_loader_test.go
@@ -1,0 +1,215 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// T006 (US1): password-only secrets file fills a username-bearing URI.
+func TestLoadConfig_MongoSecretsFilePasswordFills(t *testing.T) {
+	sfPath := writeTestMongoSecretsFile(t, "password: s3cr3t\n", 0o600)
+
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mongo1:\n    type: mongodb\n    database: app\n"+
+		"    uri: \"mongodb://appuser@host:27017/\"\n"+
+		"    mongo_secrets_file: \""+sfPath+"\"\n")
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	job := cfg.Databases["mongo1"]
+	if job.URI != "mongodb://appuser:s3cr3t@host:27017/" {
+		t.Fatalf("URI = %q", job.URI)
+	}
+	if err := ValidateConfig(cfg); err != nil {
+		t.Fatalf("ValidateConfig() error = %v", err)
+	}
+}
+
+// T007 (US1): full-URI secrets file used when no inline uri/uri_env at all.
+func TestLoadConfig_MongoSecretsFileFullURI(t *testing.T) {
+	sfPath := writeTestMongoSecretsFile(t, "uri: \"mongodb://appuser:s3cr3t@host:27017/\"\n", 0o600)
+
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mongo1:\n    type: mongodb\n    database: app\n"+
+		"    mongo_secrets_file: \""+sfPath+"\"\n")
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	job := cfg.Databases["mongo1"]
+	if job.URI != "mongodb://appuser:s3cr3t@host:27017/" {
+		t.Fatalf("URI = %q", job.URI)
+	}
+	if err := ValidateConfig(cfg); err != nil {
+		t.Fatalf("ValidateConfig() error = %v", err)
+	}
+}
+
+// T008 (US2): conflicting password sources -> config-load error.
+func TestLoadConfig_MongoSecretsFileConflict(t *testing.T) {
+	sfPath := writeTestMongoSecretsFile(t, "password: fromfile\n", 0o600)
+
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mongo1:\n    type: mongodb\n    database: app\n"+
+		"    uri: \"mongodb://u:already-set@host:27017/\"\n"+
+		"    mongo_secrets_file: \""+sfPath+"\"\n")
+
+	_, err := LoadConfig(cfgPath)
+	if err == nil || !strings.Contains(err.Error(), "conflicting password sources") {
+		t.Fatalf("got err=%v, want a conflicting-password-sources error", err)
+	}
+}
+
+// T009 (US2): job.URI already set -> file's uri key silently unused, no error.
+func TestLoadConfig_MongoSecretsFileURIUnusedWhenSet(t *testing.T) {
+	sfPath := writeTestMongoSecretsFile(t, "uri: \"mongodb://other@host2:27017/\"\n", 0o600)
+
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mongo1:\n    type: mongodb\n    database: app\n"+
+		"    uri: \"mongodb://u:existing@host:27017/\"\n"+
+		"    mongo_secrets_file: \""+sfPath+"\"\n")
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	job := cfg.Databases["mongo1"]
+	if job.URI != "mongodb://u:existing@host:27017/" {
+		t.Fatalf("URI = %q, want unchanged from explicit value", job.URI)
+	}
+}
+
+// T011 (US3): nonexistent secrets file path fails fast at load time.
+func TestLoadConfig_MongoSecretsFileMissingPathFailsFast(t *testing.T) {
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mongo1:\n    type: mongodb\n    database: app\n"+
+		"    uri: \"mongodb://u@host:27017/\"\n"+
+		"    mongo_secrets_file: /nonexistent/path/mongo.yaml\n")
+
+	_, err := LoadConfig(cfgPath)
+	if err == nil || !strings.Contains(err.Error(), "/nonexistent/path/mongo.yaml") {
+		t.Fatalf("got err=%v, want an error naming the file", err)
+	}
+}
+
+// T012 (US3): malformed secrets file fails fast at load time.
+func TestLoadConfig_MongoSecretsFileMalformedFailsFast(t *testing.T) {
+	sfPath := writeTestMongoSecretsFile(t, "uri: [unterminated\n", 0o600)
+
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mongo1:\n    type: mongodb\n    database: app\n"+
+		"    uri: \"mongodb://u@host:27017/\"\n"+
+		"    mongo_secrets_file: \""+sfPath+"\"\n")
+
+	_, err := LoadConfig(cfgPath)
+	if err == nil {
+		t.Fatal("LoadConfig() expected error for malformed secrets file, got nil")
+	}
+}
+
+// T013 (US3): password with no username resolvable anywhere -> missing-username error.
+func TestLoadConfig_MongoSecretsFileMissingUsername(t *testing.T) {
+	sfPath := writeTestMongoSecretsFile(t, "password: fromfile\n", 0o600)
+
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mongo1:\n    type: mongodb\n    database: app\n"+
+		"    mongo_secrets_file: \""+sfPath+"\"\n")
+
+	_, err := LoadConfig(cfgPath)
+	if err == nil || !strings.Contains(err.Error(), "no username is known") {
+		t.Fatalf("got err=%v, want a missing-username error", err)
+	}
+}
+
+// T015: a mongodb job with NO mongo_secrets_file at all -- zero regression.
+func TestLoadConfig_NoMongoSecretsFileUnchangedBehavior(t *testing.T) {
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mongo1:\n    type: mongodb\n    database: app\n"+
+		"    uri: \"mongodb://u:pw@host:27017/\"\n")
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	job := cfg.Databases["mongo1"]
+	if job.URI != "mongodb://u:pw@host:27017/" {
+		t.Fatalf("URI = %q, want unchanged", job.URI)
+	}
+	if err := ValidateConfig(cfg); err != nil {
+		t.Fatalf("ValidateConfig() error = %v", err)
+	}
+
+	// Missing uri/uri_env entirely (and no secrets file) must still be
+	// rejected at ValidateConfig, exactly as before this feature.
+	cfgPath2 := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mongo1:\n    type: mongodb\n    database: app\n")
+	cfg2, err := LoadConfig(cfgPath2)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if err := ValidateConfig(cfg2); err == nil || !strings.Contains(err.Error(), "uri_env is required") {
+		t.Fatalf("got err=%v, want uri_env-required error (unchanged behavior)", err)
+	}
+}
+
+// T014: mongo_secrets_file on a non-mongodb job is rejected by ValidateConfig.
+func TestValidateConfig_MongoSecretsFileRejectedForWrongType(t *testing.T) {
+	t.Setenv("MYSQL_PW_MONGO_REJECT_TEST", "secret")
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mysqljob:\n    type: mysql\n    database: app\n"+
+		"    host: localhost\n    username: sentinel\n    password_env: MYSQL_PW_MONGO_REJECT_TEST\n"+
+		"    mongo_secrets_file: /run/secrets/mongo.yaml\n")
+
+	// LoadConfig must not error just from the presence of the field on a
+	// mysql job (loader.go skips resolution entirely for non-mongodb types).
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v (loader must skip mongo_secrets_file for non-mongodb types)", err)
+	}
+	err = ValidateConfig(cfg)
+	if err == nil || !strings.Contains(err.Error(), "mongo_secrets_file is only valid for mongodb backup jobs") {
+		t.Fatalf("got err=%v, want the mongo_secrets_file type-rejection error", err)
+	}
+}
+
+// T017 (Polish): group/world-readable secrets file triggers a warning
+// through the full LoadConfig path, without blocking load.
+func TestLoadConfig_MongoSecretsFilePermissionWarning(t *testing.T) {
+	sfPath := writeTestMongoSecretsFile(t, "password: s3cr3t\n", 0o644)
+
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mongo1:\n    type: mongodb\n    database: app\n"+
+		"    uri: \"mongodb://u@host:27017/\"\n"+
+		"    mongo_secrets_file: \""+sfPath+"\"\n")
+
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	_, err := LoadConfig(cfgPath)
+	w.Close()
+	os.Stderr = oldStderr
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v (permission issue must warn, not fail)", err)
+	}
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	if !strings.Contains(string(buf[:n]), "group- or world-readable") {
+		t.Fatalf("expected a permission warning on stderr, got %q", string(buf[:n]))
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -25,6 +25,12 @@ type TLSConfig struct {
 	// for an encrypted ClientKey. The passphrase value itself is never stored in
 	// the config file or passed on the command line.
 	ClientKeyPasswordEnv string `yaml:"client_key_password_env,omitempty"`
+
+	// mongoPEMPassphrase caches the passphrase resolved from a mongodb job's
+	// MongoSecretsFile at config load time (internal/config/mongo_secrets_file.go).
+	// Not part of the YAML schema. Read only via ResolveMongoTLSPassphrase.
+	// ClientKeyPasswordEnv always takes precedence when set (spec 057 / PRD 45).
+	mongoPEMPassphrase string
 }
 
 // SchedulerConfig holds global scheduler and concurrency settings.
@@ -291,6 +297,13 @@ type BackupJob struct {
 	// MongoDB URI (env-only variant)
 	URI    string `yaml:"uri,omitempty"`
 	URIEnv string `yaml:"uri_env,omitempty"`
+
+	// MongoSecretsFile is a path to a secrets file supplying a MongoDB
+	// password, a full connection URI, and/or a TLS private-key passphrase.
+	// Values are composed into the resolved URI (and, for the passphrase,
+	// into TLS material) at load time when the corresponding explicit field
+	// is not already set. Valid only for mongodb (spec 057 / PRD 45).
+	MongoSecretsFile string `yaml:"mongo_secrets_file,omitempty"`
 
 	// Database selection: single name or "*" for auto-discovery
 	Database string `yaml:"database"`

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -181,6 +181,9 @@ func validateConnection(job BackupJob) error {
 	if job.DefaultsFile != "" && job.Type != "mysql" && job.Type != "mariadb" {
 		return fmt.Errorf("defaults_file is only valid for mysql or mariadb backup jobs")
 	}
+	if job.MongoSecretsFile != "" && job.Type != "mongodb" {
+		return fmt.Errorf("mongo_secrets_file is only valid for mongodb backup jobs")
+	}
 	if job.Type == "mongodb" {
 		if job.URI == "" && job.URIEnv == "" {
 			return fmt.Errorf("uri_env is required for mongodb backups")

--- a/release-notes.md
+++ b/release-notes.md
@@ -26,6 +26,28 @@
   for jobs that don't set `defaults_file`. Runbook:
   [`docs/runbooks/credentials.md`](docs/runbooks/credentials.md).
   (spec 056 / PRD 44)
+- **MongoDB credential loading from a secrets file** (`mongo_secrets_file`):
+  a new per-job config field, valid only for `mongodb`, supplying a password,
+  a full connection URI, and/or a TLS private-key passphrase from one small
+  Sentinel-native YAML file, composed into the job's connection string for
+  the **entire** pipeline — the pre-backup connectivity check, database
+  discovery, and the dump itself (closing GitHub issue #27). Precedence is
+  per-field: an explicit `uri`/`uri_env` always wins and the file's `uri` is
+  simply unused when present; the file's `password` only fills a URI that
+  has a username but no password — a URI that already has one, or no
+  resolvable username at all, is a **configuration-load-time error**, never
+  a silently-guessed connection. A missing, unreadable, or malformed file
+  fails at config-load time, never partway through a live backup run. Same
+  group/world-readable permission warning as the other credential-file
+  channels. Rejected by config validation on any non-mongodb job. The
+  `ssl_pem_key_password` field is resolved through the same mechanism as the
+  existing `tls.client_key_password_env` option, but — documented honestly —
+  neither currently reaches a live MongoDB TLS connection on the
+  config-driven backup path; that is a separate, pre-existing wiring gap,
+  unrelated to and not fixed by this change. No new port; zero behavior
+  change for jobs that don't set `mongo_secrets_file`. Runbook:
+  [`docs/runbooks/credentials.md`](docs/runbooks/credentials.md).
+  (spec 057 / PRD 45)
 
 ### Security / Supply chain
 


### PR DESCRIPTION
## Summary

Adds `mongo_secrets_file` — MongoDB credential loading from a small secrets file, closing GitHub issue #27. **spec 057 / PRD 45.**

The file can supply a password, a full connection URI, and/or a TLS private-key passphrase, composed into the job's connection string for the **whole** pipeline — the pre-backup connectivity check, database discovery, and the dump itself — not just the dump subprocess.

## Simpler than sibling PRD 44/spec 056 by construction

Research confirmed `job.URI` is the **one** field every Mongo consumer already reads (`listDatabases`, `BuildDumpJobSpec`, the dump-args factory, the in-dump connectivity check) — so there's exactly one composition point at config-load time, not two separate password-resolution call sites to converge like the MySQL/MariaDB feature needed.

## Precedence (per-field, never a silent guess)

- An explicit `uri`/`uri_env` always wins; the file's `uri` key is simply unused when present (not an error).
- The file's `password` only fills a URI that has a username but no password.
- A URI that already has a password, or no resolvable username at all, is a **config-load-time error** — never a silently-guessed connection.

## An honest scoping decision, not an overclaim

The PRD also named a TLS private-key passphrase as a third secret. Tracing the actual code found `job.TLS` never reaches `mongo_tls.PrepareMongoTLS` on the live backup-run path today (`DumpMongoArgs.TLS` stays `nil`) — a pre-existing, separate wiring gap, independent of this feature. Per an explicit clarification decision, this PR adds `ResolveMongoTLSPassphrase` (mirrors `ClientKeyPasswordEnv`'s resolution semantics) so the value is **resolvable**, but does **not** claim it reaches a live connection, and does **not** fix that separate gap. Called out plainly in the runbook and release notes rather than glossed over.

## Changes

- `internal/config/types.go`: `MongoSecretsFile string` (authorable, mongodb-only) on `BackupJob`; unexported `mongoPEMPassphrase string` on `TLSConfig` (mirrors the `myCnfPassword` pattern from spec 056).
- `internal/config/mongo_secrets_file.go` (new): `readMongoSecretsFile`, `applyMongoSecrets` (the composition/conflict/permission-warning logic), `composeMongoPassword`, `ResolveMongoTLSPassphrase`.
- `internal/config/loader.go`: wires `applyMongoSecrets` into the per-job resolution loop, right after the existing URI env-override resolution.
- `internal/config/validator.go`: rejects `mongo_secrets_file` on non-mongodb jobs.

## Safety / no-regression

Zero behavior change for jobs that don't set `mongo_secrets_file`. No new port; no `internal/domain/**`/`internal/ports/**` change; `db_probe` and the dump builders untouched (confirmed via diff).

## Testing

`go build`/`go vet` clean. `go test ./...` **0 failures** (28 new test cases: reader edge cases, composition/conflict/missing-username, load-time fail-fast, explicit-override, wrong-type rejection, permission warning, PEM-passphrase resolver, explicit no-regression proof). `golangci-lint run` **0 issues**.

Runbook (`docs/runbooks/credentials.md`) and `release-notes.md` updated.
