### PR TITLE
feat: serve the documentation at sentinel.denisakp.me/docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,6 +58,8 @@ jobs:
       # or a stale heading anchor fails here rather than reaching a reader.
       - name: Build
         run: npm run build
+        env:
+          DEPLOY_TARGET: ${{ vars.DEPLOY_TARGET || 'custom' }}
 
       # Serve and audit in one step: a background process started in one step is
       # not reliably still there in the next.
@@ -66,6 +68,9 @@ jobs:
       # meaningful alt text, descriptive link text, heading nesting; is covered
       # by the authoring convention and by review, not by this step.
       - name: Accessibility audit (WCAG 2.1 AA)
+        env:
+          DOCS_BASE: /docs/
+          DOCS_ORIGIN: https://sentinel.denisakp.me
         run: |
           set -euo pipefail
           npm run serve -- --no-open --port 3000 &
@@ -73,14 +78,14 @@ jobs:
           trap 'kill "$SERVE_PID" 2>/dev/null || true' EXIT
 
           for _ in $(seq 1 30); do
-            if curl -sSf -o /dev/null http://localhost:3000/sentinel/; then
+            if curl -sSf -o /dev/null "http://localhost:3000${DOCS_BASE}"; then
               echo "site is up"
               break
             fi
             sleep 2
           done
 
-          curl -sSf -o /dev/null http://localhost:3000/sentinel/ \
+          curl -sSf -o /dev/null "http://localhost:3000${DOCS_BASE}" \
             || { echo "site did not come up within 60s" >&2; exit 1; }
 
           # On failure, re-run with the JSON reporter and print the exact colours
@@ -101,11 +106,66 @@ jobs:
             exit 1
           fi
 
+      # Docusaurus does NOT nest its output under baseUrl: with baseUrl '/docs/'
+      # the files still land at the root of build/. That was invisible while the
+      # site was a GitHub Pages project site, because Pages serves the artifact
+      # root at /<repo>/, which happened to match baseUrl '/sentinel/'.
+      #
+      # With a custom domain the artifact root IS the domain root, so the files
+      # would sit at / while every generated link points at /docs/. Nesting the
+      # artifact one level restores the match.
+      - name: Nest the artifact under /docs
+        if: github.event_name != 'pull_request'
+        run: |
+          set -euo pipefail
+          mkdir -p ../artifact/docs
+          mv build/* ../artifact/docs/
+          # A CNAME file has to sit at the artifact root, not inside /docs.
+          if [ -f ../artifact/docs/CNAME ]; then
+            mv ../artifact/docs/CNAME ../artifact/CNAME
+          fi
+          # Anything hitting the domain root goes to the documentation for now.
+          # Replace this with a real landing page when there is one.
+          cat > ../artifact/index.html <<'HTML'
+          <!doctype html>
+          <meta charset="utf-8">
+          <title>Sentinel</title>
+          <meta http-equiv="refresh" content="0; url=/docs/">
+          <link rel="canonical" href="/docs/">
+          <p><a href="/docs/">Sentinel documentation</a></p>
+          HTML
+
+      # Published URLs are permanent (FR-044). The site was live at
+      # denisakp.github.io/sentinel/... before the custom domain existed. With the
+      # domain configured, GitHub redirects those requests to
+      # sentinel.denisakp.me/sentinel/..., preserving the path, so the old prefix
+      # has to keep resolving on the new origin.
+      #
+      # Docusaurus cannot emit these: its client-redirects plugin only writes
+      # under baseUrl. So they are generated here, mirroring every page.
+      - name: Keep the previously published /sentinel/ URLs resolving
+        if: github.event_name != 'pull_request'
+        run: |
+          set -euo pipefail
+          cd ../artifact
+          count=0
+          while IFS= read -r page; do
+            rel="${page#docs/}"
+            dest="/docs/${rel%.html}"
+            out="sentinel/${rel}"
+            mkdir -p "$(dirname "$out")"
+            printf '<!doctype html>\n<meta charset="utf-8">\n<meta http-equiv="refresh" content="0; url=%s">\n<link rel="canonical" href="%s">\n<p>This page moved to <a href="%s">%s</a>.</p>\n' \
+              "$dest" "$dest" "$dest" "$dest" > "$out"
+            count=$((count + 1))
+          done < <(find docs -name '*.html' -type f)
+          printf '<!doctype html>\n<meta http-equiv="refresh" content="0; url=/docs/">\n' > sentinel/index.html
+          echo "generated $count redirect stubs for the previous URL prefix"
+
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v5
         with:
-          path: website/build
+          path: artifact
 
   deploy:
     name: Deploy to GitHub Pages

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -15,15 +15,17 @@ const SENTINEL_RELEASE = 'v1.4.0';
  * different paths, and Docusaurus bakes `baseUrl` into every generated link and
  * asset at build time: so this cannot be a constant.
  *
- *   ghpages (default): https://denisakp.github.io/sentinel/
- *   custom           : https://sentinel.denisakp.me/docs/
+ *   custom (default): https://sentinel.denisakp.me/docs/
+ *   ghpages         : https://denisakp.github.io/sentinel/
  *
- * `ghpages` stays the default until DNS for sentinel.denisakp.me resolves.
+ * `custom` became the default once DNS resolved. `ghpages` is kept as a way back
+ * if the domain ever has to be given up.
  *
- * WARNING: do not add static/CNAME or set a custom domain in the repository's
- * Pages settings before that DNS record exists. Configuring a custom domain
- * makes GitHub redirect the github.io URL to it; with DNS unresolved the site
- * becomes unreachable at BOTH addresses.
+ * One thing baseUrl does NOT do: nest the build output. With `/docs/` the files
+ * still land at the root of `build/`. That matched the old project-site layout by
+ * accident, because Pages serves the artifact root at /<repo>/. On a custom domain
+ * the artifact root is the domain root, so `.github/workflows/docs.yml` nests the
+ * artifact one level to make the paths line up again.
  */
 const DEPLOY_TARGET = process.env.DEPLOY_TARGET ?? 'custom';
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -25,7 +25,7 @@ const SENTINEL_RELEASE = 'v1.4.0';
  * makes GitHub redirect the github.io URL to it; with DNS unresolved the site
  * becomes unreachable at BOTH addresses.
  */
