### PR TITLE
docs: wire up placeholders left over from incremental delivery

### DIFF
--- a/website/docs/concepts/index.md
+++ b/website/docs/concepts/index.md
@@ -12,7 +12,9 @@ something you did not expect.
 Each page explains what the concept is for, how it actually works, how it is configured, and how it
 fails.
 
-## Start here
+## The core loop
+
+Start here if you are new. These three explain what Sentinel does on a normal day.
 
 | Page | Read it when |
 |---|---|
@@ -20,14 +22,37 @@ fails.
 | [Restore](./restore.md) | You want to know how Sentinel decides *which* artifact to restore, and what it does before touching your database. |
 | [Schedule](./schedule.md) | You are moving from running backups by hand to running them on a cron loop. |
 
-## Not yet written
+## Keeping backups trustworthy
 
-The remaining concepts (encryption, retention, manifests, credential sanitization, storage backends,
-locking, incremental and point-in-time recovery, monitoring history, compression, and notifications)
-are being published in later increments.
+| Page | Read it when |
+|---|---|
+| [Manifests and integrity](./manifest.md) | You want to know how Sentinel proves an artifact has not changed, and what `backup verify` does and does not tell you. |
+| [Security and encryption](./security-encryption.md) | You are deciding whether to encrypt artifacts at rest, or handling a key. |
+| [Credential handling](./credential-sanitization.md) | You are choosing how Sentinel authenticates, and want passwords kept out of process arguments and logs. |
+| [Locking and concurrency](./locking.md) | Two runs might overlap, or one is refusing to start. |
 
-Until then, the [runbooks in the repository](https://github.com/denisakp/sentinel/tree/develop/docs/runbooks)
-cover those areas from an operator's angle, and the
-[configuration reference](../reference/configuration.md) documents every key they use.
+## Managing what accumulates
 
-<!-- sources: internal/domain/backup/, internal/domain/restore/, internal/domain/schedule/ -->
+| Page | Read it when |
+|---|---|
+| [Retention](./retention.md) | You need old backups expired, and want to know exactly what will be deleted. |
+| [Storage backends](./storage-backends.md) | You are choosing where artifacts live, or moving them. |
+| [Compression](./compression.md) | Artifact size or transfer cost matters. |
+| [Incremental and PITR](./incremental-pitr.md) | Full backups are too expensive, or you need to recover to a point in time. |
+
+## Knowing what happened
+
+| Page | Read it when |
+|---|---|
+| [Monitoring and history](./monitoring-history.md) | You are asking what ran, when, and whether it worked. |
+| [Notifications](./notifications.md) | You want to hear about failures rather than discover them. |
+
+## A note on what these pages say
+
+They describe what Sentinel does today, not what it is meant to do. Where a capability does not work,
+the page says so and links to the open issue rather than describing the intended behaviour.
+
+Several pages carry warnings of that kind. They are the most useful part of the page: read them
+before you rely on the feature.
+
+<!-- sources: internal/domain/, internal/adapters/ -->

--- a/website/docs/intro/architecture-overview.md
+++ b/website/docs/intro/architecture-overview.md
@@ -48,23 +48,19 @@ its hash, decrypt if needed, then feed it to `pg_restore`, `mysql`, `mariadb`, o
 
 | Part | What it is | Read more |
 |---|---|---|
-| **Backup** | Producing an artifact from a live database | Concepts (increment 2) |
-| **Restore** | Turning an artifact back into a database | Concepts (increment 2) |
-| **Schedule** | The cron loop that runs backup and restore jobs | Concepts (increment 2) |
-| **Storage backend** | Where artifacts live: local, S3, GCS, Google Drive, Azure | Concepts (increment 3) |
-| **Manifest** | The SHA-256 record proving an artifact is intact and where it sits in a chain | Concepts (increment 3) |
-| **Retention** | Deciding which old artifacts to delete | Concepts (increment 3) |
-| **Encryption** | Opt-in AES-256 protection of artifacts at rest | Concepts (increment 3) |
-| **Locking** | Preventing two runs of the same job from colliding | Concepts (increment 3) |
-| **Monitor** | The local SQLite history of every execution | Concepts (increment 4) |
-| **Notifications** | Slack, Discord, email, webhook | Concepts (increment 4) |
-
-:::note This documentation is still being written
-Concept, guide, tutorial, and reference sections are being published incrementally. Sections not yet
-listed in the sidebar have not been written yet; they are not missing links, just future work. In
-the meantime, the [runbooks in the repository](https://github.com/denisakp/sentinel/tree/develop/docs/runbooks)
-cover operational procedures in depth.
-:::
+| **Backup** | Producing an artifact from a live database | [Backup](../concepts/backup.md) |
+| **Restore** | Turning an artifact back into a database | [Restore](../concepts/restore.md) |
+| **Schedule** | The cron loop that runs backup and restore jobs | [Schedule](../concepts/schedule.md) |
+| **Storage backend** | Where artifacts live: local, S3, GCS, Google Drive, Azure | [Storage backends](../concepts/storage-backends.md) |
+| **Manifest** | The SHA-256 record proving an artifact is intact and where it sits in a chain | [Manifests and integrity](../concepts/manifest.md) |
+| **Retention** | Deciding which old artifacts to delete | [Retention](../concepts/retention.md) |
+| **Encryption** | Opt-in AES-256 protection of artifacts at rest | [Security and encryption](../concepts/security-encryption.md) |
+| **Credential handling** | Keeping passwords out of process arguments and logs | [Credential handling](../concepts/credential-sanitization.md) |
+| **Locking** | Preventing two runs of the same job from colliding | [Locking and concurrency](../concepts/locking.md) |
+| **Incremental and PITR** | Backing up only what changed, and recovering to a point in time | [Incremental and PITR](../concepts/incremental-pitr.md) |
+| **Compression** | Reducing artifact size, in the pipeline or natively | [Compression](../concepts/compression.md) |
+| **Monitor** | The local SQLite history of every execution | [Monitoring and history](../concepts/monitoring-history.md) |
+| **Notifications** | Slack, Discord, email, webhook | [Notifications](../concepts/notifications.md) |
 
 ## Three ideas worth internalising early
 


### PR DESCRIPTION
Reported by a reader.

`intro/architecture-overview` had a "Read more" column reading `Concepts (increment 2)` as plain text, not a link. `concepts/index` listed three of the thirteen concept pages and announced the other ten as not yet written.

Both were written in increment 1, when no concept page existed. Neither was revisited once they did.

The overview now links all thirteen pages, and drops the "still being written" admonition, since the sections it apologised for are published. The concepts index lists all thirteen, grouped by what a reader is trying to do rather than by delivery order.

Worth noting how this got through: the editorial pass checked terminology and punctuation, and never asked whether text written for a half-built site was still true of a finished one. Scaffolding that describes the build order reads as normal prose once the build is done, which is exactly why it survives.