### PR TITLE
release: serve the docs at sentinel.denisakp.me/docs, mark superseded runbooks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,6 +58,8 @@ jobs:
       # or a stale heading anchor fails here rather than reaching a reader.
       - name: Build
         run: npm run build
+        env:
+          DEPLOY_TARGET: ${{ vars.DEPLOY_TARGET || 'custom' }}
 
       # Serve and audit in one step: a background process started in one step is
       # not reliably still there in the next.
@@ -66,6 +68,9 @@ jobs:
       # meaningful alt text, descriptive link text, heading nesting; is covered
       # by the authoring convention and by review, not by this step.
       - name: Accessibility audit (WCAG 2.1 AA)
+        env:
+          DOCS_BASE: /docs/
+          DOCS_ORIGIN: https://sentinel.denisakp.me
         run: |
           set -euo pipefail
           npm run serve -- --no-open --port 3000 &
@@ -73,14 +78,14 @@ jobs:
           trap 'kill "$SERVE_PID" 2>/dev/null || true' EXIT
 
           for _ in $(seq 1 30); do
-            if curl -sSf -o /dev/null http://localhost:3000/sentinel/; then
+            if curl -sSf -o /dev/null "http://localhost:3000${DOCS_BASE}"; then
               echo "site is up"
               break
             fi
             sleep 2
           done
 
-          curl -sSf -o /dev/null http://localhost:3000/sentinel/ \
+          curl -sSf -o /dev/null "http://localhost:3000${DOCS_BASE}" \
             || { echo "site did not come up within 60s" >&2; exit 1; }
 
           # On failure, re-run with the JSON reporter and print the exact colours
@@ -101,11 +106,66 @@ jobs:
             exit 1
           fi
 
