### PR TITLE
feat(config): environment-variable indirection for secrets-file paths (spec 058 / PRD 46)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,5 +113,5 @@ Every new feature MUST run these skills in this exact order — no skipping, no 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/057-mongo-secrets-file/plan.md`
+`specs/058-secrets-file-env-paths/plan.md`
 <!-- SPECKIT END -->

--- a/docs/runbooks/credentials.md
+++ b/docs/runbooks/credentials.md
@@ -70,6 +70,16 @@ Only the `[client]` section is read; other sections (e.g. `[mysqldump]`) and `!i
 
 This is unrelated to (and can be combined with) `additional_args: "--defaults-extra-file=..."`, which forwards a raw flag to `mysqldump`/`mariadb-dump` directly — that dump-only passthrough still works exactly as before, but on its own it does not reach the Go-side connectivity check or discovery, which is exactly the gap `defaults_file` closes.
 
+For deployments where the file's mount location is only known at runtime (Kubernetes secret mounts, ephemeral CI paths), point at it via `defaults_file_env` instead of a literal path — same precedence as every other `*_env` field (env wins when set; unset-but-referenced is a config-load error) (spec 058 / PRD 46):
+
+```yaml
+databases:
+  mydb:
+    type: mysql
+    database: "*"
+    defaults_file_env: MYSQL_DEFAULTS_FILE   # e.g. /var/run/secrets/db/my.cnf
+```
+
 ### 5. MongoDB secrets file — `mongo_secrets_file`
 
 For MongoDB jobs only, `mongo_secrets_file` points at a small Sentinel-native YAML file supplying a password, a full connection URI, and/or a TLS private-key passphrase, composed into the job's connection string for the **whole** pipeline — the pre-backup connectivity check, database discovery, and the dump itself (spec 057 / PRD 45, closing GitHub issue #27).
@@ -92,6 +102,16 @@ password: "s3cr3t"
 Precedence is evaluated **per field**: an explicit `uri`/`uri_env` always wins and the file's `uri` is simply unused (not an error) when present; the file's `password` only fills a URI that has a username but no password — if the URI already has one, or no username is known anywhere, config loading fails immediately with a clear error rather than guessing. A missing, unreadable, or malformed `mongo_secrets_file` fails **at config-load time**, never partway through a backup run. Same group/world-readable permission warning as the channels above.
 
 > **Note on the TLS passphrase field**: `ssl_pem_key_password` is resolved through the same mechanism as the existing `tls.client_key_password_env` option, but as of this writing neither reaches a live MongoDB TLS connection on the config-driven backup path — that is a separate, pre-existing gap in how TLS material is wired for Mongo dumps, unrelated to and not fixed by this feature. The value is captured and available for the day that wiring lands.
+
+Like `defaults_file`, the file's location can be injected via `mongo_secrets_file_env` instead of a literal path, with the same precedence rule (spec 058 / PRD 46):
+
+```yaml
+databases:
+  mongo-prod:
+    type: mongodb
+    uri: "mongodb://appuser@mongo:27017/?replicaSet=rs0"
+    mongo_secrets_file_env: MONGO_SECRETS_FILE   # e.g. /run/secrets/mongo.yaml
+```
 
 ## Precedence
 
@@ -168,10 +188,10 @@ After the v1.x deprecation release, no Sentinel backup adapter writes the databa
 
 | Engine | Password channel | Source file |
 |--------|-----------------|-------------|
