### PR TITLE
feat(security): optional at-rest encryption for DB-credential secrets files (#30)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,5 +113,5 @@ Every new feature MUST run these skills in this exact order — no skipping, no 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/058-secrets-file-env-paths/plan.md`
+`specs/059-encrypt-secrets-file/plan.md`
 <!-- SPECKIT END -->

--- a/docs/runbooks/credentials.md
+++ b/docs/runbooks/credentials.md
@@ -113,6 +113,66 @@ databases:
     mongo_secrets_file_env: MONGO_SECRETS_FILE   # e.g. /run/secrets/mongo.yaml
 ```
 
+### 6. Encrypting a secrets file at rest — `security encrypt-secrets-file`
+
+A plaintext `defaults_file` or `mongo_secrets_file` holds live database passwords on disk — a standing exposure risk if the file is copied into a support bundle, a snapshot, a config-dir backup, or a mount with lax permissions. Both files can optionally be stored **encrypted at rest** and decrypted **in memory** at config-load time (spec 059 / PRD 47). This closes at-rest disclosure of the file; it does **not** protect against a live-process memory dump (plaintext credentials necessarily exist in memory while a backup runs).
+
+It reuses Sentinel's existing AES-256-GCM encryption — no new cipher or key format. A key from `sentinel security init-key` works directly.
+
+**1. Encrypt the plaintext file to a NEW path** (the command never modifies or deletes the input):
+
+```bash
+sentinel security init-key --output text        # or reuse an existing key
+sentinel security encrypt-secrets-file /etc/sentinel/db.cnf \
+  --out /etc/sentinel/db.cnf.enc \
+  --key-file /etc/sentinel/master.key            # or --key-env SENTINEL_MASTER_KEY
+```
+
+The same command encrypts a MongoDB secrets YAML — its content is opaque to the command:
+
+```bash
+sentinel security encrypt-secrets-file /run/secrets/mongo.yaml \
+  --out /run/secrets/mongo.yaml.enc --key-file /etc/sentinel/master.key
+```
+
+**2. Point the job at the encrypted file and declare the key** (global; a dedicated `secrets_key_*` with fallback to `encryption_key_*`):
+
+```yaml
+# global
+secrets_key_file: /etc/sentinel/master.key       # or secrets_key_env: SENTINEL_SECRETS_KEY
+#   (falls back to encryption_key_file / encryption_key_env when secrets_key_* is unset)
+
+databases:
+  mysql-prod:
+    type: mysql
+    defaults_file: /etc/sentinel/db.cnf.enc       # encrypted form — auto-detected
+  mongo-prod:
+    type: mongodb
+    uri: "mongodb://appuser@mongo:27017/?replicaSet=rs0"
+    mongo_secrets_file: /run/secrets/mongo.yaml.enc
+```
+
+Encryption is **auto-detected** from the file's content (a `SSEC` container header) — no config flag says "this file is encrypted". A plaintext file keeps working unchanged and needs no key.
+
+**3. Verify it loads, then remove the plaintext original:**
+
+```bash
+sentinel backup run --job mysql-prod --config sentinel.yaml   # decrypts in memory
+shred -u /etc/sentinel/db.cnf                                 # retire the plaintext
+```
+
+The decrypted credentials never touch disk. The encrypted file is self-contained — it carries its own decrypt material, so moving/copying it as a single file (no sidecar) never breaks decryption.
+
+**Failure is always a single clear config-load error naming the file** — a wrong/missing key, or a corrupt/truncated/unsupported file, fails before any database connection, never as a garbled parse:
+
+```
+error: backup 'mysql-prod': defaults_file: cannot decrypt secrets file '/etc/sentinel/db.cnf.enc': wrong key or corrupt data
+```
+
+The group/world-readable permission warning applies only to **plaintext** secrets files; an encrypted file is ciphertext, so no warning fires on it.
+
+> **Scope**: applies to MySQL/MariaDB `defaults_file` and MongoDB `mongo_secrets_file` on backup jobs only. PostgreSQL has no secrets file. This is unrelated to backup-artifact encryption (`encryption_key_env`, which encrypts the dump itself) — the two just share the same underlying cipher and key format.
+
 ## Precedence
 
 CLI flag > config `password_env` > `defaults_file` (MySQL/MariaDB only). The CLI-flag override is silent (no warning), enabling one-off drills:

--- a/internal/adapters/crypto/secrets_envelope.go
+++ b/internal/adapters/crypto/secrets_envelope.go
@@ -1,0 +1,113 @@
+package crypto
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/denisakp/sentinel/internal/ports"
+)
+
+// SSEC is the self-contained container for an encrypted DB-credentials secrets
+// file (the MySQL/MariaDB defaults file or the MongoDB secrets file).
+//
+// Unlike a backup artifact — whose base nonce lives in a manifest sidecar — a
+// standalone secrets file has no companion metadata, so the container embeds the
+// nonce in a small header ahead of an otherwise-untouched standard SENC v2 chunk
+// stream:
+//
+//	SSEC (4 bytes) || version 0x01 (1 byte) || base nonce (12 bytes) || <SENC v2 stream>
+//
+// The distinct SSEC magic keeps a secrets file unambiguous from a backup
+// artifact (SENC). The payload is produced/consumed by the shipped
+// ChunkEncryptWriter / ChunkDecryptReader verbatim — this file adds only framing,
+// no new cipher, key format, or generator (spec 059 FR-008).
+var secretsMagic = [4]byte{'S', 'S', 'E', 'C'}
+
+const (
+	secretsVersionV1 uint8 = 0x01
+	secretsNonceSize       = 12 // AES-GCM standard nonce size
+	secretsPrefixSize      = 4 + 1 + secretsNonceSize
+	// secretsAAD is the fixed Additional Authenticated Data for the secrets-file
+	// container. A secrets file has no backup ID; a constant binds the ciphertext
+	// to this purpose/version (domain separation) and must match on decrypt.
+	secretsAAD = "sentinel-secrets-file/v1"
+)
+
+// ErrSecretsEnvelopeCorrupt indicates the SSEC container is truncated or does not
+// begin with the SSEC magic.
+var ErrSecretsEnvelopeCorrupt = errors.New("crypto: secrets file is not a valid SSEC container (corrupt or truncated)")
+
+// ErrSecretsEnvelopeUnsupportedVersion indicates an SSEC container carries an
+// unrecognized version byte.
+var ErrSecretsEnvelopeUnsupportedVersion = errors.New("crypto: unsupported secrets-file envelope version")
+
+// IsEncryptedSecretsFile reports whether data begins with the SSEC magic and is
+// therefore an encrypted secrets-file container. A plaintext credentials file
+// (my.cnf or secrets YAML) never starts with these bytes, so detection is
+// content-based and requires no config flag.
+func IsEncryptedSecretsFile(data []byte) bool {
+	return len(data) >= 4 &&
+		data[0] == secretsMagic[0] && data[1] == secretsMagic[1] &&
+		data[2] == secretsMagic[2] && data[3] == secretsMagic[3]
+}
+
+// EncryptSecretsFile encrypts plaintext under key (32 bytes) into a self-contained
+// SSEC container. The key is used directly (no PBKDF2/salt); AAD is a fixed
+// constant. The returned bytes are the whole on-disk file.
+func EncryptSecretsFile(plaintext, key []byte) ([]byte, error) {
+	var payload bytes.Buffer
+	w, err := NewChunkEncryptWriter(&payload, key, secretsAAD)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := w.Write(plaintext); err != nil {
+		return nil, fmt.Errorf("crypto: failed to encrypt secrets file: %w", err)
+	}
+	if err := w.Flush(); err != nil {
+		return nil, fmt.Errorf("crypto: failed to finalize secrets file: %w", err)
+	}
+
+	nonce := w.BaseNonce()
+	if len(nonce) != secretsNonceSize {
+		return nil, fmt.Errorf("crypto: unexpected base nonce size %d (want %d)", len(nonce), secretsNonceSize)
+	}
+
+	out := make([]byte, 0, secretsPrefixSize+payload.Len())
+	out = append(out, secretsMagic[0], secretsMagic[1], secretsMagic[2], secretsMagic[3])
+	out = append(out, secretsVersionV1)
+	out = append(out, nonce...)
+	out = append(out, payload.Bytes()...)
+	return out, nil
+}
+
+// DecryptSecretsFile validates the SSEC header, extracts the embedded base nonce,
+// and decrypts the SENC payload in memory, returning the plaintext bytes. A wrong
+// key or tampered ciphertext surfaces as ports.ErrAuthTagFailed; a bad magic /
+// truncation as ErrSecretsEnvelopeCorrupt; an unknown version as
+// ErrSecretsEnvelopeUnsupportedVersion. Because the whole (small) file is
+// decrypted before returning, a wrong key never yields a partial result.
+func DecryptSecretsFile(data, key []byte) ([]byte, error) {
+	if len(data) < secretsPrefixSize || !IsEncryptedSecretsFile(data) {
+		return nil, ErrSecretsEnvelopeCorrupt
+	}
+	if data[4] != secretsVersionV1 {
+		return nil, fmt.Errorf("%w 0x%02X", ErrSecretsEnvelopeUnsupportedVersion, data[4])
+	}
+
+	nonce := data[5:secretsPrefixSize]
+	payload := data[secretsPrefixSize:]
+
+	r, err := NewChunkDecryptReaderWithOptions(bytes.NewReader(payload), key, nonce,
+		ports.DecryptOptions{BackupID: secretsAAD, Source: "secrets-file"})
+	if err != nil {
+		return nil, err
+	}
+
+	plaintext, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: failed to decrypt secrets file: %w", err)
+	}
+	return plaintext, nil
+}

--- a/internal/adapters/crypto/secrets_envelope_test.go
+++ b/internal/adapters/crypto/secrets_envelope_test.go
@@ -1,0 +1,141 @@
+package crypto
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/denisakp/sentinel/internal/ports"
+)
+
+func testKey(t *testing.T) []byte {
+	t.Helper()
+	k := make([]byte, 32)
+	for i := range k {
+		k[i] = byte(i + 1)
+	}
+	return k
+}
+
+func TestEncryptSecretsFile_RoundTrip(t *testing.T) {
+	key := testKey(t)
+	plaintext := []byte("[client]\nuser=root\npassword=s3cr3t\n")
+
+	enc, err := EncryptSecretsFile(plaintext, key)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if !IsEncryptedSecretsFile(enc) {
+		t.Fatal("produced file not detected as SSEC")
+	}
+
+	got, err := DecryptSecretsFile(enc, key)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("round-trip mismatch: got %q want %q", got, plaintext)
+	}
+}
+
+func TestEncryptSecretsFile_EmptyPlaintext(t *testing.T) {
+	key := testKey(t)
+	enc, err := EncryptSecretsFile(nil, key)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	got, err := DecryptSecretsFile(enc, key)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty plaintext, got %q", got)
+	}
+}
+
+func TestDecryptSecretsFile_WrongKey(t *testing.T) {
+	key := testKey(t)
+	enc, err := EncryptSecretsFile([]byte("password=hunter2"), key)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	wrong := make([]byte, 32)
+	copy(wrong, key)
+	wrong[0] ^= 0xFF
+
+	_, err = DecryptSecretsFile(enc, wrong)
+	if !errors.Is(err, ports.ErrAuthTagFailed) {
+		t.Fatalf("expected ErrAuthTagFailed, got %v", err)
+	}
+}
+
+func TestDecryptSecretsFile_CorruptPayload(t *testing.T) {
+	key := testKey(t)
+	enc, err := EncryptSecretsFile([]byte("password=hunter2"), key)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	// Flip a byte inside the SENC payload (past the 17-byte prefix + SENC header).
+	enc[secretsPrefixSize+8] ^= 0xFF
+
+	if _, err := DecryptSecretsFile(enc, key); err == nil {
+		t.Fatal("expected error on corrupt payload, got nil")
+	}
+}
+
+func TestDecryptSecretsFile_Truncated(t *testing.T) {
+	key := testKey(t)
+	enc, err := EncryptSecretsFile([]byte("password=hunter2"), key)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	truncated := enc[:len(enc)-4]
+	if _, err := DecryptSecretsFile(truncated, key); err == nil {
+		t.Fatal("expected error on truncated container, got nil")
+	}
+}
+
+func TestDecryptSecretsFile_BadMagic(t *testing.T) {
+	key := testKey(t)
+	// A backup-artifact SENC stream must NOT be treated as an SSEC secrets file.
+	var artifact bytes.Buffer
+	w, err := NewChunkEncryptWriter(&artifact, key, "some-backup-id")
+	if err != nil {
+		t.Fatalf("writer: %v", err)
+	}
+	_, _ = w.Write([]byte("dump data"))
+	_ = w.Flush()
+
+	if IsEncryptedSecretsFile(artifact.Bytes()) {
+		t.Fatal("SENC backup artifact wrongly detected as SSEC secrets file")
+	}
+	if _, err := DecryptSecretsFile(artifact.Bytes(), key); !errors.Is(err, ErrSecretsEnvelopeCorrupt) {
+		t.Fatalf("expected ErrSecretsEnvelopeCorrupt for non-SSEC input, got %v", err)
+	}
+}
+
+func TestDecryptSecretsFile_UnsupportedVersion(t *testing.T) {
+	key := testKey(t)
+	enc, err := EncryptSecretsFile([]byte("password=hunter2"), key)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	enc[4] = 0x02 // bump version byte
+
+	if _, err := DecryptSecretsFile(enc, key); !errors.Is(err, ErrSecretsEnvelopeUnsupportedVersion) {
+		t.Fatalf("expected ErrSecretsEnvelopeUnsupportedVersion, got %v", err)
+	}
+}
+
+func TestIsEncryptedSecretsFile_Plaintext(t *testing.T) {
+	if IsEncryptedSecretsFile([]byte("[client]\nuser=root\n")) {
+		t.Fatal("plaintext my.cnf wrongly detected as encrypted")
+	}
+	if IsEncryptedSecretsFile([]byte("SS")) {
+		t.Fatal("too-short input wrongly detected as encrypted")
+	}
+	if IsEncryptedSecretsFile(nil) {
+		t.Fatal("nil wrongly detected as encrypted")
+	}
+}

--- a/internal/adapters/mysqlargs/defaults_file.go
+++ b/internal/adapters/mysqlargs/defaults_file.go
@@ -2,8 +2,10 @@ package mysqlargs
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 )
@@ -40,17 +42,37 @@ func ParseDefaultsFile(path string) (ClientCreds, os.FileMode, error) {
 		return ClientCreds{}, 0, fmt.Errorf("%w '%s': %v", ErrDefaultsFileUnreadable, path, err)
 	}
 
-	creds, sawClient, err := parseClientSection(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return ClientCreds{}, info.Mode(), fmt.Errorf("%w '%s': %v", ErrDefaultsFileUnreadable, path, err)
 	}
-	if !sawClient || creds == (ClientCreds{}) {
-		return ClientCreds{}, info.Mode(), fmt.Errorf("%w: '%s'", ErrDefaultsFileNoClientSection, path)
+
+	creds, err := ParseDefaultsFileBytes(data)
+	if err != nil {
+		if errors.Is(err, ErrDefaultsFileNoClientSection) {
+			return ClientCreds{}, info.Mode(), fmt.Errorf("%w: '%s'", ErrDefaultsFileNoClientSection, path)
+		}
+		return ClientCreds{}, info.Mode(), fmt.Errorf("%w '%s': %v", ErrDefaultsFileUnreadable, path, err)
 	}
 	return creds, info.Mode(), nil
 }
 
-func parseClientSection(f *os.File) (ClientCreds, bool, error) {
+// ParseDefaultsFileBytes parses my.cnf-format bytes (already read into memory,
+// e.g. after in-memory decryption of an encrypted secrets file) and returns the
+// [client]-section credentials. Errors are path-free; callers wrap them with the
+// originating path.
+func ParseDefaultsFileBytes(data []byte) (ClientCreds, error) {
+	creds, sawClient, err := parseClientSection(bytes.NewReader(data))
+	if err != nil {
+		return ClientCreds{}, err
+	}
+	if !sawClient || creds == (ClientCreds{}) {
+		return ClientCreds{}, ErrDefaultsFileNoClientSection
+	}
+	return creds, nil
+}
+
+func parseClientSection(f io.Reader) (ClientCreds, bool, error) {
 	var creds ClientCreds
 	inClient := false
 	sawClient := false
@@ -106,12 +128,12 @@ func parseClientSection(f *os.File) (ClientCreds, bool, error) {
 // A bare "key" (no '=') is a valid my.cnf option but carries no value we care
 // about here, so it is skipped (ok=false).
 func splitOptionLine(line string) (key, value string, ok bool) {
-	idx := strings.Index(line, "=")
-	if idx < 0 {
+	rawKey, rawValue, found := strings.Cut(line, "=")
+	if !found {
 		return "", "", false
 	}
-	key = strings.TrimSpace(line[:idx])
-	value = strings.TrimSpace(line[idx+1:])
+	key = strings.TrimSpace(rawKey)
+	value = strings.TrimSpace(rawValue)
 	if key == "" {
 		return "", "", false
 	}

--- a/internal/cli/security_secrets.go
+++ b/internal/cli/security_secrets.go
@@ -1,0 +1,117 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/denisakp/sentinel/internal/adapters/crypto"
+	"github.com/spf13/cobra"
+)
+
+var securityEncryptSecretsFileCmd = &cobra.Command{
+	Use:   "encrypt-secrets-file <plaintext-path>",
+	Short: "Encrypt a DB-credentials secrets file at rest",
+	Long: `Encrypt a plaintext DB-credentials secrets file (a MySQL/MariaDB defaults
+file or a MongoDB secrets file) into Sentinel's self-contained encrypted form,
+so it can be stored encrypted at rest and decrypted in memory at config-load
+time.
+
+The encrypted output is written to a NEW path (--out); the plaintext input is
+never modified or deleted — remove it yourself once you have verified the
+encrypted file loads. Point the job's defaults_file / mongo_secrets_file at the
+encrypted output and configure the key via secrets_key_env / secrets_key_file
+(falling back to encryption_key_env / encryption_key_file).
+
+The key is the same 256-bit AES key used elsewhere; generate one with
+'sentinel security init-key'.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		inPath := args[0]
+		outPath, _ := cmd.Flags().GetString("out")
+		keyEnv, _ := cmd.Flags().GetString("key-env")
+		keyFile, _ := cmd.Flags().GetString("key-file")
+		force, _ := cmd.Flags().GetBool("force")
+
+		if outPath == "" {
+			return fmt.Errorf("--out is required (the encrypted output path; the plaintext input is left untouched)")
+		}
+		if keyEnv == "" && keyFile == "" {
+			return fmt.Errorf("a key is required: pass --key-env or --key-file")
+		}
+
+		absIn, err := filepath.Abs(inPath)
+		if err != nil {
+			return fmt.Errorf("resolve input path: %w", err)
+		}
+		absOut, err := filepath.Abs(outPath)
+		if err != nil {
+			return fmt.Errorf("resolve output path: %w", err)
+		}
+		if absIn == absOut {
+			return fmt.Errorf("--out must differ from the input path (refusing to overwrite the plaintext secrets file '%s')", inPath)
+		}
+		if _, err := os.Stat(absOut); err == nil && !force {
+			return fmt.Errorf("output file '%s' already exists (pass --force to overwrite)", outPath)
+		}
+
+		plaintext, err := os.ReadFile(absIn)
+		if err != nil {
+			return fmt.Errorf("cannot read plaintext secrets file '%s': %w", inPath, err)
+		}
+
+		kp := &crypto.FileKeyProvider{EnvVar: keyEnv, FilePath: keyFile}
+		key, err := kp.GetKey()
+		if err != nil {
+			return fmt.Errorf("cannot resolve encryption key: %w", err)
+		}
+
+		enc, err := crypto.EncryptSecretsFile(plaintext, key)
+		if err != nil {
+			return fmt.Errorf("failed to encrypt secrets file: %w", err)
+		}
+
+		// Write atomically via a temp file in the same directory, then rename, so a
+		// failure never leaves a partial, valid-looking output — and never touches
+		// the plaintext input.
+		tmp, err := os.CreateTemp(filepath.Dir(absOut), ".sentinel-secrets-*.tmp")
+		if err != nil {
+			return fmt.Errorf("cannot create temporary output: %w", err)
+		}
+		tmpName := tmp.Name()
+		cleanup := true
+		defer func() {
+			if cleanup {
+				_ = os.Remove(tmpName)
+			}
+		}()
+		if _, err := tmp.Write(enc); err != nil {
+			_ = tmp.Close()
+			return fmt.Errorf("cannot write encrypted output: %w", err)
+		}
+		if err := tmp.Chmod(0o600); err != nil {
+			_ = tmp.Close()
+			return fmt.Errorf("cannot set output permissions: %w", err)
+		}
+		if err := tmp.Close(); err != nil {
+			return fmt.Errorf("cannot finalize encrypted output: %w", err)
+		}
+		if err := os.Rename(tmpName, absOut); err != nil {
+			return fmt.Errorf("cannot move encrypted output into place: %w", err)
+		}
+		cleanup = false
+
+		fmt.Printf("Encrypted secrets file written to %s\n", outPath)
+		fmt.Printf("The plaintext input '%s' was left untouched.\n", inPath)
+		fmt.Println("Once you have verified the encrypted file loads, remove the plaintext original (e.g. shred -u).")
+		return nil
+	},
+}
+
+func init() {
+	SecurityCmd.AddCommand(securityEncryptSecretsFileCmd)
+	securityEncryptSecretsFileCmd.Flags().String("out", "", "Destination path for the encrypted secrets file (required)")
+	securityEncryptSecretsFileCmd.Flags().String("key-env", "", "Env var holding the base64-encoded 256-bit key")
+	securityEncryptSecretsFileCmd.Flags().String("key-file", "", "Path to a file holding the base64-encoded key")
+	securityEncryptSecretsFileCmd.Flags().Bool("force", false, "Overwrite the output file if it already exists")
+}