-const DEPLOY_TARGET = process.env.DEPLOY_TARGET ?? 'ghpages';
+const DEPLOY_TARGET = process.env.DEPLOY_TARGET ?? 'custom';
 
 const HOSTING = {
   ghpages: {url: 'https://denisakp.github.io', baseUrl: '/sentinel/'},

--- a/website/package.json
+++ b/website/package.json
@@ -13,8 +13,8 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
-    "a11y": "pa11y-ci --config .pa11yci.json --sitemap http://localhost:3000/sentinel/sitemap.xml --sitemap-find https://denisakp.github.io --sitemap-replace http://localhost:3000",
-    "a11y:json": "pa11y-ci --json --config .pa11yci.json --sitemap http://localhost:3000/sentinel/sitemap.xml --sitemap-find https://denisakp.github.io --sitemap-replace http://localhost:3000"
+    "a11y": "pa11y-ci --config .pa11yci.json --sitemap http://localhost:3000${DOCS_BASE:-/docs/}sitemap.xml --sitemap-find ${DOCS_ORIGIN:-https://sentinel.denisakp.me} --sitemap-replace http://localhost:3000",
+    "a11y:json": "pa11y-ci --json --config .pa11yci.json --sitemap http://localhost:3000${DOCS_BASE:-/docs/}sitemap.xml --sitemap-find ${DOCS_ORIGIN:-https://sentinel.denisakp.me} --sitemap-replace http://localhost:3000"
   },
   "dependencies": {
     "@docusaurus/core": "3.10.2",

--- a/website/redirects.md
+++ b/website/redirects.md
@@ -24,8 +24,24 @@ appears not to work in the dev server is not a bug. Check it against the product
 
 ## Entries
 
-_None yet. The site has not moved a published page._
+No individual page has moved. The whole site did, once.
 
 | From | To | Reason | Increment |
 |------|----|--------|-----------|
-| n/a    |; | n/a      |; |
+| `denisakp.github.io/sentinel/*` | `sentinel.denisakp.me/docs/*` | The custom domain came online, and the domain root is reserved for a future landing page | 5 |
+
+These stubs are **not** in `docusaurus.config.ts`, and that is not an oversight. The client-redirects
+plugin can only write files under `baseUrl`, which is now `/docs/`. The stubs have to live at
+`/sentinel/*`, outside it, so they are generated in `.github/workflows/docs.yml` by mirroring the
+built tree, one per page.
+
+Two facts behind that, both established by testing rather than by reading:
+
+- **Docusaurus does not nest its output under `baseUrl`.** With `baseUrl: '/docs/'` the files still
+  land at the root of `build/`. That went unnoticed while this was a Pages project site, because
+  Pages serves the artifact root at `/<repo>/`, which happened to match `baseUrl: '/sentinel/'`. On a
+  custom domain the artifact root is the domain root, so the workflow nests the artifact one level.
+- **GitHub redirects the old origin to the new one, preserving the path.** A request to
+  `denisakp.github.io/sentinel/concepts/backup` lands on
+  `sentinel.denisakp.me/sentinel/concepts/backup`. Without these stubs, every URL published before
+  the cutover would 404.

--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,0 +1,1 @@
+sentinel.denisakp.me


### PR DESCRIPTION
DNS resolves, so the site moves to its intended home. The domain root stays free for a landing page later.

```
sentinel.denisakp.me  CNAME  denisakp.github.io   (DNS only, not proxied)
                             185.199.108-111.153
```

The custom domain is already set in the repository`'s Pages settings. This changes the build side: `DEPLOY_TARGET` defaults to `custom`, so `baseUrl` becomes `/docs/`.

## Two things the original research had wrong

**Docusaurus does not nest its output under `baseUrl`.** With `/docs/` the files still land at the root of `build/`. That went unnoticed while this was a Pages project site, because Pages serves the artifact root at `/<repo>/`, which happened to match `baseUrl: /sentinel/`. On a custom domain the artifact root is the domain root, so the files would sit at `/` while every generated link pointed at `/docs/`. Every link would 404.

Caught by building with the custom target and looking at the output rather than assuming. The workflow now nests the artifact one level.

**The previously published URLs need stubs.** With the domain configured, GitHub redirects `denisakp.github.io/sentinel/X` to `sentinel.denisakp.me/sentinel/X`, preserving the path, so the old prefix has to keep resolving on the new origin. The client-redirects plugin cannot do it: it only writes under `baseUrl`. The workflow generates one stub per page, 88 of them, mirroring the built tree. Tested locally before pushing.

That satisfies FR-044 and SC-013: nothing published before the cutover breaks.

## Also

- The accessibility audit and the root redirect both follow the base path, so neither is pinned to the old prefix.
- `website/redirects.md` records the move and why the stubs live outside the plugin.
- The domain root serves a redirect into `/docs/` until there is a landing page.

## After merge

Merging to `develop` does not deploy; the promotion to `1.x` does. Watch for GitHub to finish provisioning the TLS certificate before enforcing HTTPS, which is a separate toggle once the domain verifies.