### PR TITLE
docs: mark superseded runbooks and correct the README chain example

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,17 @@ databases:
 
 Inspect and manage chains:
 
+> **These three subcommands cannot currently be invoked.** They require `--config` but never register
+> the flag, and the one on `sentinel backup` is local rather than persistent, so they fail whether you
+> pass it or not. Tracked in
+> [#136](https://github.com/denisakp/sentinel/issues/136). The usage shown below is what they are
+> meant to accept once that is fixed.
+>
+> Until then, use `sentinel monitor list` and `sentinel monitor show` to inspect chain state, and
+> `sentinel restore validate-chain <job>` to check a chain. See
+> [Incremental backup and PITR](https://denisakp.github.io/sentinel/concepts/incremental-pitr) for
+> what does work today.
+
 ```bash
 sentinel backup chain-status --config sentinel.yaml
 sentinel backup chain-list --config sentinel.yaml

--- a/docs/runbooks/additional-args.md
+++ b/docs/runbooks/additional-args.md
@@ -1,5 +1,10 @@
 # Runbook — `additional_args` quoting reference
 
+> **Superseded by the documentation site: [reference/additional-args](https://denisakp.github.io/sentinel/reference/additional-args).**
+>
+> This runbook documents `restore_options.additional_args` as working; it is validated then discarded. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 Sentinel forwards the operator-supplied `additional_args` string to the
 underlying dump or restore tool (`pg_dump`, `mysqldump`, `mariadb-dump`,
 `mongodump`, and their restore counterparts) as command-line arguments.

--- a/docs/runbooks/alerting-setup.md
+++ b/docs/runbooks/alerting-setup.md
@@ -1,5 +1,10 @@
 # Runbook — Alerting setup
 
+> **Superseded by the documentation site: [guides/alerting-setup](https://denisakp.github.io/sentinel/guides/alerting-setup).**
+>
+> This runbook its email example does not load: the keys are `from_address_env` and `to_addresses`. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [failed-backup-triage](./failed-backup-triage.md), [restore-from-backup](./restore-from-backup.md), [start-scheduler](./start-scheduler.md)

--- a/docs/runbooks/apply-retention.md
+++ b/docs/runbooks/apply-retention.md
@@ -1,5 +1,10 @@
 # Runbook — Apply retention
 
+> **Superseded by the documentation site: [guides/apply-retention](https://denisakp.github.io/sentinel/guides/apply-retention).**
+>
+> This runbook claims `keep_last` and `keep_days` union; they intersect. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [run-backup-from-config](./run-backup-from-config.md), [check-storage-backend](./check-storage-backend.md)

--- a/docs/runbooks/backup-compression.md
+++ b/docs/runbooks/backup-compression.md
@@ -1,5 +1,10 @@
 # Runbook — Backup compression (gzip / zstd)
 
+> **Superseded by the documentation site: [guides/backup-compression](https://denisakp.github.io/sentinel/guides/backup-compression).**
+>
+> This runbook superseded; verified against the code. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-08-02
 - **Related**: PRD 33 / spec 049 (pipeline compression), [enable-encryption](./enable-encryption.md), [verify-backup-integrity](./verify-backup-integrity.md), [restore-from-backup](./restore-from-backup.md), [check-storage-backend](./check-storage-backend.md)

--- a/docs/runbooks/chain-corruption-recovery.md
+++ b/docs/runbooks/chain-corruption-recovery.md
@@ -1,5 +1,10 @@
 # Runbook — Chain corruption recovery
 
+> **Superseded by the documentation site: [operations/chain-corruption-recovery](https://denisakp.github.io/sentinel/operations/chain-corruption-recovery).**
+>
+> This runbook centres on three subcommands that cannot be invoked at all. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [restore-pitr-and-incremental](./restore-pitr-and-incremental.md), [apply-retention](./apply-retention.md), [verify-backup-integrity](./verify-backup-integrity.md)

--- a/docs/runbooks/check-storage-backend.md
+++ b/docs/runbooks/check-storage-backend.md
@@ -1,5 +1,10 @@
 # Runbook — Check storage backend
 
+> **Superseded by the documentation site: [guides/check-storage-backend](https://denisakp.github.io/sentinel/guides/check-storage-backend).**
+>
+> This runbook refers to a `file_path` column that `monitor list` does not have. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [migrate-storage-backend](./migrate-storage-backend.md), [apply-retention](./apply-retention.md), [restore-from-gcs](./restore-from-gcs.md)

--- a/docs/runbooks/credentials.md
+++ b/docs/runbooks/credentials.md
@@ -1,5 +1,10 @@
 # Database credentials
 
+> **Superseded by the documentation site: [guides/database-credentials](https://denisakp.github.io/sentinel/guides/database-credentials).**
+>
+> This runbook uses `sentinel backup run --job`, which does not exist, and its argv claim is false for MongoDB. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 Sentinel never accepts passwords on the command line in supported channels. Use one of three safe sources; conflicts among the CLI flags are hard errors before any database I/O.
 
 ## Three safe channels

--- a/docs/runbooks/db-migration-status.md
+++ b/docs/runbooks/db-migration-status.md
@@ -1,5 +1,10 @@
 # Runbook — DB migration status
 
+> **Superseded by the documentation site: [guides/db-migration-status](https://denisakp.github.io/sentinel/guides/db-migration-status).**
+>
+> This runbook wrong output format, and lists three of the five migrations. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [upgrade-sentinel-binary](./upgrade-sentinel-binary.md), [inspect-monitor-history](./inspect-monitor-history.md)

--- a/docs/runbooks/enable-encryption.md
+++ b/docs/runbooks/enable-encryption.md
@@ -1,5 +1,10 @@
 # Runbook — Enable encryption
 
+> **Superseded by the documentation site: [guides/enable-encryption](https://denisakp.github.io/sentinel/guides/enable-encryption).**
+>
+> This runbook shows `security init-key` output that the command no longer prints. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-08-02
 - **Related**: ADR 0006 (envelope v1), spec 047 (remote-artifact security), [key-rotation](./key-rotation.md), [key-loss-incident](./key-loss-incident.md), [verify-backup-integrity](./verify-backup-integrity.md), [recover-legacy-envelope](./recover-legacy-envelope.md), [check-storage-backend](./check-storage-backend.md)

--- a/docs/runbooks/environment-setup.md
+++ b/docs/runbooks/environment-setup.md
@@ -1,5 +1,10 @@
 # Runbook — Environment setup
 
+> **Superseded by the documentation site: [guides/environment-setup](https://denisakp.github.io/sentinel/guides/environment-setup).**
+>
+> This runbook wrong PostgreSQL version, and references a dataset file that is not in the repository. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [run-backup-from-config](./run-backup-from-config.md), [troubleshooting](./troubleshooting.md)

--- a/docs/runbooks/failed-backup-triage.md
+++ b/docs/runbooks/failed-backup-triage.md
@@ -1,5 +1,10 @@
 # Runbook — Failed backup triage
 
+> **Superseded by the documentation site: [operations/failed-backup-triage](https://denisakp.github.io/sentinel/operations/failed-backup-triage).**
+>
+> This runbook lists statuses and error strings that the code never emits. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [inspect-monitor-history](./inspect-monitor-history.md), [troubleshooting](./troubleshooting.md), [stale-lock-recovery](./stale-lock-recovery.md), [check-storage-backend](./check-storage-backend.md), [enable-encryption](./enable-encryption.md)

--- a/docs/runbooks/inspect-monitor-history.md
+++ b/docs/runbooks/inspect-monitor-history.md
@@ -1,5 +1,10 @@
 # Runbook — Inspect monitor history
 
+> **Superseded by the documentation site: [guides/inspect-monitor-history](https://denisakp.github.io/sentinel/guides/inspect-monitor-history).**
+>
+> This runbook wrong columns, and its example demonstrates a silent all-time window bug. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [failed-backup-triage](./failed-backup-triage.md), [db-migration-status](./db-migration-status.md)

--- a/docs/runbooks/integrity-sweep.md
+++ b/docs/runbooks/integrity-sweep.md
@@ -1,5 +1,10 @@
 # Runbook — Repository-wide integrity sweep (`backup verify --all` + scheduled)
 
+> **Superseded by the documentation site: [guides/integrity-sweep](https://denisakp.github.io/sentinel/guides/integrity-sweep).**
+>
+> This runbook incomplete JSON field list and a trigger value that is never written. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-08-03
 - **Related**: [verify-backup-integrity](./verify-backup-integrity.md), [failed-backup-triage](./failed-backup-triage.md), [enable-encryption](./enable-encryption.md)

--- a/docs/runbooks/key-loss-incident.md
+++ b/docs/runbooks/key-loss-incident.md
@@ -1,5 +1,10 @@
 # Runbook — Key loss incident
 
+> **Superseded by the documentation site: [operations/key-loss-incident](https://denisakp.github.io/sentinel/operations/key-loss-incident).**
+>
+> This runbook presents `backup verify` as proof a key still works; verification never decrypts, so a wrong-key artifact passes. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [enable-encryption](./enable-encryption.md), [key-rotation](./key-rotation.md), ADR 0006 (envelope v1)

--- a/docs/runbooks/key-rotation.md
+++ b/docs/runbooks/key-rotation.md
@@ -1,5 +1,10 @@
 # Runbook — Key rotation
 
+> **Superseded by the documentation site: [guides/key-rotation](https://denisakp.github.io/sentinel/guides/key-rotation).**
+>
+> This runbook shows `encryption_key_env` nested under a `restores:` job, which is not a field that exists. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-08-05
 - **Related**: [enable-encryption](./enable-encryption.md), [key-loss-incident](./key-loss-incident.md), [recover-legacy-envelope](./recover-legacy-envelope.md), ADR 0006

--- a/docs/runbooks/migrate-storage-backend.md
+++ b/docs/runbooks/migrate-storage-backend.md
@@ -1,5 +1,10 @@
 # Runbook — Migrate storage backend
 
+> **Superseded by the documentation site: [guides/migrate-storage-backend](https://denisakp.github.io/sentinel/guides/migrate-storage-backend).**
+>
+> This runbook same column problem, and claims retention runs cleanly after a migration. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [check-storage-backend](./check-storage-backend.md), [apply-retention](./apply-retention.md), [run-backup-from-config](./run-backup-from-config.md)

--- a/docs/runbooks/mongo-staging.md
+++ b/docs/runbooks/mongo-staging.md
@@ -1,5 +1,10 @@
 # Runbook: `.staging/` directory for Mongo remote backups
 
+> **Superseded by the documentation site: [reference/mongo-staging](https://denisakp.github.io/sentinel/reference/mongo-staging).**
+>
+> This runbook describes the wrong staging directory for config-driven remote backups. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 When a MongoDB backup targets a **remote** backend — `sentinel backup --type mongodb --storage s3|gcs|gdrive` (or the equivalent config-file `storage:` block, including `azure`) — `mongodump` is invoked in archive mode against a transient file under:
 
 ```

--- a/docs/runbooks/monitor-schema-migration.md
+++ b/docs/runbooks/monitor-schema-migration.md
@@ -1,5 +1,10 @@
 # Monitor Schema Migration
 
+> **Superseded by the documentation site: [guides/monitor-schema-migration](https://denisakp.github.io/sentinel/guides/monitor-schema-migration).**
+>
+> This runbook the "same transaction" claim is false and the lock file name is wrong. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 How Sentinel manages the schema of its monitor (history) SQLite database, and how operators inspect or repair it.
 
 ## What `schema_version` is

--- a/docs/runbooks/parallel-restore.md
+++ b/docs/runbooks/parallel-restore.md
@@ -1,5 +1,10 @@
 # Parallel Multi-Job Restore
 
+> **Superseded by the documentation site: [guides/parallel-restore](https://denisakp.github.io/sentinel/guides/parallel-restore).**
+>
+> This runbook its example omits `enabled` and `schedule`, so no job in it would run. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 `sentinel restore run --all` runs every **enabled** configured restore job at once, bounded by a concurrency limit. It turns a disaster-recovery drill across N services (one restore job per service) from a serial sum-of-times into a parallel run.
 
 > Scope: this parallelises **jobs** (the job axis). It does not restore multiple databases within a single job — a restore job targets exactly one database.

--- a/docs/runbooks/recover-legacy-envelope.md
+++ b/docs/runbooks/recover-legacy-envelope.md
@@ -1,5 +1,10 @@
 # Runbook — Recover legacy envelope (pre-v2)
 
+> **Superseded by the documentation site: [operations/recover-legacy-envelope](https://denisakp.github.io/sentinel/operations/recover-legacy-envelope).**
+>
+> This runbook its default-deny claim is false for `backup verify`. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: ADR 0006 (envelope v1/v2), [enable-encryption](./enable-encryption.md), [key-rotation](./key-rotation.md)

--- a/docs/runbooks/restore-from-backup.md
+++ b/docs/runbooks/restore-from-backup.md
@@ -1,5 +1,10 @@
 # Runbook — Restore from backup
 
+> **Superseded by the documentation site: [tutorials/postgres/restore](https://denisakp.github.io/sentinel/tutorials/postgres/restore).**
+>
+> This runbook superseded by the per-engine tutorial tracks. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [restore-pitr-and-incremental](./restore-pitr-and-incremental.md), [restore-from-gcs](./restore-from-gcs.md), [restore-rehearsal](./restore-rehearsal.md), [verify-backup-integrity](./verify-backup-integrity.md)

--- a/docs/runbooks/restore-from-gcs.md
+++ b/docs/runbooks/restore-from-gcs.md
@@ -1,5 +1,10 @@
 # Runbook — Restore from GCS
 
+> **Superseded by the documentation site: [guides/restore-from-gcs](https://denisakp.github.io/sentinel/guides/restore-from-gcs).**
+>
+> This runbook superseded; verified against the code. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [restore-from-backup](./restore-from-backup.md), [check-storage-backend](./check-storage-backend.md)

--- a/docs/runbooks/restore-pitr-and-incremental.md
+++ b/docs/runbooks/restore-pitr-and-incremental.md
@@ -1,5 +1,10 @@
 # Runbook — PITR and incremental restore
 
+> **Superseded by the documentation site: [concepts/incremental-pitr](https://denisakp.github.io/sentinel/concepts/incremental-pitr).**
+>
+> This runbook PITR cannot currently be planned for any engine; see #148. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [restore-from-backup](./restore-from-backup.md), [chain-corruption-recovery](./chain-corruption-recovery.md), [verify-backup-integrity](./verify-backup-integrity.md)

--- a/docs/runbooks/restore-rehearsal.md
+++ b/docs/runbooks/restore-rehearsal.md
@@ -1,5 +1,10 @@
 # Runbook — Restore rehearsal (DR drill)
 
+> **Superseded by the documentation site: [guides/index](https://denisakp.github.io/sentinel/guides/index).**
+>
+> This runbook the site page is held pending #149; verify a rehearsal by querying the restored database, not with `verify_after_restore`. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [restore-from-backup](./restore-from-backup.md), [restore-pitr-and-incremental](./restore-pitr-and-incremental.md), [verify-backup-integrity](./verify-backup-integrity.md)

--- a/docs/runbooks/retention-gfs.md
+++ b/docs/runbooks/retention-gfs.md
@@ -1,5 +1,10 @@
 # Grandfather-Father-Son (GFS) Retention
 
+> **Superseded by the documentation site: [guides/retention-gfs](https://denisakp.github.io/sentinel/guides/retention-gfs).**
+>
+> This runbook claims the flat rules union, and overstates baseline protection. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 Long-horizon, calendar-tiered retention that keeps one representative backup per
 day / week / month / year — so you can satisfy multi-year compliance or DR
 mandates without hoarding every backup.

--- a/docs/runbooks/run-backup-from-config.md
+++ b/docs/runbooks/run-backup-from-config.md
@@ -1,5 +1,10 @@
 # Runbook — Run backup from config
 
+> **Superseded by the documentation site: [guides/run-backup-from-config](https://denisakp.github.io/sentinel/guides/run-backup-from-config).**
+>
+> This runbook uses `sentinel backup --job`, which does not exist. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [environment-setup](./environment-setup.md), [start-scheduler](./start-scheduler.md), [inspect-monitor-history](./inspect-monitor-history.md), [verify-backup-integrity](./verify-backup-integrity.md)

--- a/docs/runbooks/scheduler-crash-recovery.md
+++ b/docs/runbooks/scheduler-crash-recovery.md
@@ -1,5 +1,10 @@
 # Runbook — Scheduler crash recovery
 
+> **Superseded by the documentation site: [operations/scheduler-crash-recovery](https://denisakp.github.io/sentinel/operations/scheduler-crash-recovery).**
+>
+> This runbook same startup reap claim, and `monitor list --status skipped` can never return a row. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: ADR 0008 (scheduler concurrency), ADR 0007 (lock file format), [start-scheduler](./start-scheduler.md), [stale-lock-recovery](./stale-lock-recovery.md)

--- a/docs/runbooks/stale-lock-recovery.md
+++ b/docs/runbooks/stale-lock-recovery.md
@@ -1,5 +1,10 @@
 # Runbook — Stale lock recovery
 
+> **Superseded by the documentation site: [operations/stale-lock-recovery](https://denisakp.github.io/sentinel/operations/stale-lock-recovery).**
+>
+> This runbook describes a stale-lock reap at scheduler startup that does not happen. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: ADR 0007 (lock file format), [scheduler-crash-recovery](./scheduler-crash-recovery.md), [troubleshooting](./troubleshooting.md)

--- a/docs/runbooks/start-scheduler.md
+++ b/docs/runbooks/start-scheduler.md
@@ -1,5 +1,10 @@
 # Runbook — Start the scheduler
 
+> **Superseded by the documentation site: [concepts/schedule](https://denisakp.github.io/sentinel/concepts/schedule).**
+>
+> This runbook the site page is held pending #138; its stale-lock claim is also untrue. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: ADR 0008 (scheduler concurrency), [scheduler-crash-recovery](./scheduler-crash-recovery.md), [stale-lock-recovery](./stale-lock-recovery.md)

--- a/docs/runbooks/state-repair.md
+++ b/docs/runbooks/state-repair.md
@@ -1,5 +1,10 @@
 # Runbook — Repository state repair (`sentinel repair`)
 
+> **Superseded by the documentation site: [operations/state-repair](https://denisakp.github.io/sentinel/operations/state-repair).**
+>
+> This runbook `--fix` does not mark broken chains, and the sample output header is wrong. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-08-03
 - **Related**: [stale-lock-recovery](./stale-lock-recovery.md), [scheduler-crash-recovery](./scheduler-crash-recovery.md), [chain-corruption-recovery](./chain-corruption-recovery.md), [integrity-sweep](./integrity-sweep.md), [monitor-schema-migration](./monitor-schema-migration.md)

--- a/docs/runbooks/troubleshooting.md
+++ b/docs/runbooks/troubleshooting.md
@@ -1,5 +1,10 @@
 # Runbook — Troubleshooting
 
+> **Superseded by the documentation site: [operations/troubleshooting](https://denisakp.github.io/sentinel/operations/troubleshooting).**
+>
+> This runbook several error strings are wrong, and the `log_format` advice does not do what it says. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [failed-backup-triage](./failed-backup-triage.md), [stale-lock-recovery](./stale-lock-recovery.md), [environment-setup](./environment-setup.md)

--- a/docs/runbooks/upgrade-sentinel-binary.md
+++ b/docs/runbooks/upgrade-sentinel-binary.md
@@ -1,5 +1,10 @@
 # Runbook — Upgrade Sentinel binary
 
+> **Superseded by the documentation site: [guides/upgrade-sentinel-binary](https://denisakp.github.io/sentinel/guides/upgrade-sentinel-binary).**
+>
+> This runbook claims migrations apply automatically and that startup reaps stale locks; neither happens. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [db-migration-status](./db-migration-status.md), [start-scheduler](./start-scheduler.md), [scheduler-crash-recovery](./scheduler-crash-recovery.md)

--- a/docs/runbooks/verify-backup-integrity.md
+++ b/docs/runbooks/verify-backup-integrity.md
@@ -1,5 +1,10 @@
 # Runbook — Verify backup integrity
 
+> **Superseded by the documentation site: [guides/verify-backup-integrity](https://denisakp.github.io/sentinel/guides/verify-backup-integrity).**
+>
+> This runbook shows a PASS string the command never prints, and misstates an exit code. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: ADR 0005 (manifest v1), [enable-encryption](./enable-encryption.md), [recover-legacy-envelope](./recover-legacy-envelope.md), [failed-backup-triage](./failed-backup-triage.md)

--- a/docs/runbooks/verify-release-artifacts.md
+++ b/docs/runbooks/verify-release-artifacts.md
@@ -1,5 +1,10 @@
 # Runbook — Verify release artifacts (cosign signature + SLSA provenance)
 
+> **Superseded by the documentation site: [operations/verify-release-artifacts](https://denisakp.github.io/sentinel/operations/verify-release-artifacts).**
+>
+> This runbook pins a version while fetching from `latest/download`, so the download can be a 404 page. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE / anyone installing a prebuilt binary
 - **Related**: [upgrade-sentinel-binary](./upgrade-sentinel-binary.md), README "Installation" section
 


### PR DESCRIPTION
Follow-up to #198, so the documentation-drift issues can be closed honestly.

Each of the 34 runbooks now carries a banner naming the site page that replaced it and, where one was found, the specific claim that does not match the code. `docs/runbooks/README.md` already carried that warning; this puts it where a reader actually lands, since most arrive at a runbook by search or a direct link rather than through the index.

The README chain-command example is corrected in place. The three subcommands still cannot be invoked (#136), so rather than delete the example or leave it looking usable, it says so and points at what works today.

Closes #147, #162, #174, #178, #180 and #192.

Closing those with the files untouched would have removed the open issue while leaving the wrong instructions exactly where they were. The underlying code defects each of them describes stay open and are indexed in #176.