+      # Docusaurus does NOT nest its output under baseUrl: with baseUrl '/docs/'
+      # the files still land at the root of build/. That was invisible while the
+      # site was a GitHub Pages project site, because Pages serves the artifact
+      # root at /<repo>/, which happened to match baseUrl '/sentinel/'.
+      #
+      # With a custom domain the artifact root IS the domain root, so the files
+      # would sit at / while every generated link points at /docs/. Nesting the
+      # artifact one level restores the match.
+      - name: Nest the artifact under /docs
+        if: github.event_name != 'pull_request'
+        run: |
+          set -euo pipefail
+          mkdir -p ../artifact/docs
+          mv build/* ../artifact/docs/
+          # A CNAME file has to sit at the artifact root, not inside /docs.
+          if [ -f ../artifact/docs/CNAME ]; then
+            mv ../artifact/docs/CNAME ../artifact/CNAME
+          fi
+          # Anything hitting the domain root goes to the documentation for now.
+          # Replace this with a real landing page when there is one.
+          cat > ../artifact/index.html <<'HTML'
+          <!doctype html>
+          <meta charset="utf-8">
+          <title>Sentinel</title>
+          <meta http-equiv="refresh" content="0; url=/docs/">
+          <link rel="canonical" href="/docs/">
+          <p><a href="/docs/">Sentinel documentation</a></p>
+          HTML
+
+      # Published URLs are permanent (FR-044). The site was live at
+      # denisakp.github.io/sentinel/... before the custom domain existed. With the
+      # domain configured, GitHub redirects those requests to
+      # sentinel.denisakp.me/sentinel/..., preserving the path, so the old prefix
+      # has to keep resolving on the new origin.
+      #
+      # Docusaurus cannot emit these: its client-redirects plugin only writes
+      # under baseUrl. So they are generated here, mirroring every page.
+      - name: Keep the previously published /sentinel/ URLs resolving
+        if: github.event_name != 'pull_request'
+        run: |
+          set -euo pipefail
+          cd ../artifact
+          count=0
+          while IFS= read -r page; do
+            rel="${page#docs/}"
+            dest="/docs/${rel%.html}"
+            out="sentinel/${rel}"
+            mkdir -p "$(dirname "$out")"
+            printf '<!doctype html>\n<meta charset="utf-8">\n<meta http-equiv="refresh" content="0; url=%s">\n<link rel="canonical" href="%s">\n<p>This page moved to <a href="%s">%s</a>.</p>\n' \
+              "$dest" "$dest" "$dest" "$dest" > "$out"
+            count=$((count + 1))
+          done < <(find docs -name '*.html' -type f)
+          printf '<!doctype html>\n<meta http-equiv="refresh" content="0; url=/docs/">\n' > sentinel/index.html
+          echo "generated $count redirect stubs for the previous URL prefix"
+
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v5
         with:
-          path: website/build
+          path: artifact
 
   deploy:
     name: Deploy to GitHub Pages

--- a/README.md
+++ b/README.md
@@ -299,6 +299,17 @@ databases:
 
 Inspect and manage chains:
 
+> **These three subcommands cannot currently be invoked.** They require `--config` but never register
+> the flag, and the one on `sentinel backup` is local rather than persistent, so they fail whether you
+> pass it or not. Tracked in
+> [#136](https://github.com/denisakp/sentinel/issues/136). The usage shown below is what they are
+> meant to accept once that is fixed.
+>
+> Until then, use `sentinel monitor list` and `sentinel monitor show` to inspect chain state, and
+> `sentinel restore validate-chain <job>` to check a chain. See
+> [Incremental backup and PITR](https://denisakp.github.io/sentinel/concepts/incremental-pitr) for
+> what does work today.
+
 ```bash
 sentinel backup chain-status --config sentinel.yaml
 sentinel backup chain-list --config sentinel.yaml

--- a/docs/runbooks/additional-args.md
+++ b/docs/runbooks/additional-args.md
@@ -1,5 +1,10 @@
 # Runbook — `additional_args` quoting reference
 
+> **Superseded by the documentation site: [reference/additional-args](https://denisakp.github.io/sentinel/reference/additional-args).**
+>
+> This runbook documents `restore_options.additional_args` as working; it is validated then discarded. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 Sentinel forwards the operator-supplied `additional_args` string to the
 underlying dump or restore tool (`pg_dump`, `mysqldump`, `mariadb-dump`,
 `mongodump`, and their restore counterparts) as command-line arguments.

--- a/docs/runbooks/alerting-setup.md
+++ b/docs/runbooks/alerting-setup.md
@@ -1,5 +1,10 @@
 # Runbook — Alerting setup
 
+> **Superseded by the documentation site: [guides/alerting-setup](https://denisakp.github.io/sentinel/guides/alerting-setup).**
+>
+> This runbook its email example does not load: the keys are `from_address_env` and `to_addresses`. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [failed-backup-triage](./failed-backup-triage.md), [restore-from-backup](./restore-from-backup.md), [start-scheduler](./start-scheduler.md)

--- a/docs/runbooks/apply-retention.md
+++ b/docs/runbooks/apply-retention.md
@@ -1,5 +1,10 @@
 # Runbook — Apply retention
 
+> **Superseded by the documentation site: [guides/apply-retention](https://denisakp.github.io/sentinel/guides/apply-retention).**
+>
+> This runbook claims `keep_last` and `keep_days` union; they intersect. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [run-backup-from-config](./run-backup-from-config.md), [check-storage-backend](./check-storage-backend.md)

--- a/docs/runbooks/backup-compression.md
+++ b/docs/runbooks/backup-compression.md
@@ -1,5 +1,10 @@
 # Runbook — Backup compression (gzip / zstd)
 
+> **Superseded by the documentation site: [guides/backup-compression](https://denisakp.github.io/sentinel/guides/backup-compression).**
+>
+> This runbook superseded; verified against the code. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-08-02
 - **Related**: PRD 33 / spec 049 (pipeline compression), [enable-encryption](./enable-encryption.md), [verify-backup-integrity](./verify-backup-integrity.md), [restore-from-backup](./restore-from-backup.md), [check-storage-backend](./check-storage-backend.md)

--- a/docs/runbooks/chain-corruption-recovery.md
+++ b/docs/runbooks/chain-corruption-recovery.md
@@ -1,5 +1,10 @@
 # Runbook — Chain corruption recovery
 
+> **Superseded by the documentation site: [operations/chain-corruption-recovery](https://denisakp.github.io/sentinel/operations/chain-corruption-recovery).**
+>
+> This runbook centres on three subcommands that cannot be invoked at all. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [restore-pitr-and-incremental](./restore-pitr-and-incremental.md), [apply-retention](./apply-retention.md), [verify-backup-integrity](./verify-backup-integrity.md)

--- a/docs/runbooks/check-storage-backend.md
+++ b/docs/runbooks/check-storage-backend.md
@@ -1,5 +1,10 @@
 # Runbook — Check storage backend
 
+> **Superseded by the documentation site: [guides/check-storage-backend](https://denisakp.github.io/sentinel/guides/check-storage-backend).**
+>
+> This runbook refers to a `file_path` column that `monitor list` does not have. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [migrate-storage-backend](./migrate-storage-backend.md), [apply-retention](./apply-retention.md), [restore-from-gcs](./restore-from-gcs.md)

--- a/docs/runbooks/credentials.md
+++ b/docs/runbooks/credentials.md
@@ -1,5 +1,10 @@
 # Database credentials
 
+> **Superseded by the documentation site: [guides/database-credentials](https://denisakp.github.io/sentinel/guides/database-credentials).**
+>
+> This runbook uses `sentinel backup run --job`, which does not exist, and its argv claim is false for MongoDB. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 Sentinel never accepts passwords on the command line in supported channels. Use one of three safe sources; conflicts among the CLI flags are hard errors before any database I/O.
 
 ## Three safe channels

--- a/docs/runbooks/db-migration-status.md
+++ b/docs/runbooks/db-migration-status.md
@@ -1,5 +1,10 @@
 # Runbook — DB migration status
 
+> **Superseded by the documentation site: [guides/db-migration-status](https://denisakp.github.io/sentinel/guides/db-migration-status).**
+>
+> This runbook wrong output format, and lists three of the five migrations. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [upgrade-sentinel-binary](./upgrade-sentinel-binary.md), [inspect-monitor-history](./inspect-monitor-history.md)

--- a/docs/runbooks/enable-encryption.md
+++ b/docs/runbooks/enable-encryption.md
@@ -1,5 +1,10 @@
 # Runbook — Enable encryption
 
+> **Superseded by the documentation site: [guides/enable-encryption](https://denisakp.github.io/sentinel/guides/enable-encryption).**
+>
+> This runbook shows `security init-key` output that the command no longer prints. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-08-02
 - **Related**: ADR 0006 (envelope v1), spec 047 (remote-artifact security), [key-rotation](./key-rotation.md), [key-loss-incident](./key-loss-incident.md), [verify-backup-integrity](./verify-backup-integrity.md), [recover-legacy-envelope](./recover-legacy-envelope.md), [check-storage-backend](./check-storage-backend.md)

--- a/docs/runbooks/environment-setup.md
+++ b/docs/runbooks/environment-setup.md
@@ -1,5 +1,10 @@
 # Runbook — Environment setup
 
+> **Superseded by the documentation site: [guides/environment-setup](https://denisakp.github.io/sentinel/guides/environment-setup).**
+>
+> This runbook wrong PostgreSQL version, and references a dataset file that is not in the repository. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [run-backup-from-config](./run-backup-from-config.md), [troubleshooting](./troubleshooting.md)

--- a/docs/runbooks/failed-backup-triage.md
+++ b/docs/runbooks/failed-backup-triage.md
@@ -1,5 +1,10 @@
 # Runbook — Failed backup triage
 
+> **Superseded by the documentation site: [operations/failed-backup-triage](https://denisakp.github.io/sentinel/operations/failed-backup-triage).**
+>
+> This runbook lists statuses and error strings that the code never emits. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [inspect-monitor-history](./inspect-monitor-history.md), [troubleshooting](./troubleshooting.md), [stale-lock-recovery](./stale-lock-recovery.md), [check-storage-backend](./check-storage-backend.md), [enable-encryption](./enable-encryption.md)

--- a/docs/runbooks/inspect-monitor-history.md
+++ b/docs/runbooks/inspect-monitor-history.md
@@ -1,5 +1,10 @@
 # Runbook — Inspect monitor history
 
+> **Superseded by the documentation site: [guides/inspect-monitor-history](https://denisakp.github.io/sentinel/guides/inspect-monitor-history).**
+>
+> This runbook wrong columns, and its example demonstrates a silent all-time window bug. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [failed-backup-triage](./failed-backup-triage.md), [db-migration-status](./db-migration-status.md)

--- a/docs/runbooks/integrity-sweep.md
+++ b/docs/runbooks/integrity-sweep.md
@@ -1,5 +1,10 @@
 # Runbook — Repository-wide integrity sweep (`backup verify --all` + scheduled)
 
+> **Superseded by the documentation site: [guides/integrity-sweep](https://denisakp.github.io/sentinel/guides/integrity-sweep).**
+>
+> This runbook incomplete JSON field list and a trigger value that is never written. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-08-03
 - **Related**: [verify-backup-integrity](./verify-backup-integrity.md), [failed-backup-triage](./failed-backup-triage.md), [enable-encryption](./enable-encryption.md)

--- a/docs/runbooks/key-loss-incident.md
+++ b/docs/runbooks/key-loss-incident.md
@@ -1,5 +1,10 @@
 # Runbook — Key loss incident
 
+> **Superseded by the documentation site: [operations/key-loss-incident](https://denisakp.github.io/sentinel/operations/key-loss-incident).**
+>
+> This runbook presents `backup verify` as proof a key still works; verification never decrypts, so a wrong-key artifact passes. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [enable-encryption](./enable-encryption.md), [key-rotation](./key-rotation.md), ADR 0006 (envelope v1)

--- a/docs/runbooks/key-rotation.md
+++ b/docs/runbooks/key-rotation.md
@@ -1,5 +1,10 @@
 # Runbook — Key rotation
 
+> **Superseded by the documentation site: [guides/key-rotation](https://denisakp.github.io/sentinel/guides/key-rotation).**
+>
+> This runbook shows `encryption_key_env` nested under a `restores:` job, which is not a field that exists. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-08-05
 - **Related**: [enable-encryption](./enable-encryption.md), [key-loss-incident](./key-loss-incident.md), [recover-legacy-envelope](./recover-legacy-envelope.md), ADR 0006

--- a/docs/runbooks/migrate-storage-backend.md
+++ b/docs/runbooks/migrate-storage-backend.md
@@ -1,5 +1,10 @@
 # Runbook — Migrate storage backend
 
+> **Superseded by the documentation site: [guides/migrate-storage-backend](https://denisakp.github.io/sentinel/guides/migrate-storage-backend).**
+>
+> This runbook same column problem, and claims retention runs cleanly after a migration. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [check-storage-backend](./check-storage-backend.md), [apply-retention](./apply-retention.md), [run-backup-from-config](./run-backup-from-config.md)

--- a/docs/runbooks/mongo-staging.md
+++ b/docs/runbooks/mongo-staging.md
@@ -1,5 +1,10 @@
 # Runbook: `.staging/` directory for Mongo remote backups
 
+> **Superseded by the documentation site: [reference/mongo-staging](https://denisakp.github.io/sentinel/reference/mongo-staging).**
+>
+> This runbook describes the wrong staging directory for config-driven remote backups. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 When a MongoDB backup targets a **remote** backend — `sentinel backup --type mongodb --storage s3|gcs|gdrive` (or the equivalent config-file `storage:` block, including `azure`) — `mongodump` is invoked in archive mode against a transient file under:
 
 ```

--- a/docs/runbooks/monitor-schema-migration.md
+++ b/docs/runbooks/monitor-schema-migration.md
@@ -1,5 +1,10 @@
 # Monitor Schema Migration
 
+> **Superseded by the documentation site: [guides/monitor-schema-migration](https://denisakp.github.io/sentinel/guides/monitor-schema-migration).**
+>
+> This runbook the "same transaction" claim is false and the lock file name is wrong. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 How Sentinel manages the schema of its monitor (history) SQLite database, and how operators inspect or repair it.
 
 ## What `schema_version` is

--- a/docs/runbooks/parallel-restore.md
+++ b/docs/runbooks/parallel-restore.md
@@ -1,5 +1,10 @@
 # Parallel Multi-Job Restore
 
+> **Superseded by the documentation site: [guides/parallel-restore](https://denisakp.github.io/sentinel/guides/parallel-restore).**
+>
+> This runbook its example omits `enabled` and `schedule`, so no job in it would run. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 `sentinel restore run --all` runs every **enabled** configured restore job at once, bounded by a concurrency limit. It turns a disaster-recovery drill across N services (one restore job per service) from a serial sum-of-times into a parallel run.
 
 > Scope: this parallelises **jobs** (the job axis). It does not restore multiple databases within a single job — a restore job targets exactly one database.

--- a/docs/runbooks/recover-legacy-envelope.md
+++ b/docs/runbooks/recover-legacy-envelope.md
@@ -1,5 +1,10 @@
 # Runbook — Recover legacy envelope (pre-v2)
 
+> **Superseded by the documentation site: [operations/recover-legacy-envelope](https://denisakp.github.io/sentinel/operations/recover-legacy-envelope).**
+>
+> This runbook its default-deny claim is false for `backup verify`. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: ADR 0006 (envelope v1/v2), [enable-encryption](./enable-encryption.md), [key-rotation](./key-rotation.md)

--- a/docs/runbooks/restore-from-backup.md
+++ b/docs/runbooks/restore-from-backup.md
@@ -1,5 +1,10 @@
 # Runbook — Restore from backup
 
+> **Superseded by the documentation site: [tutorials/postgres/restore](https://denisakp.github.io/sentinel/tutorials/postgres/restore).**
+>
+> This runbook superseded by the per-engine tutorial tracks. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [restore-pitr-and-incremental](./restore-pitr-and-incremental.md), [restore-from-gcs](./restore-from-gcs.md), [restore-rehearsal](./restore-rehearsal.md), [verify-backup-integrity](./verify-backup-integrity.md)

--- a/docs/runbooks/restore-from-gcs.md
+++ b/docs/runbooks/restore-from-gcs.md
@@ -1,5 +1,10 @@
 # Runbook — Restore from GCS
 
+> **Superseded by the documentation site: [guides/restore-from-gcs](https://denisakp.github.io/sentinel/guides/restore-from-gcs).**
+>
+> This runbook superseded; verified against the code. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [restore-from-backup](./restore-from-backup.md), [check-storage-backend](./check-storage-backend.md)

--- a/docs/runbooks/restore-pitr-and-incremental.md
+++ b/docs/runbooks/restore-pitr-and-incremental.md
@@ -1,5 +1,10 @@
 # Runbook — PITR and incremental restore
 
+> **Superseded by the documentation site: [concepts/incremental-pitr](https://denisakp.github.io/sentinel/concepts/incremental-pitr).**
+>
+> This runbook PITR cannot currently be planned for any engine; see #148. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [restore-from-backup](./restore-from-backup.md), [chain-corruption-recovery](./chain-corruption-recovery.md), [verify-backup-integrity](./verify-backup-integrity.md)

--- a/docs/runbooks/restore-rehearsal.md
+++ b/docs/runbooks/restore-rehearsal.md
@@ -1,5 +1,10 @@
 # Runbook — Restore rehearsal (DR drill)
 
+> **Superseded by the documentation site: [guides/index](https://denisakp.github.io/sentinel/guides/index).**
+>
+> This runbook the site page is held pending #149; verify a rehearsal by querying the restored database, not with `verify_after_restore`. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [restore-from-backup](./restore-from-backup.md), [restore-pitr-and-incremental](./restore-pitr-and-incremental.md), [verify-backup-integrity](./verify-backup-integrity.md)

--- a/docs/runbooks/retention-gfs.md
+++ b/docs/runbooks/retention-gfs.md
@@ -1,5 +1,10 @@
 # Grandfather-Father-Son (GFS) Retention
 
+> **Superseded by the documentation site: [guides/retention-gfs](https://denisakp.github.io/sentinel/guides/retention-gfs).**
+>
+> This runbook claims the flat rules union, and overstates baseline protection. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 Long-horizon, calendar-tiered retention that keeps one representative backup per
 day / week / month / year — so you can satisfy multi-year compliance or DR
 mandates without hoarding every backup.

--- a/docs/runbooks/run-backup-from-config.md
+++ b/docs/runbooks/run-backup-from-config.md
@@ -1,5 +1,10 @@
 # Runbook — Run backup from config
 
+> **Superseded by the documentation site: [guides/run-backup-from-config](https://denisakp.github.io/sentinel/guides/run-backup-from-config).**
+>
+> This runbook uses `sentinel backup --job`, which does not exist. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [environment-setup](./environment-setup.md), [start-scheduler](./start-scheduler.md), [inspect-monitor-history](./inspect-monitor-history.md), [verify-backup-integrity](./verify-backup-integrity.md)

--- a/docs/runbooks/scheduler-crash-recovery.md
+++ b/docs/runbooks/scheduler-crash-recovery.md
@@ -1,5 +1,10 @@
 # Runbook — Scheduler crash recovery
 
+> **Superseded by the documentation site: [operations/scheduler-crash-recovery](https://denisakp.github.io/sentinel/operations/scheduler-crash-recovery).**
+>
+> This runbook same startup reap claim, and `monitor list --status skipped` can never return a row. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: ADR 0008 (scheduler concurrency), ADR 0007 (lock file format), [start-scheduler](./start-scheduler.md), [stale-lock-recovery](./stale-lock-recovery.md)

--- a/docs/runbooks/stale-lock-recovery.md
+++ b/docs/runbooks/stale-lock-recovery.md
@@ -1,5 +1,10 @@
 # Runbook — Stale lock recovery
 
+> **Superseded by the documentation site: [operations/stale-lock-recovery](https://denisakp.github.io/sentinel/operations/stale-lock-recovery).**
+>
+> This runbook describes a stale-lock reap at scheduler startup that does not happen. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: ADR 0007 (lock file format), [scheduler-crash-recovery](./scheduler-crash-recovery.md), [troubleshooting](./troubleshooting.md)

--- a/docs/runbooks/start-scheduler.md
+++ b/docs/runbooks/start-scheduler.md
@@ -1,5 +1,10 @@
 # Runbook — Start the scheduler
 
+> **Superseded by the documentation site: [concepts/schedule](https://denisakp.github.io/sentinel/concepts/schedule).**
+>
+> This runbook the site page is held pending #138; its stale-lock claim is also untrue. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: ADR 0008 (scheduler concurrency), [scheduler-crash-recovery](./scheduler-crash-recovery.md), [stale-lock-recovery](./stale-lock-recovery.md)

--- a/docs/runbooks/state-repair.md
+++ b/docs/runbooks/state-repair.md
@@ -1,5 +1,10 @@
 # Runbook — Repository state repair (`sentinel repair`)
 
+> **Superseded by the documentation site: [operations/state-repair](https://denisakp.github.io/sentinel/operations/state-repair).**
+>
+> This runbook `--fix` does not mark broken chains, and the sample output header is wrong. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-08-03
 - **Related**: [stale-lock-recovery](./stale-lock-recovery.md), [scheduler-crash-recovery](./scheduler-crash-recovery.md), [chain-corruption-recovery](./chain-corruption-recovery.md), [integrity-sweep](./integrity-sweep.md), [monitor-schema-migration](./monitor-schema-migration.md)

--- a/docs/runbooks/troubleshooting.md
+++ b/docs/runbooks/troubleshooting.md
@@ -1,5 +1,10 @@
 # Runbook — Troubleshooting
 
+> **Superseded by the documentation site: [operations/troubleshooting](https://denisakp.github.io/sentinel/operations/troubleshooting).**
+>
+> This runbook several error strings are wrong, and the `log_format` advice does not do what it says. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [failed-backup-triage](./failed-backup-triage.md), [stale-lock-recovery](./stale-lock-recovery.md), [environment-setup](./environment-setup.md)

--- a/docs/runbooks/upgrade-sentinel-binary.md
+++ b/docs/runbooks/upgrade-sentinel-binary.md
@@ -1,5 +1,10 @@
 # Runbook — Upgrade Sentinel binary
 
+> **Superseded by the documentation site: [guides/upgrade-sentinel-binary](https://denisakp.github.io/sentinel/guides/upgrade-sentinel-binary).**
+>
+> This runbook claims migrations apply automatically and that startup reaps stale locks; neither happens. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: [db-migration-status](./db-migration-status.md), [start-scheduler](./start-scheduler.md), [scheduler-crash-recovery](./scheduler-crash-recovery.md)

--- a/docs/runbooks/verify-backup-integrity.md
+++ b/docs/runbooks/verify-backup-integrity.md
@@ -1,5 +1,10 @@
 # Runbook — Verify backup integrity
 
+> **Superseded by the documentation site: [guides/verify-backup-integrity](https://denisakp.github.io/sentinel/guides/verify-backup-integrity).**
+>
+> This runbook shows a PASS string the command never prints, and misstates an exit code. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE
 - **Last reviewed**: 2026-05-17
 - **Related**: ADR 0005 (manifest v1), [enable-encryption](./enable-encryption.md), [recover-legacy-envelope](./recover-legacy-envelope.md), [failed-backup-triage](./failed-backup-triage.md)

--- a/docs/runbooks/verify-release-artifacts.md
+++ b/docs/runbooks/verify-release-artifacts.md
@@ -1,5 +1,10 @@
 # Runbook — Verify release artifacts (cosign signature + SLSA provenance)
 
+> **Superseded by the documentation site: [operations/verify-release-artifacts](https://denisakp.github.io/sentinel/operations/verify-release-artifacts).**
+>
+> This runbook pins a version while fetching from `latest/download`, so the download can be a 404 page. The site page was checked against the source and describes current
+> behaviour. Prefer it. This file is kept as source material and is not maintained in parallel.
+
 - **Audience**: ops / SRE / anyone installing a prebuilt binary
 - **Related**: [upgrade-sentinel-binary](./upgrade-sentinel-binary.md), README "Installation" section
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -15,15 +15,17 @@ const SENTINEL_RELEASE = 'v1.4.0';
  * different paths, and Docusaurus bakes `baseUrl` into every generated link and
  * asset at build time: so this cannot be a constant.
  *
- *   ghpages (default): https://denisakp.github.io/sentinel/
- *   custom           : https://sentinel.denisakp.me/docs/
+ *   custom (default): https://sentinel.denisakp.me/docs/
+ *   ghpages         : https://denisakp.github.io/sentinel/
  *
- * `ghpages` stays the default until DNS for sentinel.denisakp.me resolves.
+ * `custom` became the default once DNS resolved. `ghpages` is kept as a way back
+ * if the domain ever has to be given up.
  *
- * WARNING: do not add static/CNAME or set a custom domain in the repository's
- * Pages settings before that DNS record exists. Configuring a custom domain
- * makes GitHub redirect the github.io URL to it; with DNS unresolved the site
- * becomes unreachable at BOTH addresses.
+ * One thing baseUrl does NOT do: nest the build output. With `/docs/` the files
+ * still land at the root of `build/`. That matched the old project-site layout by
+ * accident, because Pages serves the artifact root at /<repo>/. On a custom domain
+ * the artifact root is the domain root, so `.github/workflows/docs.yml` nests the
+ * artifact one level to make the paths line up again.
  */
 const DEPLOY_TARGET = process.env.DEPLOY_TARGET ?? 'custom';
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -25,7 +25,7 @@ const SENTINEL_RELEASE = 'v1.4.0';
  * makes GitHub redirect the github.io URL to it; with DNS unresolved the site
  * becomes unreachable at BOTH addresses.
  */