-| PostgreSQL | `PGPASSWORD` env | `pkg/backup/pg_dump/pg_dump.go` |
-| MySQL | `MYSQL_PWD` env | `pkg/backup/mysql_dump/mysql_dump.go` |
-| MariaDB | `MYSQL_PWD` env | `pkg/backup/mariadb_dump/mariadb_dump.go` |
-| MongoDB | URI userinfo | `pkg/backup/mongo_dump/` |
+| PostgreSQL | `PGPASSWORD` env | `internal/adapters/dump/pg/` |
+| MySQL | `MYSQL_PWD` env | `internal/adapters/dump/mysql/` |
+| MariaDB | `MYSQL_PWD` env | `internal/adapters/dump/mariadb/` |
+| MongoDB | URI userinfo | `internal/adapters/dump/mongo/` |
 
 You can verify with `ps -o args= -p $(pgrep -f mariadb-dump)` during a backup; it must contain no `--password` or `password=` token.
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -217,6 +217,9 @@ func applyEnvOverrides(cfg *Configuration) error {
 			return fmt.Errorf("backup '%s': %w", name, err)
 		}
 
+		if err := resolveEnvOverride(&job.MongoSecretsFile, job.MongoSecretsFileEnv); err != nil {
+			return fmt.Errorf("backup '%s': %w", name, err)
+		}
 		if job.MongoSecretsFile != "" && job.Type == "mongodb" {
 			if err := applyMongoSecrets(&job); err != nil {
 				return fmt.Errorf("backup '%s': %w", name, err)
@@ -236,6 +239,9 @@ func applyEnvOverrides(cfg *Configuration) error {
 			return fmt.Errorf("backup '%s': %w", name, err)
 		}
 
+		if err := resolveEnvOverride(&job.DefaultsFile, job.DefaultsFileEnv); err != nil {
+			return fmt.Errorf("backup '%s': %w", name, err)
+		}
 		if job.DefaultsFile != "" && (job.Type == "mysql" || job.Type == "mariadb") {
 			if err := applyDefaultsFile(&job); err != nil {
 				return fmt.Errorf("backup '%s': %w", name, err)

--- a/internal/config/secrets_file_env_test.go
+++ b/internal/config/secrets_file_env_test.go
@@ -1,0 +1,197 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// T003 (US1): defaults_file_env only (no literal path) -> resolved and applied.
+func TestLoadConfig_DefaultsFileEnvOnly(t *testing.T) {
+	p := writeTestDefaultsFile(t, "[client]\nhost=127.0.0.1\nuser=sentinel\npassword=s3cr3t\n", 0o600)
+	t.Setenv("MYCNF_PATH_ENV", p)
+
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mydb:\n    type: mysql\n    database: app\n"+
+		"    defaults_file_env: MYCNF_PATH_ENV\n")
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	job := cfg.Databases["mydb"]
+	if job.DefaultsFile != p {
+		t.Fatalf("DefaultsFile = %q, want %q", job.DefaultsFile, p)
+	}
+	if job.Host != "127.0.0.1" || job.Username != "sentinel" {
+		t.Fatalf("got Host=%q Username=%q, want file contents applied", job.Host, job.Username)
+	}
+	pw, err := ResolveJobPassword(job)
+	if err != nil || pw != "s3cr3t" {
+		t.Fatalf("password = %q err=%v", pw, err)
+	}
+}
+
+// T004 (US1): mongo_secrets_file_env only (no literal path) -> resolved and applied.
+func TestLoadConfig_MongoSecretsFileEnvOnly(t *testing.T) {
+	p := writeTestMongoSecretsFile(t, "password: s3cr3t\n", 0o600)
+	t.Setenv("MONGO_SECRETS_PATH_ENV", p)
+
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mongo1:\n    type: mongodb\n    database: app\n"+
+		"    uri: \"mongodb://appuser@host:27017/\"\n"+
+		"    mongo_secrets_file_env: MONGO_SECRETS_PATH_ENV\n")
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	job := cfg.Databases["mongo1"]
+	if job.MongoSecretsFile != p {
+		t.Fatalf("MongoSecretsFile = %q, want %q", job.MongoSecretsFile, p)
+	}
+	if job.URI != "mongodb://appuser:s3cr3t@host:27017/" {
+		t.Fatalf("URI = %q, want composed password", job.URI)
+	}
+}
+
+// T005 (US2): defaults_file_env names an unset variable -> fails fast.
+func TestLoadConfig_DefaultsFileEnvUnsetVariable(t *testing.T) {
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mydb:\n    type: mysql\n    database: app\n"+
+		"    defaults_file_env: MYCNF_DEFINITELY_UNSET_VAR\n")
+
+	_, err := LoadConfig(cfgPath)
+	if err == nil || !strings.Contains(err.Error(), "MYCNF_DEFINITELY_UNSET_VAR") {
+		t.Fatalf("got err=%v, want an error naming the unset variable", err)
+	}
+}
+
+// T006 (US2): mongo_secrets_file_env names an unset variable -> fails fast.
+func TestLoadConfig_MongoSecretsFileEnvUnsetVariable(t *testing.T) {
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mongo1:\n    type: mongodb\n    database: app\n"+
+		"    uri: \"mongodb://u@host:27017/\"\n"+
+		"    mongo_secrets_file_env: MONGO_DEFINITELY_UNSET_VAR\n")
+
+	_, err := LoadConfig(cfgPath)
+	if err == nil || !strings.Contains(err.Error(), "MONGO_DEFINITELY_UNSET_VAR") {
+		t.Fatalf("got err=%v, want an error naming the unset variable", err)
+	}
+}
+
+// T007 (US3): literal defaults_file only (no _env) -> unchanged behavior.
+func TestLoadConfig_DefaultsFileLiteralOnlyUnaffectedByEnvFeature(t *testing.T) {
+	p := writeTestDefaultsFile(t, "[client]\nhost=127.0.0.1\nuser=sentinel\npassword=s3cr3t\n", 0o600)
+
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mydb:\n    type: mysql\n    database: app\n"+
+		"    defaults_file: \""+p+"\"\n")
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	job := cfg.Databases["mydb"]
+	if job.DefaultsFile != p || job.Host != "127.0.0.1" {
+		t.Fatalf("got DefaultsFile=%q Host=%q", job.DefaultsFile, job.Host)
+	}
+}
+
+// T008 (US3): literal mongo_secrets_file only (no _env) -> unchanged behavior.
+func TestLoadConfig_MongoSecretsFileLiteralOnlyUnaffectedByEnvFeature(t *testing.T) {
+	p := writeTestMongoSecretsFile(t, "password: s3cr3t\n", 0o600)
+
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mongo1:\n    type: mongodb\n    database: app\n"+
+		"    uri: \"mongodb://u@host:27017/\"\n"+
+		"    mongo_secrets_file: \""+p+"\"\n")
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	job := cfg.Databases["mongo1"]
+	if job.MongoSecretsFile != p || job.URI != "mongodb://u:s3cr3t@host:27017/" {
+		t.Fatalf("got MongoSecretsFile=%q URI=%q", job.MongoSecretsFile, job.URI)
+	}
+}
+
+// T009 (US3): both literal and _env set -> _env wins (precedence proof), for both mechanisms.
+func TestLoadConfig_SecretsFileEnvWinsOverLiteral(t *testing.T) {
+	t.Run("defaults_file", func(t *testing.T) {
+		literalPath := writeTestDefaultsFile(t, "[client]\nhost=wrong-host\nuser=wronguser\n", 0o600)
+		envPath := writeTestDefaultsFile(t, "[client]\nhost=right-host\nuser=rightuser\npassword=s3cr3t\n", 0o600)
+		t.Setenv("MYCNF_PRECEDENCE_VAR", envPath)
+
+		cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+			"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+			"databases:\n  mydb:\n    type: mysql\n    database: app\n"+
+			"    defaults_file: \""+literalPath+"\"\n"+
+			"    defaults_file_env: MYCNF_PRECEDENCE_VAR\n")
+
+		cfg, err := LoadConfig(cfgPath)
+		if err != nil {
+			t.Fatalf("LoadConfig() error = %v", err)
+		}
+		job := cfg.Databases["mydb"]
+		if job.DefaultsFile != envPath {
+			t.Fatalf("DefaultsFile = %q, want the env-resolved path %q (env must win)", job.DefaultsFile, envPath)
+		}
+		if job.Host != "right-host" {
+			t.Fatalf("Host = %q, want right-host (from the env-resolved file)", job.Host)
+		}
+	})
+
+	t.Run("mongo_secrets_file", func(t *testing.T) {
+		literalPath := writeTestMongoSecretsFile(t, "password: wrongpass\n", 0o600)
+		envPath := writeTestMongoSecretsFile(t, "password: s3cr3t\n", 0o600)
+		t.Setenv("MONGO_SECRETS_PRECEDENCE_VAR", envPath)
+
+		cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+			"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+			"databases:\n  mongo1:\n    type: mongodb\n    database: app\n"+
+			"    uri: \"mongodb://u@host:27017/\"\n"+
+			"    mongo_secrets_file: \""+literalPath+"\"\n"+
+			"    mongo_secrets_file_env: MONGO_SECRETS_PRECEDENCE_VAR\n")
+
+		cfg, err := LoadConfig(cfgPath)
+		if err != nil {
+			t.Fatalf("LoadConfig() error = %v", err)
+		}
+		job := cfg.Databases["mongo1"]
+		if job.MongoSecretsFile != envPath {
+			t.Fatalf("MongoSecretsFile = %q, want the env-resolved path %q (env must win)", job.MongoSecretsFile, envPath)
+		}
+		if job.URI != "mongodb://u:s3cr3t@host:27017/" {
+			t.Fatalf("URI = %q, want composed from the env-resolved file's password", job.URI)
+		}
+	})
+}
+
+// T010 (US3): neither literal nor _env set for either mechanism -> completely unaffected.
+func TestLoadConfig_NeitherSecretsFileFieldSetUnaffected(t *testing.T) {
+	t.Setenv("MYSQL_PW_UNAFFECTED_TEST", "secret")
+	cfgPath := writeTempConfig(t, "version: \"1.0\"\n"+
+		"defaults:\n  storage:\n    type: local\n    local_path: ./backups\n\n"+
+		"databases:\n  mydb:\n    type: mysql\n    database: app\n"+
+		"    host: localhost\n    username: sentinel\n    password_env: MYSQL_PW_UNAFFECTED_TEST\n"+
+		"  mongo1:\n    type: mongodb\n    database: app\n"+
+		"    uri: \"mongodb://u:pw@host:27017/\"\n")
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if cfg.Databases["mydb"].DefaultsFile != "" || cfg.Databases["mongo1"].MongoSecretsFile != "" {
+		t.Fatalf("expected both secrets-file fields to remain empty")
+	}
+	if err := ValidateConfig(cfg); err != nil {
+		t.Fatalf("ValidateConfig() error = %v", err)
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -288,6 +288,13 @@ type BackupJob struct {
 	// valid only for mysql/mariadb (spec 056 / PRD 44).
 	DefaultsFile string `yaml:"defaults_file,omitempty"`
 
+	// DefaultsFileEnv names an environment variable holding the path for
+	// DefaultsFile — for deployments where the mount location is only known
+	// at runtime (e.g. Kubernetes secret mounts). When set, its resolved
+	// value overwrites DefaultsFile, same precedence as every other *_env
+	// field (spec 058 / PRD 46).
+	DefaultsFileEnv string `yaml:"defaults_file_env,omitempty"`
+
 	// myCnfPassword caches the password resolved from DefaultsFile at config
 	// load time (internal/config/loader.go). Not part of the YAML schema —
 	// mirrors Name's yaml:"-" pattern for a runtime-computed field. Read only
@@ -304,6 +311,10 @@ type BackupJob struct {
 	// into TLS material) at load time when the corresponding explicit field
 	// is not already set. Valid only for mongodb (spec 057 / PRD 45).
 	MongoSecretsFile string `yaml:"mongo_secrets_file,omitempty"`
+
+	// MongoSecretsFileEnv names an environment variable holding the path for
+	// MongoSecretsFile. Same precedence as DefaultsFileEnv (spec 058 / PRD 46).
+	MongoSecretsFileEnv string `yaml:"mongo_secrets_file_env,omitempty"`
 
 	// Database selection: single name or "*" for auto-discovery
 	Database string `yaml:"database"`

--- a/release-notes.md
+++ b/release-notes.md
@@ -48,6 +48,19 @@
   change for jobs that don't set `mongo_secrets_file`. Runbook:
   [`docs/runbooks/credentials.md`](docs/runbooks/credentials.md).
   (spec 057 / PRD 45)
+- **Environment-variable indirection for secrets-file paths** (`defaults_file_env`,
+  `mongo_secrets_file_env`): the location of the MySQL/MariaDB defaults file
+  and the MongoDB secrets file can now be supplied via an environment
+  variable instead of a literal path in configuration — for containerized
+  and Kubernetes deployments where a secret's mount location is only known
+  at runtime, closing GitHub issue #29. Same precedence as every existing
+  `*_env` field: when set, the environment-resolved path overwrites the
+  literal one; an `_env` field referencing an unset or empty variable fails
+  immediately at configuration-load time, naming the job and the variable —
+  never a silent fallback or a delayed failure during a live backup run.
+  Reuses the existing, already-proven env-override resolution unchanged; no
+  new machinery, no new port, zero behavior change for jobs that don't set
+  either `_env` field. (spec 058 / PRD 46)
 
 ### Security / Supply chain
 


### PR DESCRIPTION
## Summary

Adds `defaults_file_env` and `mongo_secrets_file_env` — environment-variable indirection for the two secrets-file path fields shipped in spec 056 (MySQL/MariaDB `defaults_file`) and spec 057 (MongoDB `mongo_secrets_file`), closing GitHub issue #29. **spec 058 / PRD 46.**

For containerized/Kubernetes deployments where a secret's mount location is only known at runtime (not at config-authoring time), the path can now be supplied by naming an environment variable instead of hardcoding it into `sentinel.yaml`.

## The smallest Phase G feature by design

Two struct fields plus two `resolveEnvOverride` calls — the exact same pattern `host_env`/`username_env`/`password_env`/`uri_env` already use, proven four times over in this codebase. No new resolution helper, no validator change (the existing `defaults_file`/`mongo_secrets_file` type-gate checks already operate on the *resolved* field, so by validation time it's already correct regardless of source), no new package.

## Precedence (identical to every other `*_env` field)

- When `<field>_env` is set, its resolved value overwrites the literal `<field>`.
- An `<field>_env` naming an unset/empty variable fails immediately at config-load time, naming the job and the variable.
- When `<field>_env` is not set, the literal path (if any) works exactly as before.

## Changes

- `internal/config/types.go`: `DefaultsFileEnv`, `MongoSecretsFileEnv` (siblings to `DefaultsFile`/`MongoSecretsFile`).
- `internal/config/loader.go`: two `resolveEnvOverride` calls, inserted immediately before the existing `applyDefaultsFile`/`applyMongoSecrets` calls — the path resolves before the file at that path is opened.

## Safety / no-regression

Zero behavior change for jobs that don't set either `_env` field. No new port; no `internal/domain/**`/`internal/ports/**` change; `db_probe`, the dump builders, and the existing secrets-file reading logic are untouched.

## Testing

`go build`/`go vet` clean. `go test ./...` **0 failures** (10 new test cases: env-only resolution for both mechanisms, unset-variable fail-fast for both, literal-only unaffected for both, the env-wins-over-literal precedence proof for both, and a neither-field-set no-op proof). `golangci-lint run` **0 issues**.

Runbook (`docs/runbooks/credentials.md`) and `release-notes.md` updated.

## Note

Some unrelated, pre-existing doc-path fixups (post-hexagonal-migration path corrections in other runbooks) were present in the working tree from other activity — left out of this PR entirely, not part of this feature.