--- a/internal/cli/security_secrets_test.go
+++ b/internal/cli/security_secrets_test.go
@@ -1,0 +1,167 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/denisakp/sentinel/internal/adapters/crypto"
+	"github.com/spf13/cobra"
+)
+
+type encryptSecretsFlags struct {
+	out     string
+	keyEnv  string
+	keyFile string
+	force   bool
+}
+
+func runEncryptSecrets(t *testing.T, arg string, f encryptSecretsFlags) error {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.Flags().String("out", f.out, "")
+	cmd.Flags().String("key-env", f.keyEnv, "")
+	cmd.Flags().String("key-file", f.keyFile, "")
+	cmd.Flags().Bool("force", f.force, "")
+	return securityEncryptSecretsFileCmd.RunE(cmd, []string{arg})
+}
+
+func writeKeyFile(t *testing.T, dir string) string {
+	t.Helper()
+	b64, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(dir, "master.key")
+	if err := os.WriteFile(p, []byte(b64), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestEncryptSecretsFile_ProducesDecryptableFile(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := writeKeyFile(t, dir)
+	inPath := filepath.Join(dir, "db.cnf")
+	body := []byte("[client]\nuser=root\npassword=s3cr3t\n")
+	if err := os.WriteFile(inPath, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	outPath := filepath.Join(dir, "db.cnf.enc")
+
+	if err := runEncryptSecrets(t, inPath, encryptSecretsFlags{out: outPath, keyFile: keyPath}); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	enc, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if !crypto.IsEncryptedSecretsFile(enc) {
+		t.Fatal("output is not an SSEC container")
+	}
+
+	// Round-trips with the same key (read-path wiring covered in config tests).
+	raw := decodeKey(t, keyPath)
+	got, err := crypto.DecryptSecretsFile(enc, raw)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Fatalf("round-trip mismatch: %q", got)
+	}
+}
+
+func TestEncryptSecretsFile_InputUntouched(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := writeKeyFile(t, dir)
+	inPath := filepath.Join(dir, "db.cnf")
+	body := []byte("[client]\nuser=root\npassword=s3cr3t\n")
+	if err := os.WriteFile(inPath, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Success path.
+	if err := runEncryptSecrets(t, inPath, encryptSecretsFlags{out: filepath.Join(dir, "ok.enc"), keyFile: keyPath}); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if after := readAll(t, inPath); after != string(body) {
+		t.Fatalf("input modified after success: %q", after)
+	}
+
+	// Error path (bad key file) must also leave the input untouched.
+	badKey := filepath.Join(dir, "bad.key")
+	_ = os.WriteFile(badKey, []byte("not-base64!!!"), 0o600)
+	err := runEncryptSecrets(t, inPath, encryptSecretsFlags{out: filepath.Join(dir, "err.enc"), keyFile: badKey})
+	if err == nil {
+		t.Fatal("expected error on bad key")
+	}
+	if after := readAll(t, inPath); after != string(body) {
+		t.Fatalf("input modified after error: %q", after)
+	}
+}
+
+func TestEncryptSecretsFile_RefusesOverwriteInput(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := writeKeyFile(t, dir)
+	inPath := filepath.Join(dir, "db.cnf")
+	if err := os.WriteFile(inPath, []byte("[client]\nuser=root\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runEncryptSecrets(t, inPath, encryptSecretsFlags{out: inPath, keyFile: keyPath})
+	if err == nil || !strings.Contains(err.Error(), "must differ") {
+		t.Fatalf("expected refusal to overwrite input, got %v", err)
+	}
+}
+
+func TestEncryptSecretsFile_RefusesExistingOutputWithoutForce(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := writeKeyFile(t, dir)
+	inPath := filepath.Join(dir, "db.cnf")
+	outPath := filepath.Join(dir, "out.enc")
+	_ = os.WriteFile(inPath, []byte("[client]\nuser=root\n"), 0o600)
+	_ = os.WriteFile(outPath, []byte("existing"), 0o600)
+
+	err := runEncryptSecrets(t, inPath, encryptSecretsFlags{out: outPath, keyFile: keyPath})
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected refusal without --force, got %v", err)
+	}
+
+	if err := runEncryptSecrets(t, inPath, encryptSecretsFlags{out: outPath, keyFile: keyPath, force: true}); err != nil {
+		t.Fatalf("expected --force to overwrite, got %v", err)
+	}
+}
+
+func TestEncryptSecretsFile_RequiresKeyAndOut(t *testing.T) {
+	dir := t.TempDir()
+	inPath := filepath.Join(dir, "db.cnf")
+	_ = os.WriteFile(inPath, []byte("[client]\nuser=root\n"), 0o600)
+
+	if err := runEncryptSecrets(t, inPath, encryptSecretsFlags{keyFile: writeKeyFile(t, dir)}); err == nil {
+		t.Fatal("expected error when --out missing")
+	}
+	if err := runEncryptSecrets(t, inPath, encryptSecretsFlags{out: filepath.Join(dir, "o.enc")}); err == nil {
+		t.Fatal("expected error when no key provided")
+	}
+}
+
+func readAll(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func decodeKey(t *testing.T, keyPath string) []byte {
+	t.Helper()
+	kp := &crypto.FileKeyProvider{FilePath: keyPath}
+	raw, err := kp.GetKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}

--- a/internal/config/defaults_file_resolve.go
+++ b/internal/config/defaults_file_resolve.go
@@ -16,16 +16,23 @@ import (
 // problem reading or parsing the file is a hard config-load error (FR-006) —
 // except "no [client] section", which means the file simply has nothing to
 // contribute (spec Edge Cases), not a failure.
-func applyDefaultsFile(job *BackupJob) error {
-	creds, mode, err := mysqlargs.ParseDefaultsFile(job.DefaultsFile)
+func applyDefaultsFile(job *BackupJob, cfg *Configuration) error {
+	data, mode, encrypted, err := readSecretsFileMaybeDecrypt(job.DefaultsFile, cfg)
+	if err != nil {
+		return fmt.Errorf("defaults_file: %w", err)
+	}
+
+	creds, err := mysqlargs.ParseDefaultsFileBytes(data)
 	if err != nil {
 		if errors.Is(err, mysqlargs.ErrDefaultsFileNoClientSection) {
 			return nil
 		}
-		return fmt.Errorf("defaults_file: %w", err)
+		return fmt.Errorf("defaults_file '%s': %w", job.DefaultsFile, err)
 	}
 
-	if mode.Perm()&0o044 != 0 {
+	// Permission warning applies only to plaintext files: an encrypted secrets
+	// file being group/world-readable is ciphertext, not a credential exposure.
+	if !encrypted && mode.Perm()&0o044 != 0 {
 		fmt.Fprintf(os.Stderr,
 			"warning: defaults_file '%s' has permissions 0o%03o (group- or world-readable); recommend chmod 0600\n",
 			job.DefaultsFile, mode.Perm())

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -221,7 +221,7 @@ func applyEnvOverrides(cfg *Configuration) error {
 			return fmt.Errorf("backup '%s': %w", name, err)
 		}
 		if job.MongoSecretsFile != "" && job.Type == "mongodb" {
-			if err := applyMongoSecrets(&job); err != nil {
+			if err := applyMongoSecrets(&job, cfg); err != nil {
 				return fmt.Errorf("backup '%s': %w", name, err)
 			}
 		}
@@ -243,7 +243,7 @@ func applyEnvOverrides(cfg *Configuration) error {
 			return fmt.Errorf("backup '%s': %w", name, err)
 		}
 		if job.DefaultsFile != "" && (job.Type == "mysql" || job.Type == "mariadb") {
-			if err := applyDefaultsFile(&job); err != nil {
+			if err := applyDefaultsFile(&job, cfg); err != nil {
 				return fmt.Errorf("backup '%s': %w", name, err)
 			}
 		}

--- a/internal/config/mongo_secrets_file.go
+++ b/internal/config/mongo_secrets_file.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 
@@ -30,25 +31,46 @@ func readMongoSecretsFile(path string) (mongoSecrets, os.FileMode, error) {
 		return mongoSecrets{}, 0, fmt.Errorf("cannot read mongo secrets file '%s': %w", path, err)
 	}
 
-	var secrets mongoSecrets
-	dec := yaml.NewDecoder(f)
-	if err := dec.Decode(&secrets); err != nil {
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return mongoSecrets{}, info.Mode(), fmt.Errorf("cannot read mongo secrets file '%s': %w", path, err)
+	}
+
+	secrets, err := parseMongoSecrets(data)
+	if err != nil {
 		return mongoSecrets{}, info.Mode(), fmt.Errorf("cannot parse mongo secrets file '%s': %w", path, err)
 	}
 	return secrets, info.Mode(), nil
+}
+
+// parseMongoSecrets decodes mongo secrets YAML bytes already read into memory
+// (e.g. after in-memory decryption of an encrypted secrets file).
+func parseMongoSecrets(data []byte) (mongoSecrets, error) {
+	var secrets mongoSecrets
+	if err := yaml.Unmarshal(data, &secrets); err != nil {
+		return mongoSecrets{}, err
+	}
+	return secrets, nil
 }
 
 // applyMongoSecrets reads job.MongoSecretsFile and composes its values into
 // job.URI (fallback-only, per-field precedence — contracts/uri-composition.md)
 // and job.TLS.mongoPEMPassphrase. Called only for mongodb jobs with a
 // non-empty MongoSecretsFile.
-func applyMongoSecrets(job *BackupJob) error {
-	secrets, mode, err := readMongoSecretsFile(job.MongoSecretsFile)
+func applyMongoSecrets(job *BackupJob, cfg *Configuration) error {
+	data, mode, encrypted, err := readSecretsFileMaybeDecrypt(job.MongoSecretsFile, cfg)
 	if err != nil {
 		return err
 	}
 
-	if mode.Perm()&0o044 != 0 {
+	secrets, err := parseMongoSecrets(data)
+	if err != nil {
+		return fmt.Errorf("cannot parse mongo secrets file '%s': %w", job.MongoSecretsFile, err)
+	}
+
+	// Permission warning applies only to plaintext files (encrypted content is
+	// ciphertext, not a credential exposure).
+	if !encrypted && mode.Perm()&0o044 != 0 {
 		fmt.Fprintf(os.Stderr,
 			"warning: mongo_secrets_file '%s' has permissions 0o%03o (group- or world-readable); recommend chmod 0600\n",
 			job.MongoSecretsFile, mode.Perm())

--- a/internal/config/mongo_secrets_file_test.go
+++ b/internal/config/mongo_secrets_file_test.go
@@ -71,7 +71,7 @@ func TestApplyMongoSecrets(t *testing.T) {
 	t.Run("password fills a username-bearing URI with no password", func(t *testing.T) {
 		p := writeTestMongoSecretsFile(t, "password: s3cr3t\n", 0o600)
 		job := BackupJob{Name: "mongo1", Type: "mongodb", URI: "mongodb://appuser@host:27017/", MongoSecretsFile: p}
-		if err := applyMongoSecrets(&job); err != nil {
+		if err := applyMongoSecrets(&job, &Configuration{}); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		if job.URI != "mongodb://appuser:s3cr3t@host:27017/" {
@@ -82,7 +82,7 @@ func TestApplyMongoSecrets(t *testing.T) {
 	t.Run("full uri used when job.URI empty", func(t *testing.T) {
 		p := writeTestMongoSecretsFile(t, "uri: mongodb://appuser:s3cr3t@host:27017/\n", 0o600)
 		job := BackupJob{Name: "mongo1", Type: "mongodb", MongoSecretsFile: p}
-		if err := applyMongoSecrets(&job); err != nil {
+		if err := applyMongoSecrets(&job, &Configuration{}); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		if job.URI != "mongodb://appuser:s3cr3t@host:27017/" {
@@ -94,7 +94,7 @@ func TestApplyMongoSecrets(t *testing.T) {
 		p := writeTestMongoSecretsFile(t, "ssl_pem_key_password: pempass\n", 0o600)
 		tls := &TLSConfig{}
 		job := BackupJob{Name: "mongo1", Type: "mongodb", URI: "mongodb://u@h/", MongoSecretsFile: p, TLS: tls}
-		if err := applyMongoSecrets(&job); err != nil {
+		if err := applyMongoSecrets(&job, &Configuration{}); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		got, err := ResolveMongoTLSPassphrase(job.TLS)
@@ -106,7 +106,7 @@ func TestApplyMongoSecrets(t *testing.T) {
 	t.Run("conflict: uri already has a password", func(t *testing.T) {
 		p := writeTestMongoSecretsFile(t, "password: fromfile\n", 0o600)
 		job := BackupJob{Name: "mongo1", Type: "mongodb", URI: "mongodb://u:existing@h/", MongoSecretsFile: p}
-		err := applyMongoSecrets(&job)
+		err := applyMongoSecrets(&job, &Configuration{})
 		if err == nil || !strings.Contains(err.Error(), "conflicting password sources") {
 			t.Fatalf("got err=%v", err)
 		}
@@ -115,7 +115,7 @@ func TestApplyMongoSecrets(t *testing.T) {
 	t.Run("missing username: password with no uri at all", func(t *testing.T) {
 		p := writeTestMongoSecretsFile(t, "password: fromfile\n", 0o600)
 		job := BackupJob{Name: "mongo1", Type: "mongodb", MongoSecretsFile: p}
-		err := applyMongoSecrets(&job)
+		err := applyMongoSecrets(&job, &Configuration{})
 		if err == nil || !strings.Contains(err.Error(), "no username is known") {
 			t.Fatalf("got err=%v", err)
 		}
@@ -124,7 +124,7 @@ func TestApplyMongoSecrets(t *testing.T) {
 	t.Run("uri unused when job.URI already set (no error)", func(t *testing.T) {
 		p := writeTestMongoSecretsFile(t, "uri: mongodb://other@h2/\n", 0o600)
 		job := BackupJob{Name: "mongo1", Type: "mongodb", URI: "mongodb://u:existing@h/", MongoSecretsFile: p}
-		if err := applyMongoSecrets(&job); err != nil {
+		if err := applyMongoSecrets(&job, &Configuration{}); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		if job.URI != "mongodb://u:existing@h/" {
@@ -139,7 +139,7 @@ func TestApplyMongoSecrets(t *testing.T) {
 		oldStderr := os.Stderr
 		r, w, _ := os.Pipe()
 		os.Stderr = w
-		err := applyMongoSecrets(&job)
+		err := applyMongoSecrets(&job, &Configuration{})
 		w.Close()
 		os.Stderr = oldStderr
 		if err != nil {
@@ -166,7 +166,7 @@ func TestResolveMongoTLSPassphrase(t *testing.T) {
 		tls := &TLSConfig{ClientKeyPasswordEnv: "MONGO_PEM_TEST_VAR"}
 		p := writeTestMongoSecretsFile(t, "ssl_pem_key_password: fromfile\n", 0o600)
 		job := BackupJob{Name: "j", Type: "mongodb", URI: "mongodb://u@h/", MongoSecretsFile: p, TLS: tls}
-		if err := applyMongoSecrets(&job); err != nil {
+		if err := applyMongoSecrets(&job, &Configuration{}); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		got, err := ResolveMongoTLSPassphrase(job.TLS)

--- a/internal/config/secrets_file_crypto.go
+++ b/internal/config/secrets_file_crypto.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/denisakp/sentinel/internal/adapters/crypto"
+	"github.com/denisakp/sentinel/internal/ports"
+)
+
+// readSecretsFileMaybeDecrypt reads a DB-credentials secrets file (the
+// MySQL/MariaDB defaults file or the MongoDB secrets file) and, if it carries the
+// SSEC container magic, decrypts it in memory before returning the plaintext
+// bytes. A plaintext file is returned as-is. The decrypted plaintext is never
+// written to disk (spec 059 FR-004).
+//
+// The decryption key is resolved from the dedicated secrets-file key reference
+// when set, falling back to the backup-artifact key reference (FR-014):
+//
+//	env  = firstNonEmpty(cfg.SecretsKeyEnv,  cfg.EncryptionKeyEnv)
+//	file = firstNonEmpty(cfg.SecretsKeyFile, cfg.EncryptionKeyFile)
+//
+// Every failure (missing key, wrong key, corrupt/truncated data, unsupported
+// version) is returned as a single clear error naming the file (FR-006); a wrong
+// key never yields a partial parse — the whole file is decrypted in memory first.
+// The returned encrypted flag lets callers gate the plaintext-only permission
+// warning (D6).
+func readSecretsFileMaybeDecrypt(path string, cfg *Configuration) (plaintext []byte, mode os.FileMode, encrypted bool, err error) {
+	info, statErr := os.Stat(path)
+	if statErr != nil {
+		return nil, 0, false, fmt.Errorf("cannot read secrets file '%s': %w", path, statErr)
+	}
+
+	raw, readErr := os.ReadFile(path)
+	if readErr != nil {
+		return nil, info.Mode(), false, fmt.Errorf("cannot read secrets file '%s': %w", path, readErr)
+	}
+
+	if !crypto.IsEncryptedSecretsFile(raw) {
+		return raw, info.Mode(), false, nil
+	}
+
+	env := firstNonEmpty(cfg.SecretsKeyEnv, cfg.EncryptionKeyEnv)
+	file := firstNonEmpty(cfg.SecretsKeyFile, cfg.EncryptionKeyFile)
+	if env == "" && file == "" {
+		return nil, info.Mode(), true, fmt.Errorf(
+			"encrypted secrets file '%s' but no decryption key configured (set secrets_key_env/secrets_key_file or encryption_key_env/encryption_key_file)", path)
+	}
+
+	kp := &crypto.FileKeyProvider{EnvVar: env, FilePath: file}
+	key, keyErr := kp.GetKey()
+	if keyErr != nil {
+		return nil, info.Mode(), true, fmt.Errorf("cannot decrypt secrets file '%s': %w", path, keyErr)
+	}
+
+	decrypted, decErr := crypto.DecryptSecretsFile(raw, key)
+	if decErr != nil {
+		switch {
+		case errors.Is(decErr, ports.ErrAuthTagFailed):
+			return nil, info.Mode(), true, fmt.Errorf("cannot decrypt secrets file '%s': wrong key or corrupt data", path)
+		case errors.Is(decErr, crypto.ErrSecretsEnvelopeUnsupportedVersion):
+			return nil, info.Mode(), true, fmt.Errorf("cannot decrypt secrets file '%s': %w", path, decErr)
+		default:
+			return nil, info.Mode(), true, fmt.Errorf("cannot decrypt secrets file '%s': corrupt or truncated envelope: %w", path, decErr)
+		}
+	}
+
+	return decrypted, info.Mode(), true, nil
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/config/secrets_file_crypto_test.go
+++ b/internal/config/secrets_file_crypto_test.go
@@ -1,0 +1,243 @@
+package config
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/denisakp/sentinel/internal/adapters/crypto"
+)
+
+// newSecretsKey returns a fresh base64 key (for env/config) and its raw 32 bytes
+// (for EncryptSecretsFile).
+func newSecretsKey(t *testing.T) (b64 string, raw []byte) {
+	t.Helper()
+	b64, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	raw, err = base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		t.Fatalf("decode key: %v", err)
+	}
+	return b64, raw
+}
+
+// writeEncryptedSecrets encrypts plaintext under raw and writes it to dir/name.
+func writeEncryptedSecrets(t *testing.T, dir, name string, plaintext, raw []byte) string {
+	t.Helper()
+	enc, err := crypto.EncryptSecretsFile(plaintext, raw)
+	if err != nil {
+		t.Fatalf("EncryptSecretsFile: %v", err)
+	}
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, enc, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return p
+}
+
+func TestReadSecretsFileMaybeDecrypt_Plaintext(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "plain.cnf")
+	body := []byte("[client]\nuser=root\n")
+	if err := os.WriteFile(p, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _, encrypted, err := readSecretsFileMaybeDecrypt(p, &Configuration{})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if encrypted {
+		t.Fatal("plaintext file reported as encrypted")
+	}
+	if string(got) != string(body) {
+		t.Fatalf("got %q want %q", got, body)
+	}
+}
+
+func TestReadSecretsFileMaybeDecrypt_DedicatedKey(t *testing.T) {
+	dir := t.TempDir()
+	b64, raw := newSecretsKey(t)
+	body := []byte("[client]\nuser=root\npassword=s3cr3t\n")
+	p := writeEncryptedSecrets(t, dir, "db.cnf.enc", body, raw)
+
+	t.Setenv("SENTINEL_SECRETS_KEY", b64)
+	cfg := &Configuration{SecretsKeyEnv: "SENTINEL_SECRETS_KEY"}
+
+	got, _, encrypted, err := readSecretsFileMaybeDecrypt(p, cfg)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if !encrypted {
+		t.Fatal("encrypted file reported as plaintext")
+	}
+	if string(got) != string(body) {
+		t.Fatalf("got %q want %q", got, body)
+	}
+}
+
+func TestReadSecretsFileMaybeDecrypt_ArtifactKeyFallback(t *testing.T) {
+	dir := t.TempDir()
+	b64, raw := newSecretsKey(t)
+	body := []byte("uri: mongodb://user@host:27017\npassword: p\n")
+	p := writeEncryptedSecrets(t, dir, "mongo.enc", body, raw)
+
+	// Only the artifact key is configured; the secrets path must fall back to it.
+	t.Setenv("SENTINEL_ENC_KEY", b64)
+	cfg := &Configuration{EncryptionKeyEnv: "SENTINEL_ENC_KEY"}
+
+	got, _, _, err := readSecretsFileMaybeDecrypt(p, cfg)
+	if err != nil {
+		t.Fatalf("decrypt via fallback: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Fatalf("got %q want %q", got, body)
+	}
+}
+
+func TestReadSecretsFileMaybeDecrypt_NoDecryptedFileOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	b64, raw := newSecretsKey(t)
+	body := []byte("[client]\nuser=root\npassword=s3cr3t\n")
+	p := writeEncryptedSecrets(t, dir, "db.cnf.enc", body, raw)
+
+	t.Setenv("SENTINEL_SECRETS_KEY", b64)
+	cfg := &Configuration{SecretsKeyEnv: "SENTINEL_SECRETS_KEY"}
+	if _, _, _, err := readSecretsFileMaybeDecrypt(p, cfg); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+
+	// The only file in dir must be the encrypted input; no plaintext copy written.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		content, _ := os.ReadFile(filepath.Join(dir, e.Name()))
+		if strings.Contains(string(content), "s3cr3t") {
+			t.Fatalf("decrypted plaintext leaked to disk in %s", e.Name())
+		}
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 file on disk, got %d", len(entries))
+	}
+}
+
+func TestApplyDefaultsFile_Encrypted(t *testing.T) {
+	dir := t.TempDir()
+	b64, raw := newSecretsKey(t)
+	body := []byte("[client]\nhost=db.example\nuser=root\npassword=s3cr3t\nport=3307\n")
+	p := writeEncryptedSecrets(t, dir, "db.cnf.enc", body, raw)
+
+	t.Setenv("SENTINEL_SECRETS_KEY", b64)
+	cfg := &Configuration{SecretsKeyEnv: "SENTINEL_SECRETS_KEY"}
+	job := BackupJob{Name: "mysql-prod", Type: "mysql", DefaultsFile: p}
+
+	if err := applyDefaultsFile(&job, cfg); err != nil {
+		t.Fatalf("applyDefaultsFile: %v", err)
+	}
+	if job.Host != "db.example" || job.Username != "root" || job.Port != 3307 {
+		t.Fatalf("creds not applied from encrypted file: %+v", job)
+	}
+	if job.myCnfPassword != "s3cr3t" {
+		t.Fatalf("password not applied: %q", job.myCnfPassword)
+	}
+}
+
+func TestApplyMongoSecrets_Encrypted(t *testing.T) {
+	dir := t.TempDir()
+	b64, raw := newSecretsKey(t)
+	body := []byte("uri: mongodb://alice@mongo.example:27017\npassword: s3cr3t\n")
+	p := writeEncryptedSecrets(t, dir, "mongo.enc", body, raw)
+
+	t.Setenv("SENTINEL_SECRETS_KEY", b64)
+	cfg := &Configuration{SecretsKeyEnv: "SENTINEL_SECRETS_KEY"}
+	job := BackupJob{Name: "mongo-prod", Type: "mongodb", MongoSecretsFile: p}
+
+	if err := applyMongoSecrets(&job, cfg); err != nil {
+		t.Fatalf("applyMongoSecrets: %v", err)
+	}
+	if !strings.Contains(job.URI, "alice:s3cr3t@mongo.example") {
+		t.Fatalf("mongo uri not composed from encrypted file: %q", job.URI)
+	}
+}
+
+// --- US3: failure contract ---
+
+func TestReadSecretsFileMaybeDecrypt_WrongKey(t *testing.T) {
+	dir := t.TempDir()
+	_, raw := newSecretsKey(t)
+	p := writeEncryptedSecrets(t, dir, "db.cnf.enc", []byte("[client]\nuser=root\n"), raw)
+
+	otherB64, _ := newSecretsKey(t)
+	t.Setenv("SENTINEL_SECRETS_KEY", otherB64)
+	cfg := &Configuration{SecretsKeyEnv: "SENTINEL_SECRETS_KEY"}
+
+	_, _, _, err := readSecretsFileMaybeDecrypt(p, cfg)
+	if err == nil || !strings.Contains(err.Error(), p) {
+		t.Fatalf("expected error naming file %q, got %v", p, err)
+	}
+	if !strings.Contains(err.Error(), "wrong key or corrupt") {
+		t.Fatalf("expected wrong-key message, got %v", err)
+	}
+}
+
+func TestReadSecretsFileMaybeDecrypt_NoKeyConfigured(t *testing.T) {
+	dir := t.TempDir()
+	_, raw := newSecretsKey(t)
+	p := writeEncryptedSecrets(t, dir, "db.cnf.enc", []byte("[client]\nuser=root\n"), raw)
+
+	_, _, encrypted, err := readSecretsFileMaybeDecrypt(p, &Configuration{})
+	if err == nil {
+		t.Fatal("expected error when no key configured")
+	}
+	if !encrypted {
+		t.Fatal("expected encrypted=true even on no-key error")
+	}
+	if !strings.Contains(err.Error(), p) || !strings.Contains(err.Error(), "no decryption key") {
+		t.Fatalf("expected clear no-key error naming file, got %v", err)
+	}
+}
+
+func TestReadSecretsFileMaybeDecrypt_Corrupt(t *testing.T) {
+	dir := t.TempDir()
+	b64, raw := newSecretsKey(t)
+	p := writeEncryptedSecrets(t, dir, "db.cnf.enc", []byte("[client]\nuser=root\n"), raw)
+
+	// Corrupt a byte inside the payload.
+	data, _ := os.ReadFile(p)
+	data[len(data)-1] ^= 0xFF
+	if err := os.WriteFile(p, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("SENTINEL_SECRETS_KEY", b64)
+	cfg := &Configuration{SecretsKeyEnv: "SENTINEL_SECRETS_KEY"}
+	_, _, _, err := readSecretsFileMaybeDecrypt(p, cfg)
+	if err == nil || !strings.Contains(err.Error(), p) {
+		t.Fatalf("expected error naming file on corrupt data, got %v", err)
+	}
+}
+
+func TestReadSecretsFileMaybeDecrypt_UnsupportedVersion(t *testing.T) {
+	dir := t.TempDir()
+	b64, raw := newSecretsKey(t)
+	p := writeEncryptedSecrets(t, dir, "db.cnf.enc", []byte("[client]\nuser=root\n"), raw)
+
+	data, _ := os.ReadFile(p)
+	data[4] = 0x02 // bump SSEC version byte
+	if err := os.WriteFile(p, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("SENTINEL_SECRETS_KEY", b64)
+	cfg := &Configuration{SecretsKeyEnv: "SENTINEL_SECRETS_KEY"}
+	_, _, _, err := readSecretsFileMaybeDecrypt(p, cfg)
+	if err == nil || !strings.Contains(err.Error(), p) {
+		t.Fatalf("expected error naming file on unsupported version, got %v", err)
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -236,6 +236,17 @@ type Configuration struct {
 	// EncryptionKeyFile is an optional path to a file containing the base64-encoded master key.
 	// Encryption is enabled only when this or EncryptionKeyEnv is explicitly configured.
 	EncryptionKeyFile string `yaml:"encryption_key_file,omitempty"`
+
+	// SecretsKeyEnv is an optional env var name for the key that decrypts an
+	// encrypted DB-credentials secrets file (defaults_file / mongo_secrets_file).
+	// When unset, the secrets-file decrypt path falls back to EncryptionKeyEnv,
+	// so the two keys can rotate independently while simple setups need only one.
+	SecretsKeyEnv string `yaml:"secrets_key_env,omitempty"`
+
+	// SecretsKeyFile is an optional path to a file containing the base64-encoded
+	// secrets-file key. When unset, the secrets-file decrypt path falls back to
+	// EncryptionKeyFile.
+	SecretsKeyFile string `yaml:"secrets_key_file,omitempty"`
 }
 
 // GlobalDefaults contains default values applied to all backup jobs

--- a/release-notes.md
+++ b/release-notes.md
@@ -61,6 +61,29 @@
   Reuses the existing, already-proven env-override resolution unchanged; no
   new machinery, no new port, zero behavior change for jobs that don't set
   either `_env` field. (spec 058 / PRD 46)
+- **Optional at-rest encryption for DB-credential secrets files**
+  (`security encrypt-secrets-file`): the MySQL/MariaDB `defaults_file` and the
+  MongoDB `mongo_secrets_file` can now be stored **encrypted at rest** and are
+  decrypted **in memory** at configuration-load time, closing the standing
+  "plaintext database passwords on disk" exposure (GitHub issue #30). A new
+  `sentinel security encrypt-secrets-file <path> --out <path>` command produces
+  the encrypted file, writing to a **new path** and never modifying or deleting
+  the plaintext input. Encryption is **auto-detected** from the file's content
+  (a self-contained `SSEC` container that embeds its own decrypt material — no
+  sidecar), so a plaintext file keeps working unchanged and needs no key. The
+  key is resolved from a dedicated `secrets_key_env`/`secrets_key_file`, falling
+  back to the backup-artifact `encryption_key_env`/`encryption_key_file`, so the
+  two keys can rotate independently. Reuses the shipped AES-256-GCM crypto
+  verbatim — no new cipher, key format, or generator; a key from
+  `security init-key` works directly. A wrong/missing key or a
+  corrupt/truncated/unsupported file fails at config-load time with a single
+  clear error naming the file — never a partial parse, never a silent fallback,
+  never a delayed failure during a live run. The decrypted plaintext never
+  touches disk. The group/world-readable permission warning now fires only on
+  **plaintext** secrets files (an encrypted file is ciphertext). Backup-side
+  only; unrelated to and does not alter backup-artifact encryption. Runbook:
+  [`docs/runbooks/credentials.md`](docs/runbooks/credentials.md).
+  (spec 059 / PRD 47)
 
 ### Security / Supply chain
 


### PR DESCRIPTION
## Summary

Optional **at-rest encryption for DB-credential secrets files** — the MySQL/MariaDB `defaults_file` (spec 056) and the MongoDB `mongo_secrets_file` (spec 057) can now be stored encrypted on disk and are decrypted **in memory** at config-load time. Closes the standing "plaintext database passwords on disk" exposure (GitHub #30).

This is **not** backup-artifact encryption (#18) — it's a second consumer of the same shipped AES-256-GCM crypto at a new call site (config load). No new cipher, key format, or generator.

## What's in it

- **SSEC container** (`internal/adapters/crypto/secrets_envelope.go`): a self-contained file `SSEC || 0x01 || nonce(12) || <SENC v2 stream>` that embeds its own decrypt material (a standalone secrets file has no manifest sidecar for the nonce). The payload is the shipped `ChunkEncryptWriter`/`ChunkDecryptReader` output **verbatim** — the container adds only framing bytes.
- **Decrypt-at-read** (`internal/config/secrets_file_crypto.go`): auto-detects the `SSEC` magic, resolves the key (dedicated `secrets_key_env`/`secrets_key_file`, falling back to `encryption_key_env`/`encryption_key_file`), decrypts in memory, and routes both existing secrets-file readers through it. Plaintext files parse exactly as before. Decrypted plaintext never touches disk.
- **Clear failures**: a wrong/missing key or a corrupt/truncated/unsupported file fails at config-load time with a single error **naming the file** — never a partial parse, never a silent fallback.
- **Producer command**: `sentinel security encrypt-secrets-file <path> --out <path> [--key-env|--key-file] [--force]` — writes to a **new path** via temp+rename and **never modifies or deletes** the plaintext input.
- **Perm warning** now fires only on plaintext files (ciphertext isn't a credential exposure).

## Scope

Backup-side only, MySQL/MariaDB + MongoDB. PostgreSQL has no secrets file. Backup-artifact encryption is untouched.

## Tests

New: SSEC codec (round-trip, wrong-key, corrupt, truncated, bad magic/version, distinctness), config-load decrypt path (both engines, dedicated + fallback key, no-plaintext-on-disk), failure contract (wrong/missing key, corrupt, unsupported version — each names the file), and the CLI command (produces SSEC, input untouched on success **and** error, refuses input-overwrite / existing-out without `--force`). `go build`, `go vet` (incl. `-tags=integration`), full `go test ./...`, and `golangci-lint` (depguard) all green.

## Docs

- `docs/runbooks/credentials.md` — new "Encrypting a secrets file at rest" section.
- `release-notes.md` — `[Unreleased]` entry.

spec 059 / PRD 47