-const DEPLOY_TARGET = process.env.DEPLOY_TARGET ?? 'ghpages';
+const DEPLOY_TARGET = process.env.DEPLOY_TARGET ?? 'custom';
 
 const HOSTING = {
   ghpages: {url: 'https://denisakp.github.io', baseUrl: '/sentinel/'},

--- a/website/package.json
+++ b/website/package.json
@@ -13,8 +13,8 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
-    "a11y": "pa11y-ci --config .pa11yci.json --sitemap http://localhost:3000/sentinel/sitemap.xml --sitemap-find https://denisakp.github.io --sitemap-replace http://localhost:3000",
-    "a11y:json": "pa11y-ci --json --config .pa11yci.json --sitemap http://localhost:3000/sentinel/sitemap.xml --sitemap-find https://denisakp.github.io --sitemap-replace http://localhost:3000"
+    "a11y": "pa11y-ci --config .pa11yci.json --sitemap http://localhost:3000${DOCS_BASE:-/docs/}sitemap.xml --sitemap-find ${DOCS_ORIGIN:-https://sentinel.denisakp.me} --sitemap-replace http://localhost:3000",
+    "a11y:json": "pa11y-ci --json --config .pa11yci.json --sitemap http://localhost:3000${DOCS_BASE:-/docs/}sitemap.xml --sitemap-find ${DOCS_ORIGIN:-https://sentinel.denisakp.me} --sitemap-replace http://localhost:3000"
   },
   "dependencies": {
     "@docusaurus/core": "3.10.2",

--- a/website/redirects.md
+++ b/website/redirects.md
@@ -24,8 +24,24 @@ appears not to work in the dev server is not a bug. Check it against the product
 
 ## Entries
 
-_None yet. The site has not moved a published page._
+No individual page has moved. The whole site did, once.
 
 | From | To | Reason | Increment |
 |------|----|--------|-----------|
-| n/a    |; | n/a      |; |
+| `denisakp.github.io/sentinel/*` | `sentinel.denisakp.me/docs/*` | The custom domain came online, and the domain root is reserved for a future landing page | 5 |
+
+These stubs are **not** in `docusaurus.config.ts`, and that is not an oversight. The client-redirects
+plugin can only write files under `baseUrl`, which is now `/docs/`. The stubs have to live at
+`/sentinel/*`, outside it, so they are generated in `.github/workflows/docs.yml` by mirroring the
+built tree, one per page.
+
+Two facts behind that, both established by testing rather than by reading:
+
+- **Docusaurus does not nest its output under `baseUrl`.** With `baseUrl: '/docs/'` the files still
+  land at the root of `build/`. That went unnoticed while this was a Pages project site, because
+  Pages serves the artifact root at `/<repo>/`, which happened to match `baseUrl: '/sentinel/'`. On a
+  custom domain the artifact root is the domain root, so the workflow nests the artifact one level.
+- **GitHub redirects the old origin to the new one, preserving the path.** A request to
+  `denisakp.github.io/sentinel/concepts/backup` lands on
+  `sentinel.denisakp.me/sentinel/concepts/backup`. Without these stubs, every URL published before
+  the cutover would 404.

--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,0 +1,1 @@
+sentinel.denisakp.me


### PR DESCRIPTION
Two changes since the last promotion.

**The custom domain goes live.** DNS resolves, the domain is set in Pages settings, and `DEPLOY_TARGET` now defaults to `custom`, so the site moves from `denisakp.github.io/sentinel/` to `sentinel.denisakp.me/docs/`. The domain root stays free for a landing page later.

Merging this deploys. Two details that were not obvious and are worth knowing if this ever needs undoing:

- Docusaurus does not nest its output under `baseUrl`, so the workflow nests the artifact one level. Without that, every link would point at `/docs/` while the files sat at `/`.
- GitHub redirects the old origin to the new one preserving the path, so the workflow also generates 88 stubs under `/sentinel/*` pointing at their `/docs/*` equivalents. Nothing published before the cutover breaks.

**Every runbook is marked superseded**, naming the site page that replaced it and, where one was found, the specific claim that does not match the code. The README chain-command example is corrected in place.

That closes six documentation issues: #147, #162, #174, #178, #180, #192. The code defects they describe stay open and are indexed in #176, which is now a clean list of 56 code issues.