### PR TITLE
docs(audit): remediation plan for the 54 documentation-batch defects

### DIFF
--- a/docs/audit/documentation-batch-defects/I00-e2e-harness-foundation.md
+++ b/docs/audit/documentation-batch-defects/I00-e2e-harness-foundation.md
@@ -1,0 +1,113 @@
+# PRD I00 — e2e harness foundation
+
+**Severity:** Critical (this is why 73 defects shipped undetected)
+**Status:** Open
+**Issues:** #175 (root cause of the whole batch), context in #176
+**Area:** `scripts/e2e.sh`, `tests/integration/`, `Makefile`, `.github/workflows/integration.yml`
+**Blocks:** every other PRD in this directory
+
+## Problem
+
+The e2e suite reported success across surfaces that were, at the same time, entirely broken. This
+is not a coverage shortfall to be topped up. Three structural mechanisms make whole defect classes
+invisible.
+
+### 1. Part of the suite never executes
+
+`test_unit` in `scripts/e2e.sh` runs `go test ./...`. That command **silently skips every file
+behind `//go:build integration`**. Those files run only via `.github/workflows/integration.yml`
+(`go test -tags integration ./tests/integration/...`). A local `make e2e` therefore reports green
+having never compiled, let alone run, the integration suite.
+
+### 2. The incremental coverage is scenery
+
+`grep incremental scripts/e2e.sh` returns 0. `grep` across `tests/integration/incremental/` returns
+22 hits — and **every scenario in that directory is a `t.Skip("...scaffold...")`**. Chain reset,
+fallback confirmation, mysql binlog replay, postgres chain backup+restore: all dead code that reads
+as coverage to anyone grepping for it.
+
+### 3. The one PITR test cannot see the PITR bug
+
+`tests/integration/postgres_pitr_restore_test.go` builds its own manifest fixture via
+`WritePITRManifest` with `RestoreMode: "pitr"`, then exercises the planner. It never traverses the
+backup-time manifest-writing path. #148 — `Capabilities` hard-coded to `{"full","incremental"}` at
+`internal/domain/backup/pipeline.go:226` — lives exactly there. The test is structurally incapable
+of failing on the bug it appears to cover.
+
+### 4. The default assertion is exit-code-only
+
+`scripts/e2e.sh` is 1295 lines with 28 `assert_exit_ok` calls against ~30 outcome-based checks
+(7 `assert_file_nonempty`, 4 `assert_output_contains`, ~19 hand-rolled magic-byte / `sqlite3`
+rowcount / data-match blocks). Roughly 48% / 52% by call count — but the outcome checks cluster in
+three late-added suites (verify_all, compression, remote-encrypted-backup, gfs). The backup,
+restore-dryrun, retention-preview, monitor, storage-status, s3, gcs and azure suites are
+exit-code-only.
+
+**A command that validates a config key, silently ignores it, and exits 0 is indistinguishable from
+success under `assert_exit_ok`.** That is the dominant shape of this defect batch.
+
+## Uncovered surfaces
+
+| Surface | Hits in `scripts/e2e.sh` | Would have caught |
+|---|---|---|
+| `pitr` | 0 | #148 |
+| `restore_mode` | 0 | #148, #186 |
+| `chain-status` / `chain-list` / `force-full` | 0 each | #136 |
+| `incremental` | 0 (22 in `tests/integration/`, all `t.Skip`) | #150, #185, #190 |
+| `binlog` / `oplog` | 0 (skip-scaffolds only) | #190, #191 |
+| `dry_run` | 0 (`--dry-run`: 8, exit-code-only except gfs) | #157 |
+| `lock` | 4, none a concurrency test | #163, #196 |
+| `notification` | 0 | #187 |
+| `monitor export` | 3, but via `--output`, never a shell `>` redirection | #165 |
+| `azure` | 14, connectivity only — the script's own comment admits no backup is exercised | #161 |
+| `gcs` | 17, no delete-verification | #182 |
+| `gdrive` | 0 | #169 |
+
+## Fix
+
+Ordered. Items 1, 3 and 5 are the cheap half and must land before the bug-fix batch starts; they
+require no new fixtures and cover the widest defect class.
+
+1. **Make the integration suite run.** Either have `test_unit` also run
+   `go test -tags integration ./tests/integration/...`, or document explicitly why it stays in a
+   separate workflow — and then ensure that workflow is a required check.
+2. **Un-skip or delete the five `t.Skip` scaffolds** in `tests/integration/incremental/`. Dead code
+   that reads as coverage is worse than an acknowledged gap. If they cannot be implemented now,
+   they must fail loudly or be removed.
+3. **Add `assert_rejected`** — the mirror of `assert_exit_ok`: requires non-zero exit **and** a
+   `grep` match on stderr. Every command that validates and rejects input gets one. This is what
+   catches the "validated then discarded" class (#172, #168, #170.x).
+4. **Add a real shell-redirection assertion** for `monitor export ... > file` (not `--output`),
+   which is the only form that detects stdout/stderr misrouting (#165).
+5. **Add a config-key-reachability test**: for every YAML key the validator accepts, assert it
+   changes *some* observable runtime behaviour. Fixture-diff, not "validates ok". This is the
+   generic catcher for the entire dead-config class (#141–#155, #172, #194).
+6. **Add one concurrency test**: two `backup` runs on the same job, assert the second is blocked or
+   serialised rather than silently racing (#163).
+7. **Add PITR / chain / force-full assertions that traverse the real
+   backup → manifest → restore pipeline**, not a hand-built manifest fixture.
+
+## Minimal shared scaffold
+
+So that each later PRD adds an assertion in a few lines rather than building its own fixture:
+
+- `assert_rejected <cmd> <expected-stderr-pattern>` — one-line use per negative test.
+- `assert_config_key_changes_behavior <key> <value> <observable>` — ~3 lines per dead-config fix.
+- A **real-backup** PITR/incremental fixture builder that runs `sentinel backup` (not
+  `WritePITRManifest`) against the containers already up in `docker-compose.yml`, producing a
+  genuine manifest chain other tests can extend.
+- `assert_blocks_when_concurrent <cmd>` — run a command twice concurrently, assert one blocks.
+
+## Acceptance
+
+- `make e2e` executes the integration-tagged tests, or a required CI check does and the split is
+  documented in `scripts/e2e.sh`.
+- `grep -c "t.Skip" tests/integration/incremental/` is 0.
+- The four scaffold helpers exist and are used by at least one test each.
+- A PITR fixture exists that is produced by a real `sentinel backup` invocation.
+- `go vet -tags=integration ./...` passes (integration files compile).
+
+## Sequencing
+
+Items **1, 3, 5** land before any bug-fix PRD. Items **2, 6, 7** land alongside the PRDs that need
+them: I09 (incremental/PITR fixtures), I04 (concurrency), I05 (retention deletion verification).

--- a/docs/audit/documentation-batch-defects/I00-e2e-harness-foundation.md
+++ b/docs/audit/documentation-batch-defects/I00-e2e-harness-foundation.md
@@ -71,9 +71,11 @@ require no new fixtures and cover the widest defect class.
 1. **Make the integration suite run.** Either have `test_unit` also run
    `go test -tags integration ./tests/integration/...`, or document explicitly why it stays in a
    separate workflow — and then ensure that workflow is a required check.
-2. **Un-skip or delete the five `t.Skip` scaffolds** in `tests/integration/incremental/`. Dead code
-   that reads as coverage is worse than an acknowledged gap. If they cannot be implemented now,
-   they must fail loudly or be removed.
+2. **Make the five `t.Skip` scaffolds in `tests/integration/incremental/` fail loudly.**
+   *RESOLVED 2026-08-06.* Implementing them needs the real PITR/incremental fixtures, which belong
+   to I09. Rather than deleting the scaffolding or leaving it as a false signal, each one fails with
+   a message pointing at I09. That removes the "grep finds coverage" illusion without discarding the
+   skeleton work. They convert to real assertions when I09 lands its fixtures.
 3. **Add `assert_rejected`** — the mirror of `assert_exit_ok`: requires non-zero exit **and** a
    `grep` match on stderr. Every command that validates and rejects input gets one. This is what
    catches the "validated then discarded" class (#172, #168, #170.x).
@@ -102,7 +104,8 @@ So that each later PRD adds an assertion in a few lines rather than building its
 
 - `make e2e` executes the integration-tagged tests, or a required CI check does and the split is
   documented in `scripts/e2e.sh`.
-- `grep -c "t.Skip" tests/integration/incremental/` is 0.
+- `grep -c "t.Skip" tests/integration/incremental/` is 0 — each scenario now fails with a message
+  naming I09, or is a real assertion.
 - The four scaffold helpers exist and are used by at least one test each.
 - A PITR fixture exists that is produced by a real `sentinel backup` invocation.
 - `go vet -tags=integration ./...` passes (integration files compile).

--- a/docs/audit/documentation-batch-defects/I01-cli-honesty-exit-codes.md
+++ b/docs/audit/documentation-batch-defects/I01-cli-honesty-exit-codes.md
@@ -1,0 +1,84 @@
+# PRD I01 — CLI honesty: exit codes, stdout routing, usage noise
+
+**Severity:** High (unattended and scripted use cannot detect failure)
+**Status:** Open
+**Issues:** #165, #168 (= #170.4), #170.1, #170.2, #170.3 (= #167.4), #179.7, #181.1, #181.5, #170.6
+**Area:** `internal/cli/{monitor,security,storage_cmd,repair,retention_helpers,backup_verify,version,root}.go`
+**Blocked by:** I00 (items 1, 3 — `assert_rejected` is the helper every test here needs)
+**Blocks:** I05, I14
+
+## Problem
+
+Across the CLI, success and failure look the same. A command refuses to act, or acts and fails, and
+still exits 0 with its output on the wrong stream. In cron and CI this is silent.
+
+This PRD lands early and on purpose: **until failures are observable, no later fix in this
+directory can be verified.**
+
+## Confirmed defects
+
+All reproduced against the reference binary.
+
+| # | Defect | Cause | Evidence |
+|---|---|---|---|
+| #165 | `monitor list/show/stats/export` write to stderr | `internal/cli/monitor.go` uses `cmd.Print*` without `SetOut`; Cobra defaults to `OutOrStderr()` | `monitor list --format json > out.json 2>err.log` → out.json **0 bytes**, err.log 930 bytes holding the JSON, exit 0 |
+| #170.2 | `storage status` exits 0 with an unreachable backend | `storage_cmd.go:197` returns `nil` unconditionally | unreachable S3 endpoint → printed `reachable:false` with a populated error, exit 0 |
+| #170.3 (=#167.4) | `repair --job <unknown>` reports "no drift" | `repair.go:684-718` `collectRepos` returns an empty list, no existence check | `repair --job doesnotexist` → "No drift detected." / "0 finding(s)", exit 0 |
+| #168 (=#170.4) | `retention apply` without `--job` swallows per-job errors | `retention_helpers.go:91-99` prints a warning then `return nil`; the `--job` path correctly returns the error | source; the two paths differ by construction |
+| #170.1 | `security init-key` exits 0 when it refuses | `security.go:30-34` `return nil` on the overwrite guard | `SENTINEL_MASTER_KEY=x security init-key` → "Warning: … already configured", exit 0 |
+| #170.5 | `security init-key --output <anything>` silently falls back to text | `security.go:41` only tests `== "json"`, no validation | `--output bogusformat` printed text, exit 0, no file created |
+| #181.1 | Same failure, two exit codes | `backup_verify.go:288-290` maps single-ID `missing_artifact` to `ErrVerifyInternal` (4); the `--all` sweep at 509/518 maps it to `ErrVerifyIntegrityFailed` (5) | source, both branches read |
+| #181.5 | `sentinel version foo bar` exits 0 | `version.go` sets no `Args`, Cobra accepts arbitrary positionals | ran the binary, printed the version block, exit 0 |
+| #179.7 | Every business-logic error prints the full usage block | `root.go:101` sets `SilenceErrors = true` but never `SilenceUsage` | `monitor stats` without `--job` printed the whole usage+flags block before the error |
+| #170.6 | `retention preview` and `retention apply` print the same wording | `retention_helpers.go:98` shares `"total deleted: %d backups"` across both paths | source |
+
+## Root cause
+
+Pattern **B** from the index. Two habits, repeated independently:
+
+- `return nil` is used for "I declined to act" and for "a sub-task failed", instead of a distinct
+  non-nil error. The information exists (`summary.Errors`, `entry.Reachable`) and is printed, then
+  discarded from the return value.
+- `cmd.Print*` is used without `SetOut`, so Cobra's default sends it to stderr. The correct pattern
+  already exists in this codebase — `monitor_doctor.go:37` and `repair.go` use `OutOrStdout()`.
+
+## Fix
+
+1. `root.go`: set `RootCmd.SilenceUsage = true`. **One line, do it first** — it makes every other
+   error in this batch readable.
+2. `monitor.go`: route `list`, `show`, `stats`, `export` through `cmd.OutOrStdout()`, matching
+   `monitor_doctor.go`.
+3. Propagate errors instead of swallowing them: non-nil return when `len(summary.Errors) > 0`
+   (`retention_helpers.go`), when any `entry.Reachable == false` (`storage_cmd.go`), and on the
+   `init-key` overwrite refusal (`security.go`).
+4. `repair.go`: validate `--job` against `cfg.Databases` up front; error on an unknown name.
+5. `security.go`: validate `--output` against `{json,text}`.
+6. `backup_verify.go` + `exit_codes.go`: the single-ID path returns `ErrVerifyIntegrityFailed` for
+   corrupted/missing artifacts; reserve `ErrVerifyInternal` for genuine operational failures.
+7. `version.go`: add `Args: cobra.NoArgs`.
+8. `retention_helpers.go`: label the dry-run path "would delete" / "total previewed".
+
+## DECISION REQUIRED
+
+Changing exit codes is a **breaking change for anyone scripting against them today**. Two of these
+change a 0 to a non-zero (`storage status`, `retention apply`), and #181.1 changes a 4 to a 5.
+Confirm whether this lands in a minor release with a release-note callout, or waits for a major.
+
+## Definition of done
+
+- **Code:** the eight fixes above.
+- **e2e** (each ships in the same PR, using `assert_rejected` from I00):
+  - `monitor list --format json > f` — `f` is non-empty, valid JSON.
+  - `storage status` with one unreachable backend — exit non-zero.
+  - `retention apply` (all jobs) with one job's delete forced to fail — exit non-zero, stderr names
+    the job.
+  - `repair --job <unknown>` — exit non-zero with an explicit "unknown job".
+  - `security init-key` with the key env var set and no `--force` — exit non-zero.
+  - `backup verify <id>` with the artifact deleted — exit 5, matching `--all` on the same fixture.
+  - `sentinel version foo` — exit non-zero.
+  - any `RunE` business-logic error — stderr does not contain `Usage:`.
+- **Docs:** `website/docs/` pages citing #165 (troubleshooting.md, chain-corruption-recovery.md,
+  failed-backup-triage.md, inspect-monitor-history.md, monitoring-history.md) and #170
+  (troubleshooting.md, chain-corruption-recovery.md, state-repair.md, check-storage-backend.md,
+  key-loss-incident.md). Remove the admonitions the fixes invalidate.
+- **Runbooks:** re-grep `docs/runbooks/` for the affected commands.

--- a/docs/audit/documentation-batch-defects/I02-config-loading-unification.md
+++ b/docs/audit/documentation-batch-defects/I02-config-loading-unification.md
@@ -1,0 +1,87 @@
+# PRD I02 — Config-loading unification + read-only monitor open
+
+**Severity:** Medium (surprising behaviour, one command mutates state just by being inspected)
+**Status:** Open
+**Issues:** #160, #171, #173, #179.3, #181.4
+**Area:** `internal/cli/{security,security_reencrypt,backup_verify,db,monitor_doctor,config_resolver}.go`,
+`internal/adapters/monitor/init.go`
+
+## Problem
+
+`internal/cli/config_resolver.go` exists to give every command one config path, one loader and one
+validation gate (`ResolveConfigPath`, `LoadAndValidateConfig`, which calls `config.ValidateConfig`).
+**Four commands bypass it**, each reinventing a different subset — and they disagree with each other
+about the default path, about whether the config is validated, and about whether opening the history
+database mutates it.
+
+## Confirmed defects
+
+| # | Defect | Cause |
+|---|---|---|
+| #160 | `security init-key`'s overwrite guard checks a hard-coded env var name | `security.go:29` reads `os.Getenv("SENTINEL_MASTER_KEY")`. The command **has no `--config` flag at all** — it structurally cannot consult `encryption_key_env` |
+| #171 | `security reencrypt` uses a different default config path and skips validation | `security_reencrypt.go:174-178` hardcodes `$HOME/.sentinel/config.yaml` and calls `config.LoadConfig` directly. Everything else uses `config_resolver.go:12`'s `./sentinel-config.yaml` and gets `ValidateConfig` for free |
+| #181.4 | `backup verify` tolerates an invalid config, `monitor` does not | `backup_verify.go:121` calls `config.LoadConfig`; `monitor.go:31/71/112/146` call `loadConfigFromFlags` → `LoadAndValidateConfig` |
+| #173 | `db migrate status` **migrates the database as a side effect of being run** | `monitor.NewMonitor()` unconditionally creates `schema_migrations` and runs `runMigrationsLocked` on every open; there is no read-only mode. Reproduced: `db migrate status` logged "migration starting/complete" and wrote `schema_migrations` rows, exit 0 |
+| #179.3 | The gates are inverted | The **mutating** `db migrate status` (`db.go:33`) uses the loose `LoadConfigMinimal`; the **read-only** `monitor doctor` (`monitor_doctor.go:20`) uses the strict `LoadAndValidateConfig` |
+
+Two further findings inside #173:
+
+- `db.go:33-39` checks `cfg.HistoryDBPath == ""` to refuse. **That branch is unreachable**:
+  `loader.go:64-65` always defaults the path to `~/.sentinel/history.db` before the check runs. So
+  with the key omitted, the command migrates a database in the user's home directory.
+- `LoadConfigMinimal` (`config_resolver.go:64-76`) is not actually minimal: it calls
+  `config.LoadConfig`, which still enforces `len(cfg.Databases) == 0` and runs
+  `applyEnvOverrides` / `interpolateConfig`. It skips only `ValidateConfig`.
+
+Two extra defects found inside #171 that the issue text does not cover:
+
+- `--new-key-env` overrides `targetCfg` **regardless of `legacyMode`** (`security_reencrypt.go:~197`),
+  so it rekeys in legacy mode too. The flag help at line 748 does not say so.
+- `swapArtifact`'s **remote** branch (`security_reencrypt.go:503-534`) returns `destObject` (the
+  artifact key) where `RecordSecurityInfo` expects `manifestPath`. The local branch at line 552
+  correctly returns `destManifest`. Remote backends record a wrong manifest path in history.
+
+## Root cause
+
+Pattern **A**. The shared helper landed after these commands were written and was never
+retro-applied. Each command's divergence is individually small and collectively means there is no
+answer to "which config does Sentinel read, and is it validated?"
+
+## Fix
+
+1. Add a **read-only open** to `internal/adapters/monitor/init.go` — a `NewMonitor` variant that
+   does not create tables or run migrations. Route `db migrate status` through it. This fixes #173
+   and #179.3 together and is the only structural item here.
+2. Route `security init-key`, `security reencrypt` and `backup verify` through
+   `config_resolver.ResolveConfigPath` + `LoadAndValidateConfig`. Add the missing `--config` flag to
+   `security init-key`.
+3. `security init-key`: resolve the env var name from `encryption_key_env`, falling back to
+   `SENTINEL_MASTER_KEY` only when no config or no field is present.
+4. `security_reencrypt.go`: return `destManifestObject` from the remote branch of `swapArtifact`.
+5. `security_reencrypt.go:748`: document `--new-key-env`'s legacy-mode rekey behaviour in the flag
+   help.
+6. Remove or fix the unreachable `HistoryDBPath == ""` check in `db.go`; require an explicit
+   `history_db_path` for `db migrate status` rather than silently defaulting into `$HOME`.
+
+## DECISION REQUIRED
+
+`backup verify` currently tolerates an invalid config. That may be **deliberate** — verify is a
+recovery-time command, and refusing to run because an unrelated job has a bad cron expression would
+be hostile exactly when it is needed. Decide: route it through the strict gate, or keep the loose
+one and document why. Do not change it silently.
+
+## Definition of done
+
+- **Code:** the six fixes above.
+- **e2e:**
+  - `security init-key` with a config setting `encryption_key_env: ACME_KEY` and `ACME_KEY` set,
+    without `--force` — warns/refuses instead of generating a new key.
+  - `db migrate status` against a stale-pending fixture DB — `schema_version` **unchanged** after
+    the call.
+  - `backup verify --all` against a validator-rejected config — behaves the same way as
+    `monitor doctor` against the same config (whichever way the decision above goes).
+  - `security reencrypt` against a remote-backed backup — the history row's `manifest_path` ends in
+    `.manifest.json`, not the artifact key. **NEEDS_LIVE** (object store) for this leg only.
+- **Docs:** `operations/key-loss-incident.md`, `reference/cli/security.md`,
+  `operations/recover-legacy-envelope.md`, `guides/db-migration-status.md`,
+  `guides/monitoring-history.md`.

--- a/docs/audit/documentation-batch-defects/I03-secret-redaction-mongo-tls.md
+++ b/docs/audit/documentation-batch-defects/I03-secret-redaction-mongo-tls.md
@@ -1,0 +1,81 @@
+# PRD I03 — Secret redaction + MongoDB TLS wiring
+
+**Severity:** High (credential disclosure; a security control that is configured but never applied)
+**Status:** Open
+**Issues:** #156, #189
+**Area:** `internal/adapters/dump/mongo/`, `internal/adapters/restore/mongo/`, `internal/cli/backup.go`,
+`internal/config/validator.go`
+
+## Problem
+
+Two independent security defects sharing one shape: the control was implemented on the dump-side
+happy path and never extended to the error paths or to the restore side.
+
+### #156 — MongoDB URI with password printed unredacted
+
+`internal/adapters/dump/mongo/mongo_dump.go:105` interpolates a raw `mongodb://` URI into an error
+string via its own `strings.Join(args, ...)`. Nine lines earlier, at line 96, the same file calls
+`sanitize.RedactStderr` correctly. The pattern is right there.
+
+`internal/adapters/restore/mongo/mongo_restore.go:163` has **no `sanitize` import at all** and
+interpolates `ra.URI` directly.
+
+Third path, lower severity, confirmed: `internal/adapters/restore/mongo/oplog_replay.go:52` embeds
+raw `mongorestore` stderr with no `RedactStderr` call.
+
+### #189 — MongoDB TLS configuration is never applied
+
+`internal/adapters/dump/mongo/args_builder.go:20` declares `DumpMongoArgs.TLS`. **Nothing sets it.**
+Both construction sites were checked — `internal/cli/backup.go:225` and
+`internal/adapters/dump/mongo/args_factory.go`'s `ArgsFactory.BuildDumpArgs` — and both omit the
+field.
+
+`internal/adapters/restore/mongo/args_builder.go:12`'s `PrepareTLS` has **zero callers repo-wide**;
+`grep -rn "PrepareTLS(" . --include=*.go` returns only its own definition.
+
+And the part that makes it worse: `internal/config/validator.go:113-129` warns only when
+`job.TLS == nil`. **Configuring TLS suppresses the warning that would tell you TLS is not being
+applied.** A user who does the right thing gets less signal than one who does nothing.
+
+## Root cause
+
+Pattern **D**: wired on one axis, forgotten on the other. Dump got redaction, restore did not. The
+TLS struct field was declared alongside the other engines' and never threaded from config through
+the args factory.
+
+## Fix
+
+1. `mongo_dump.go:105` — wrap args in `sanitize.RedactArgs` before joining.
+2. `mongo_restore.go:163` — run `ra.URI` through `sanitize` before interpolating.
+3. `oplog_replay.go:52` — add `sanitize.RedactStderr`.
+4. Thread `job.TLS` through `ArgsFactory.BuildDumpArgs` and `backup.go`'s CLI path into
+   `DumpMongoArgs.TLS`.
+5. Call `PrepareTLS` on the restore path.
+6. `validator.go:113-129` — until the wiring lands, the validator must warn **"tls configured but
+   not applied"** rather than falling silent on presence. After the wiring lands, the warning
+   reverts to the `nil` case.
+
+Item 6 ships **first and separately** if items 4–5 take longer than a release: a user configuring
+Mongo TLS today believes they have transport encryption and does not.
+
+## Cross-reference
+
+`internal/adapters/restore/mongo/args_builder.go` retains a documented cross-axis import of
+`internal/adapters/dump/mongo` for `PrepareMongoTLS` (CLAUDE.md, "Import-cycle rule"). Wiring #189
+touches that boundary — verify `make lint` still passes the `adapter-restore-axis` depguard group.
+
+## Definition of done
+
+- **Code:** the six fixes above.
+- **e2e:**
+  - Trigger a Mongo dump and a Mongo restore connect failure against a URI carrying credentials;
+    assert the error string does not contain the password substring. No live DB needed — a bad host
+    is enough to reach the error path.
+  - Assert the validator still emits a warning when `tls:` is present but unwired.
+  - **NEEDS_LIVE** for "the connection is actually TLS": requires a TLS-enabled `mongod`. The
+    warning half and the redaction half are provable without one.
+- **Docs:** `website/docs/tutorials/mongodb/restore.md`, `website/docs/tutorials/mongodb/index.md`.
+  #189 has no doc pages today — **add one**: the MongoDB TLS section currently describes a control
+  that does not exist.
+- **Security review:** run `/security-review` on the diff. The `crypto-reviewer` agent covers
+  `internal/sanitize/` and credential-interpolating arg builders.

--- a/docs/audit/documentation-batch-defects/I04-backup-locking.md
+++ b/docs/audit/documentation-batch-defects/I04-backup-locking.md
@@ -1,0 +1,112 @@
+# PRD I04 — Backup file locking, lock plumbing and job timeouts
+
+**Severity:** High (concurrent backups corrupt each other; a live job can be marked dead)
+**Status:** Open
+**Issues:** #163, #142, #154, #194, #195, #196, #197
+**Area:** `internal/cli/{backup_factory,schedule,repair}.go`, `internal/adapters/lock/`,
+`internal/scheduler/`, `internal/config/loader.go`, `internal/adapters/monitor/`
+**Blocks:** the reasoning in I05 and I10 about what "a job is running" means
+
+## Problem
+
+Two independent root causes, tangled.
+
+**(a) Backups take no file lock at all.** `internal/cli/backup_factory.go:178` wires `nil` for
+`ports.LockManager`. The domain Executor is ready for it — `internal/domain/backup/executor.go:87-100`
+acquires and releases when `e.locks != nil` — it is simply never given one. And the helpers written
+for this purpose, `RunWithLock` / `RunWithTimeout` in `internal/scheduler/lock_integration.go`, have
+**zero callers anywhere, tests included**.
+
+This is load-bearing: every downstream component that reasons "a lock file means the job is live, no
+lock file means it is safe to reconcile" is wrong for the backup axis.
+
+**(b) The lock primitives and their consumers each reimplement a different partial safety check**,
+and three config keys that would tune them never reach the code.
+
+## Confirmed defects
+
+| # | Defect | Cause |
+|---|---|---|
+| #163 | Backups take no lock | `backup_factory.go:178` passes `nil`; `RunWithLock`/`RunWithTimeout` have zero callers |
+| #142 | `scheduler.lock_dir` never reaches the scheduler, so the stale-lock scan never runs | `scheduler.go:56` `SetLockDir` has zero non-test callers; `schedule start` never calls it. `scheduler.go:69` uses the unconfigured `s.lockDir` with a hardcoded `defaultStaleLockThreshold` (60m, line 13) |
+| #154 | `lock_dir` defaults to `/var/run/sentinel`, which non-root restores cannot create | `loader.go:20` `defaultLockDir`, applied at 84-85 → `restore.go:384` → `runtime/executor.go:143` `lock.NewManager` → `lock.go:68` `os.MkdirAll` on first acquire |
+| #194 | `job_timeout_minutes` is never read | `types.go:45` set and defaulted to 180 at `loader.go:78-79`, no read site anywhere; `RunWithTimeout` (`lock_integration.go:60`) has zero callers |
+| #195 | Starting the scheduler marks in-flight backups as interrupted | `monitor/init.go:101-127` `ReconcileStaleExecutions` has no age guard and no liveness check; `queries.go:296-321` `GetStaleRunningExecutions` has no age filter. Called at `schedule.go:56` |
+| #196 | A restore can steal a live lock held by another host | `lock/state.go:30-47` `EvaluateLockState` ignores `jl.Hostname` entirely — it checks only PID liveness. Hostname is checked only in the separate `ScanStale` path (`lock.go:319-327`), not in `TryAcquire` |
+| #197 | `repair` cannot see or safely clear several classes of lock — 5 sub-defects, all verified | see below |
+
+### #197 sub-defects
+
+1. `repair.go:517` `ListLockFiles()` walks the **entire** lock dir; the loop never filters by
+   `jobFilter`, and the batch `ScanStale` at line 561 removes across all jobs. **`--job X` does not
+   scope it.**
+2. `repair.go:543-546` — `state.Removable` requires `age > staleThreshold`, so a **dead-PID but
+   young** lock is `continue`d with no finding at all.
+3. `repair.go:540-542` — foreign-host locks are `continue`d **silently**. The sibling
+   `reconcileStaleRunning` at 468-469 *does* emit "skipped (foreign-host lock)" for the
+   execution-row class, so the gap is specific to the lock-file class.
+4. `monitor/migrate.go:62-63` builds its lock manager from `filepath.Dir(dbPath)`, while
+   `repair.go:159` scans `cfg.Scheduler.LockDir`. **`migrate.lock` is structurally outside repair's
+   scan root** — no configuration can bring it in.
+5. Both `ScanStale` (`lock.go:315-318`) and `reconcileStaleLocks` (`repair.go:536-538`) treat a
+   `ReadLock` parse error or empty file as `continue`: no finding, no removal.
+
+## Correction to the issue text
+
+**#195 is PARTIAL.** The symptom is real, but the claim that "`repair --fix` carries the same
+hazard" is **false**. `repair.go:437-509` does not call `ReconcileStaleExecutions` at all — it has
+its own lock-aware `reconcileStaleRunning` / `classifyStaleRunning` that checks `lm.ReadLock` +
+`EvaluateLockState` + hostname and skips live and foreign-host locks.
+
+The fix is therefore **not** "correct both paths". It is: make `schedule start` use the logic repair
+already has. Changing repair would damage working code.
+
+Note the ordering constraint this creates: while #163 stands, even the lock-aware check sees
+`jl == nil` for a live backup and finalises it anyway. **#163 must land first or #195's fix is
+inert.**
+
+## Extra findings
+
+- `internal/domain/restore/executor.go:98` hardcodes `time.Hour` as the stale threshold instead of
+  reading `cfg.Scheduler.StaleLockThreshold` — that key reaches only `repair.go:960`.
+- `restore run --all` reads top-level `MaxConcurrentRestores` (`restore.go:420-421`) while the
+  scheduler reads `cfg.Scheduler.MaxConcurrentRestores` (`schedule.go:93`). Two different keys for
+  one concept. Same shape as #141 in I12.
+
+## Fix — strict order
+
+1. **#163** — wire a real `lock.Manager` into `backup_factory.go`. Everything else assumes it.
+2. **#142, #154** — call `SetLockDir(cfg.Scheduler.LockDir)` in `schedule start`; change the default
+   to a user-writable location, or fall back when `MkdirAll` fails.
+3. **#196** — make `EvaluateLockState` (or its `TryAcquire` caller) treat any lock with a foreign
+   hostname as live regardless of age; thread `StaleLockThreshold` into the restore executor in
+   place of the literal `time.Hour`.
+4. **#195** — point `schedule start` at repair's lock-aware reconciliation.
+5. **#197** — scope the file loop by `jobFilter`; emit findings for dead-PID-but-young, foreign-host
+   and parse-error locks; bring `migrate.lock` into repair's scan root.
+6. **#194** — wrap each scheduled job execution in `RunWithTimeout` (or `ctx.WithTimeout`) using the
+   configured value, in `internal/scheduler/executor.go`.
+
+## DECISION REQUIRED
+
+**#154's new default.** `/var/run/sentinel` is correct for a root-run daemon and wrong for everyone
+else. Options: XDG state dir, alongside `history_db_path`, or keep `/var/run/sentinel` and fall back
+on `MkdirAll` failure. This changes where locks live for existing installs — a fallback is the
+safest, a new default is the cleanest. Product call.
+
+## Definition of done
+
+- **Code:** the six fixes in order.
+- **e2e** (uses `assert_blocks_when_concurrent` from I00):
+  - Two `backup run` for the same job concurrently — the second blocks or is skipped with a lock
+    signal, not silent interleaving.
+  - Non-root `restore` with no `lock_dir` override — no "permission denied". **NEEDS_LIVE.**
+  - A lock file with a foreign hostname and age > threshold — `TryAcquire` rejects it.
+  - A long-running backup, scheduler restarted mid-run — the history row stays `running`, not
+    `interrupted`. **NEEDS_LIVE.**
+  - `repair --job A --fix` with stale locks for A and B — only A's is removed.
+  - `repair` with a foreign-host lock — a **reported** finding, not silence.
+  - A job whose dump hangs past `job_timeout_minutes` — killed and marked failed. **NEEDS_LIVE.**
+- **Docs:** `operations/stale-lock-recovery.md`, `operations/state-repair.md`,
+  `operations/scheduler-crash-recovery.md`, `operations/index.md`, `concepts/locking.md`,
+  `guides/index.md`, `reference/glossary.md`.

--- a/docs/audit/documentation-batch-defects/I05-retention-correctness.md
+++ b/docs/audit/documentation-batch-defects/I05-retention-correctness.md
@@ -1,0 +1,101 @@
+# PRD I05 — Retention correctness
+
+**Severity:** High (a safety switch that does not switch; deletions reported that never happened)
+**Status:** Open
+**Issues:** #157, #158, #159, #169, #182, #170.6, #170.7
+**Area:** `internal/domain/retention/policy.go`, `internal/cli/{retention_cleaner,retention_helpers,backup,backup_factory}.go`,
+`internal/adapters/storage/gcs/backend.go`, `internal/config/loader.go`
+**Blocked by:** I01 (#168 — while `retention apply` exits 0 on error, none of these are observable)
+
+## Problem
+
+Retention is the subsystem where a defect costs data. Two independent families here: **reporting
+honesty** (the sweep does not do what the config says, and says nothing) and **data shape** (the
+rules and the deletions are wrong).
+
+Read this PRD whole before touching any of it. Five of the seven share `retention_cleaner.go` or
+`retention_helpers.go`.
+
+## Confirmed defects
+
+| # | Verdict | Defect | Cause |
+|---|---|---|---|
+| #157 | **PARTIAL** | `retention.dry_run: true` in YAML is ignored; backups are deleted for real | `internal/cli/backup.go:617` calls `applyJobRetention(..., job.Name, false)` — `dryRun` hardcoded `false` |
+| #158 | CONFIRMED | `keep_last` and `keep_days` intersect rather than union | `domain/retention/policy.go:38-49` — `flatDeleteReason` merges both exceeded-conditions into one delete-set, so a record must satisfy **both** rules to survive |
+| #159 | CONFIRMED | Retention deletes the artifact and orphans its sidecars | `retention_cleaner.go:29-145` calls only `backend.Delete(ctx, cand.FilePath)`. `grep "manifest\|.binlogs\|.oplog"` in that file → 0 matches |
+| #169 | CONFIRMED | Retention deletion is unimplemented for `google-drive`, and `preview` never warns | `retention_cleaner.go:142-144` default case errors on "google-drive"; `backup_factory.go:118`'s dry-run branch returns **before** reaching that check. No validation-time rejection either |
+| #182 | CONFIRMED | GCS retention reports deletions that never happened | double object-path processing — see below |
+| #170.6 | CONFIRMED | `preview` and `apply` print identical wording | `retention_helpers.go:98` shares `"total deleted: %d backups"`. **Owned by I01** — same file and same PR as #168; listed here for context only |
+| #170.7 | CONFIRMED | A `dry_run`-only policy blocks `defaults.retention` inheritance | `loader.go:164` `hasRetention` returns true when `DryRun` is set even with `KeepLast`/`KeepDays`/GFS all zero; `retentionEnabled()` (`retention_helpers.go:49-57`) then ignores `DryRun`, so the job is skipped entirely by `applyAllRetention` |
+
+### Correction to #157
+
+The issue cites `backup_factory.go:313` as a second site. That line builds `djob.Retention` — and
+**that field is read nowhere in `internal/domain/backup/`**. `executor.go:166` says so in a comment:
+"Retention sweep … stays in the driving adapter". It is a dead field. Fixing the cited line changes
+nothing; the real site is `backup.go:617`.
+
+### #182 in detail — more precise than the issue
+
+The root cause is **the object path being stripped twice**.
+
+1. `retention_cleaner.go:92` `parseBucketObjectRef` already strips `gs://bucket/` and passes the
+   bucket-relative key, e.g. `backups/pg-job/dump.sql.gz` — still containing `/`.
+2. `gcs/backend.go:128-137` `Delete` then runs `extractObjectPath` **again** (`backend.go:319-336`),
+   and for any non-`gs://` string containing `/` it applies `filepath.Base`, flattening the key to
+   `dump.sql.gz`.
+3. That object does not exist. `sdkBucketClient.Delete` (`backend.go:279-285`) swallows
+   `gcsapi.ErrObjectNotExist` and returns `nil`.
+4. The run reports a successful deletion. Nothing was deleted.
+
+Second, compounding: `applyJobRetention` (`backup_factory.go:122-125`) returns on the **first**
+error from `deleteRetentionCandidates`, before calling `rec.RetentionDeleteRecords`. One failing
+candidate skips the history delete for **every** candidate in the run. Backend-agnostic.
+
+## Fix — order matters
+
+1. **#168 (in I01)** must be in first. Until `retention apply` propagates its errors, every other
+   fix here is unverifiable in unattended use.
+2. **#157** — pass `job.Retention.DryRun` (OR'd with any CLI override) into the `backup.go:617` call.
+3. **#170.7** — exclude `DryRun` from `hasRetention`'s "has a policy" test.
+4. **#170.6** — landed by I01 (same file as #168). Verify it before starting item 5.
+5. **#182** — (a) stop re-running `extractObjectPath` on an already bucket-relative key, either by
+   passing the full `gs://` URI or by making `Delete`/`Exists` accept bare keys without
+   basename-flattening; (b) treat `ErrObjectNotExist` as a reportable failure, not success;
+   (c) delete history rows **per successfully-deleted candidate**, not all-or-nothing.
+6. **#159** — derive and delete `<path>.manifest.json`, `.binlogs.tar`, `.oplog.archive` alongside
+   each artifact. Best-effort: a missing sidecar must not fail the run.
+7. **#158** — build separate keep-sets per flat rule and union them. Note `policy.go:58` already
+   *claims* "union of keeps" in a comment; the comment describes the intent, the code does the
+   opposite.
+8. **#169** — implement the gdrive `Delete`, **or** reject retention on gdrive at validation time.
+   Either way, add an explicit preview-time warning.
+
+## DECISION REQUIRED
+
+- **#158 direction.** `apply-retention.md`, `retention-gfs.md` and the README all describe a
+  **union**. Only the code disagrees. Changing the code to union means **existing installs retain
+  more backups than they do today** — storage cost goes up silently on upgrade. The alternative is
+  changing three documents and the README to describe an intersection. Recommendation: change the
+  code (documentation, README and evident intent all agree against it), but flag it in release
+  notes as a behaviour change.
+- **#169 direction.** Implement gdrive deletion, or reject the combination at config load. Rejecting
+  is honest and cheap; implementing is what the config already promises.
+
+## Definition of done
+
+- **Code:** the eight fixes above.
+- **e2e:**
+  - `retention.dry_run: true` with history exceeding `keep_last` — **no file deleted** from storage,
+    history row count unchanged.
+  - 10 daily backups, `keep_last=2` + `keep_days=30` — all 10 survive (union), versus 2 today.
+  - A backup with manifest and binlog sidecars deleted by retention — the sidecars are gone too.
+  - `retention preview` on a gdrive job — prints a warning.
+  - A GCS-backed job with a **nested** `outName` path — after `retention apply`, the object is
+    actually absent from the bucket, and with one candidate engineered to fail, only the confirmed
+    deletes lose their history rows. **NEEDS_LIVE** (fake-gcs is in the compose file).
+- **Docs:** `guides/apply-retention.md`, `guides/retention-gfs.md`, `reference/cli/retention.md`,
+  `guides/migrate-storage-backend.md`. #182 has **no** doc page today — add one, or add an
+  admonition to the GCS storage page.
+- **Runbooks:** `docs/runbooks/apply-retention.md` and `retention-gfs.md` are **correct** about the
+  union rule and the code is wrong. Do not "fix" them to match current behaviour.

--- a/docs/audit/documentation-batch-defects/I06-artifact-identity.md
+++ b/docs/audit/documentation-batch-defects/I06-artifact-identity.md
@@ -1,0 +1,96 @@
+# PRD I06 — Artifact identity: output naming, manifest, history
+
+**Severity:** High (backups are unverifiable, and history records `"unknown"` as the artifact path)
+**Status:** Open
+**Issues:** #151, #193, #184.2
+**Area:** `internal/cli/backup_factory.go`, `internal/utils/default.go`,
+`internal/domain/backup/{executor,pipeline}.go`, `internal/adapters/storage/local/backend.go`
+**Blocks:** I07 (the Mongo artifact fix reuses whatever hashing/identity primitive lands here)
+
+## Problem
+
+There is no single answer to "what file did this backup produce?". The dump builder resolves one
+name, the domain Job carries another (often empty), the manifest writer sees the empty one, and the
+storage `Status` counts the artifact twice.
+
+## Confirmed defects
+
+### #151 — no manifest is written unless the job sets `output:`
+
+**The issue's title describes the symptom, not the cause.** The cause is staleness:
+
+`internal/cli/backup_factory.go:320` sets `djob.OutName = storageParams.OutName` **before**
+`e.dumps.Build()` (`executor.go:115`) resolves the real filename via `FinalOutName`/`setOutName`.
+That resolution lands on the dump builder's own `*storage.Params` and **never propagates back to the
+domain Job**. With `output:` unset, `job.OutName` stays `""` for the whole `Run()`.
+
+Downstream: `ApplyArtifactSecurity` (`pipeline.go:116-119`) short-circuits to `(nil, nil, nil)`
+because `LocalArtifactInfo(..., job.OutName="")` returns `""`.
+
+**Extra defect, not in the issue:** `res.ArtifactPath` at `executor.go:159` resolves to `"unknown"`
+for the same reason. **The execution history is broken, not just the manifest.**
+
+Scheduled runs are unaffected — the scheduler fills a name in first. This is a CLI-path defect.
+
+### #193 — an explicit `output:` makes every backup overwrite the previous one
+
+`internal/utils/default.go:21-29` `FinalOutName` returns `outName` verbatim whenever it has an
+extension. `output: shop.sql` resolves to the same literal name on every run. No interpolation logic
+exists anywhere in the call chain — `dump/{pg,mysql,mariadb}/*_dump*.go` all call it verbatim.
+
+So `output:` is required for integrity (per #151) and destroys history when set. There is no
+configuration that gets both.
+
+### #184.2 — `backup_count` doubles
+
+`internal/adapters/storage/local/backend.go:52-70` `List` walks every file with no suffix filter;
+`Status:82-102` sets `BackupCount: len(objects)`. Each backup contributes its artifact **and** its
+`.manifest.json` sidecar. The same `List → Status` shape exists in s3/gcs/gdrive/azure — verify each.
+
+## The pairing — read before implementing
+
+**Fixing #193 alone does not fix #151.** They are different code paths.
+
+- #151's cause is `Job.OutName` staleness. Manifests are missing **even when `output:` is unset**,
+  regardless of any naming policy.
+- #193's cause is `FinalOutName`'s literal passthrough. An explicit fixed name collides every run.
+
+Correct contract, in this order:
+
+1. **The domain Job must always carry the real resolved artifact name at manifest-write time.**
+   Resolve the final output name once before constructing the Job, or refresh `job.OutName` from the
+   build result immediately after `Build()` and before `ApplyArtifactSecurity` runs. Structural —
+   do this first.
+2. **An explicit `output:` must still vary per run**, via timestamp or backup-ID interpolation, so
+   it never collides. Layered on top of (1).
+
+## Fix
+
+1. `backup_factory.go` / `executor.go` — resolve and propagate the real output name (#151).
+2. `utils/default.go` — give `FinalOutName` a template mode; document the placeholders in
+   `config/types.go` (#193).
+3. `storage/local/backend.go` — exclude `*.manifest.json` from `List`, or count only non-manifest
+   objects in `Status`. Check and fix the same pattern in s3/gcs/gdrive/azure (#184.2).
+
+## DECISION REQUIRED
+
+**#193's naming scheme.** Interpolating into an explicit `output:` changes the filenames every
+existing install produces. Options: (a) always interpolate, (b) interpolate only when the value
+contains a placeholder token, (c) keep literal names and require uniqueness at validation time.
+Option (b) is backward-compatible and explicit; (a) is what the issue asks for. Product call.
+
+## Definition of done
+
+- **Code:** the three fixes, in the stated order.
+- **e2e:**
+  - A job with **no** `output:` against local storage, then `backup verify <id>` — exit 0, not
+    `missing_manifest`, and `ArtifactPath != "unknown"`.
+  - One job run twice with `output: shop.sql` — two distinct stored artifacts, two distinct manifest
+    hashes, two history rows. Not one truncated file.
+  - `Status()` after one backup — `BackupCount == 1` with the artifact and its `.manifest.json`
+    both present.
+- **Docs:** `operations/troubleshooting.md`, `operations/failed-backup-triage.md`,
+  `operations/chain-corruption-recovery.md`, `guides/integrity-sweep.md`,
+  `guides/verify-backup-integrity.md`, `concepts/manifest.md`, `reference/glossary.md` — all cite
+  #151 with the correct root cause and note scheduled runs are unaffected. #193 has no doc page;
+  add one if the naming behaviour changes.

--- a/docs/audit/documentation-batch-defects/I07-dump-streaming.md
+++ b/docs/audit/documentation-batch-defects/I07-dump-streaming.md
@@ -1,0 +1,72 @@
+# PRD I07 — Dump streaming + MongoDB local artifact
+
+**Severity:** High (peak memory scales with database size; Mongo local backups are unverifiable)
+**Status:** Open
+**Issues:** #164 (PARTIAL), #191
+**Area:** `internal/adapters/dump/{pg,mysql,mariadb,mongo}/`, `internal/adapters/storage/writer.go`,
+`internal/domain/backup/pipeline.go`
+**Blocked by:** I06 (the Mongo fix reuses the artifact-identity/hashing primitive that lands there)
+
+## Problem
+
+### #164 — PARTIAL: three engines buffer the whole dump, not four
+
+`internal/adapters/dump/pg/pg_dump.go:55-56`, `mysql_dump.go:46-47` and `mariadb_dump.go:48-49` all
+set `cmd.Stdout = &bytes.Buffer` and then do `sum := sha256.Sum256(stdOut.Bytes())` /
+`WriteBackup(stdOut.Bytes(), ...)`. Peak RSS scales with dump size.
+
+**The issue says "every dump adapter". That is wrong for MongoDB.** `mongodump` streams straight to
+disk via `--archive` / `--out`; its stdout buffer captures log text only. Mongo's real defect is
+#191, below, and it is different in kind.
+
+### #191 — a default local MongoDB backup is a directory recorded as an empty artifact
+
+`internal/adapters/dump/mongo/mongo_dump.go:130-134` hashes `stdOut.Bytes()` — **mongodump's log
+output**, not the dump — and writes that via `WriteBackup`. The actual dump went to a directory via
+`--out=` (`args_builder.go:67`).
+
+Downstream both layers agree to do nothing about it:
+- `internal/domain/backup/pipeline.go:39-40` `LocalArtifactInfo` explicitly `return path, 0` when
+  `info.IsDir()`.
+- `internal/adapters/storage/local/local.go` `WriteData` special-cases directories and no-ops.
+
+Result: the backup succeeds, the recorded artifact is empty, and the hash is computed over log text.
+It cannot be verified and it cannot be restored from the recorded path.
+
+The remote path already does the right thing — it wraps the dump in a single archive.
+
+**Not verified:** the issue's secondary claim that the oplog is deleted before upload looks
+plausible from the staging/cleanup code but was not traced end to end. Treat as unconfirmed.
+
+## Fix
+
+1. **#164** — stream `cmd.Stdout` through an `io.Pipe` / `HashingWriter` into the `writer.go`
+   storage sink instead of buffering. `internal/adapters/crypto.HashingWriter` already exists and is
+   what the manifest store uses.
+2. **#191** — for local Mongo, wrap the dump in a single archive (`--archive=`) as the remote path
+   already does, then hash and size **that file**. Reuse the streaming primitive from (1).
+3. Consider making `LocalArtifactInfo`'s directory branch an **error** rather than a silent
+   `return path, 0`. It is the layer that turned a broken artifact into a successful backup.
+
+Order: #164 first — #191's fix should reuse whatever hashing/streaming primitive it introduces
+rather than inventing a second one.
+
+## Cross-reference
+
+I06 must land first. #191's "hash the real artifact" fix depends on the domain Job carrying the real
+resolved artifact name, which is exactly what #151 fixes.
+
+## Definition of done
+
+- **Code:** the three items above.
+- **e2e:**
+  - A local MongoDB backup job — either `sentinel backup verify` fails **loudly** (not silently
+    passes), or the artifact is a single restorable file with a real hash. The latter is the goal.
+  - A restore from that local Mongo artifact round-trips the data.
+  - A multi-hundred-MB dump — peak `sentinel` RSS stays roughly flat against dump size.
+    **NEEDS_LIVE** for real proof; the buffering itself is confirmed statically.
+- **Docs:** #191 has no doc page today. The MongoDB tutorial and `concepts/storage-backends.md`
+  describe local Mongo backups as working — add an admonition now and remove it with the fix.
+  #164's `grep` hits (recover-legacy-envelope.md, operations/index.md, key-loss-incident.md,
+  failed-backup-triage.md, security-encryption.md) are about `--allow-legacy-envelope`, a **different
+  matter** that happens to share the number in prose. Do not edit them for this PRD.

--- a/docs/audit/documentation-batch-defects/I08-compression-validation-order.md
+++ b/docs/audit/documentation-batch-defects/I08-compression-validation-order.md
@@ -1,0 +1,79 @@
+# PRD I08 — Compression wiring + validation ordering
+
+**Severity:** Medium (a flag that does nothing; a guard that fires on a valid config)
+**Status:** Open
+**Issues:** #183, #188
+**Area:** `internal/cli/backup.go`, `internal/adapters/dump/{mysql,mariadb}/`,
+`internal/config/{loader,validator}.go`, `internal/cli/config_resolver.go`
+
+## Problem
+
+### #183 — `backup --compress` is a no-op on MySQL and MariaDB
+
+`buildSingleDump`'s `mysql` / `mariadb` branches in `internal/cli/backup.go` (~393-400) never read
+`cmd.Flags().Changed("compress")`. The `pg` and `mongo` branches do. `MySqlDumpArgs` and
+`MariaDBDumpArgs` have **no `Compress` field at all** —
+`grep -n "Compress" internal/adapters/dump/{mysql,mariadb}/*.go` returns zero matches.
+
+### The deeper finding — validation runs before CLI overrides
+
+`internal/cli/config_resolver.go:53` calls `config.ValidateConfig` inside `LoadAndValidateConfig`.
+That runs **before** `applyCLIOverrides` (`backup.go:657`), which is where the flag sets
+`job.DatabaseOptions["compress"]`.
+
+The double-compress guard at `validator.go:563` therefore validates a config that has not yet
+received its CLI overrides. **This is wider than compression: every CLI override escapes
+validation.** It is the reason #183's second half (bypassing the guard) happens, and it is worth
+fixing as its own item.
+
+### #188 — `defaults.compression` inherits into engines that compress natively
+
+`internal/config/loader.go:103-105`:
+
+```go
+if job.Compression == nil && cfg.Defaults.Compression != nil { job.Compression = &inherited }
+```
+
+Unconditional. Nothing exempts jobs that already have engine-native compression configured
+(`pg_compression_algo`, mongo `compress`, `gzip`). Then `validator.go:563-564` sees
+`hasNativeCompression` **and** `job.Compression.Enabled` both true and hard-errors. The user never
+wrote a conflicting config — the defaults block created one.
+
+## Secondary findings
+
+Both inspected and confirmed in shape, not deep-dived:
+
+- pg's `--compress=algo:level` (`args_builder.go:90-126`) is appended with no `pg_out_format` gate.
+- restore's `restore_options.gzip` is manual-only for native mongo gzip, whereas pipeline
+  compression is auto-reversed. Asymmetric.
+
+## Fix
+
+1. **#188 first.** Skip inheritance (or auto-disable it) when `hasNativeCompression(job)` is true.
+   This gives one coherent "does this job already compress natively?" check.
+2. **#183** — wire compress into the MySQL/MariaDB dump args, **or** reject the flag for those
+   engines with a clear error. Silently accepting it is the current behaviour and the worst option.
+3. **Validation ordering** — re-validate after `applyCLIOverrides`, or move override application
+   ahead of validation. Scope this deliberately: it will surface other configs that were passing
+   validation only because their overrides were invisible to it.
+
+## DECISION REQUIRED
+
+**#183 direction.** Implement compression for MySQL/MariaDB (they support `--compress` for the
+client-server protocol, which is **not** the same as compressing the dump output — check which the
+flag is meant to mean before implementing), or reject the flag for those engines. The two produce
+very different artifacts.
+
+**Validation ordering blast radius.** Fixing item 3 may cause configs that load today to start
+failing. That is correct behaviour but it is a breaking change. Confirm the release it lands in.
+
+## Definition of done
+
+- **Code:** the three fixes.
+- **e2e:**
+  - `backup -t mysql --compress` — the artifact has gzip magic bytes, or the command is rejected
+    with a clear message. Whichever the decision above picks, assert it.
+  - `defaults.compression.enabled: true` plus a postgres job with `pg_compression_algo: gzip` and no
+    per-job override — loads and validates without the double-compress error.
+  - A CLI override that would fail validation — is now caught at validation time, not at run time.
+- **Docs:** `website/docs/concepts/compression.md` references #183. Update it with the fix.

--- a/docs/audit/documentation-batch-defects/I09-restore-planner.md
+++ b/docs/audit/documentation-batch-defects/I09-restore-planner.md
@@ -1,0 +1,141 @@
+# PRD I09 — Restore planner: PITR, incremental, dry-run, verification
+
+**Severity:** Critical (two features advertised in the README can never succeed)
+**Status:** Open
+**Issues:** #148, #150, #186, #152, #149, #185, #190
+**Area:** `internal/domain/backup/pipeline.go`, `internal/domain/restore/`,
+`internal/adapters/restore/runtime/`, `internal/config/validator.go`, `internal/cli/restore.go`,
+`internal/adapters/restore/incremental/mysqlbinlog/`
+**Needs:** the real-backup PITR/incremental fixture from I00 item 7
+
+## Problem
+
+This is the highest-stakes cluster. PITR and incremental restore are documented in the README and in
+the tutorials. Neither can complete. The e2e suite grep-matches both words and asserts neither
+(see I00).
+
+## Confirmed defects
+
+### #148 — `restore_mode: pitr` can never be planned
+
+`internal/domain/backup/pipeline.go:226` writes `Capabilities` as a **literal**
+`[]string{"full","incremental"}`. There is one call site, no conditional branch, and no
+recoverable-window fields are set anywhere. `"pitr"` can never appear. `AdvancedRestoreMetadata`
+already has the fields.
+
+### #150 — `restore_mode: incremental` fails staging its baseline
+
+Path double-resolution:
+
+1. `internal/domain/backup/executor.go:268` records
+   `FilePath = filepath.Join(job.LocalPath, outName)` → e.g. `backups/shop.sql`.
+2. `internal/domain/backup/planner.go:98-99` stores that as `BaselineBackupID`.
+3. `runtime/staging.go`'s `listSourceObjects` lists **relative to `source.LocalPath`**, which is
+   already `backups/`, returning `shop.sql`. No match.
+4. The boundary fallback at `internal/domain/restore/source.go:43` compares `filepath.Base(obj.Path)`
+   against the full `backups/shop.sql` id. Also no match. → not found.
+
+And in a flattened layout, `matchesBackupIDBoundary` matches **both** `shop.sql` and
+`shop.sql.manifest.json` against the id `shop` — ambiguous. Two fixes needed, not one.
+
+### #149 — `verify_after_restore: true` always fails, after the data has landed
+
+`grep "VerifyAfterRun:"` across non-test `internal/` returns **zero hits**.
+`runtime/executor.go:239` assigns `djob.VerifyAfterRun` only when `req.VerifyAfterRun != nil`, and no
+CLI or scheduler call site ever sets it.
+
+**Broader than the title:** `internal/domain/restore/executor.go:320-323` sets `requiresVerification`
+for `VerifyAfterRestore == true` **OR** `RestoreMode == "pitr"` **OR** `"incremental"`. So the
+synthetic "verification handler is required" failure hits all three, not just the flag.
+
+### #186 — `restore_mode: incremental` validates for every engine, only postgres can plan it
+
+`internal/config/validator.go:319-326` whitelists postgres/mysql/mariadb/mongodb.
+`internal/domain/restore/planner.go:110-113` `planIncremental` rejects anything but postgres with
+`ReasonCodeUnsupportedDatabaseType`.
+
+**The correct pattern is in the same file**: the `pitr` branch at validator.go ~300 restricts to
+postgres only. Copy it.
+
+### #152 — `restore dry-run` does not invoke the planner
+
+`internal/cli/restore.go:297-321` `handleRestoreDryRun` prints config fields only. No planner call;
+those appear only in the real run path at `restore.go:517`.
+
+**Reproduced live:** `restore dry-run pg_pitr_job` with `restore_mode: pitr` → exit 0, printed
+"Restore Mode: pitr", no planner error — for a job that #148 makes unplannable.
+
+### #185 — every incremental prerequisite check is unreachable or never called
+
+`internal/config/validator.go:346` calls `ValidateMySQLIncrementalPrerequisites(true, ...)` and
+:351 calls `ValidateMongoIncrementalPrerequisites(true)` — `logBinEnabled` and `replicaSetEnabled`
+**hard-coded true**. `ValidateMongoOplogWindowPrerequisite` and
+`ValidatePostgresIncrementalPrerequisites` have zero non-test callers. `.BinlogCheck` is parsed and
+never read.
+
+### #190 — binlog archival matches only `mysql-bin` / `mariadb-bin`
+
+`internal/adapters/restore/incremental/mysqlbinlog/archive.go:105` and `replay.go:195` hard-code
+`strings.HasPrefix(name, "mysql-bin.")` / `"mariadb-bin."`.
+`grep log_bin_basename` across `internal/` returns **zero**. The server is never asked.
+**Stock MySQL 8 uses `binlog`.** A default MySQL 8 install archives nothing, silently.
+
+## Two independent chains
+
+**(a) Manifest-writing gap.** #148 is the root cause of the PITR half of #152's false-clean dry-run.
+
+**(b) Restore-staging gap.** #150 is why incremental restore fails *after* a successful plan.
+Independent of #148.
+
+#186 and #185 are both "config accepts what the runtime rejects" (pattern E). #149 is orthogonal but
+shares the symptom class: a restore misleads *after* real work has already landed on the target.
+#190 is fully separate — no shared code — and ships independently.
+
+## Fix order
+
+1. **#148** — populate `"pitr"` in `Capabilities` and set `RecoverableWindowStartUTC`/`EndUTC` when
+   the engine and config support it. **Or** drop the advertised feature. Not both halves silent.
+2. **#150** — store and resolve the baseline id relative to the same root the restore listing uses,
+   and exclude `*.manifest.json` from candidate matching in `ResolveChainObject`.
+3. **#186** — restrict the validator's incremental whitelist to postgres, matching the pitr branch.
+4. **#152** — have dry-run invoke the same planner path as run and print the plan status and reason
+   code. Do this **after** 1-3, so dry-run starts telling the truth about a system that works.
+5. **#149** — wire a real verification handler in `runtime`, **or** reject `verify_after_restore`
+   (and pitr/incremental modes) at validation time until one exists.
+6. **#185** — probe real server state (`log_bin`, replica-set membership, oplog window) before
+   accepting `incremental_backup` config, or remove the dead keys and functions.
+7. **#190** — query `SHOW VARIABLES LIKE 'log_bin_basename'` (or read the binlog index) instead of
+   guessing. Independent, can land at any point.
+
+## DECISION REQUIRED
+
+- **#148: implement PITR, or withdraw it.** It is in the README, the tutorials and the glossary. If
+  the recoverable-window plumbing is more than this PRD can carry, the honest interim is to reject
+  `restore_mode: pitr` at config load with a clear "not implemented" message and to remove the
+  feature from the README. Silence is the one option that is not acceptable.
+- **#149: implement verification, or reject the flag.** Same shape.
+- **#185: probe, or remove the keys.** `wal_summary_check` and `binlog_check` currently read as
+  supported safety features.
+
+## Definition of done
+
+- **Code:** the seven fixes in order.
+- **e2e** (all need the real-backup fixture from I00 item 7, not `WritePITRManifest`):
+  - Backup a postgres job, then restore with `restore_mode: pitr` inside the recoverable window —
+    `PlanStatusReady`, not `missing_advanced_metadata`.
+  - Full backup → incremental backup → incremental restore of the chain — staging succeeds, no
+    `ErrAmbiguousBackupID` / `ErrSourceObjectNotFound`.
+  - `restore run` with `verify_after_restore: true` against a real DB — succeeds, not the synthetic
+    "verification handler is required" failure. **NEEDS_LIVE.**
+  - A mongodb job with `restore_mode: incremental` — fails at **config validate**, not at run.
+  - `restore dry-run` on a job that cannot be planned — reports the planner's rejection reason,
+    exit non-zero.
+  - MySQL 8 container with stock defaults (`log_bin_basename=binlog`) — an incremental backup
+    archives more than zero binlog files. **NEEDS_LIVE.**
+  - `config validate` against MySQL with `log_bin` OFF and a standalone mongod with
+    `incremental_backup.enabled: true` — validation fails. **NEEDS_LIVE.**
+- **Docs:** `operations/troubleshooting.md`, `operations/chain-corruption-recovery.md`,
+  `concepts/incremental-pitr.md`, `concepts/manifest.md`, `tutorials/index.md`,
+  `tutorials/mongodb/pitr.md`, `reference/glossary.md`, `guides/restore-from-gcs.md`,
+  `guides/index.md`, `guides/parallel-restore.md`. The README's PITR section must match whatever the
+  decision above resolves.

--- a/docs/audit/documentation-batch-defects/I09-restore-planner.md
+++ b/docs/audit/documentation-batch-defects/I09-restore-planner.md
@@ -94,28 +94,37 @@ shares the symptom class: a restore misleads *after* real work has already lande
 ## Fix order
 
 1. **#148** — populate `"pitr"` in `Capabilities` and set `RecoverableWindowStartUTC`/`EndUTC` when
-   the engine and config support it. **Or** drop the advertised feature. Not both halves silent.
+   the engine and config support it. This is the required path; see the resolved decision below.
 2. **#150** — store and resolve the baseline id relative to the same root the restore listing uses,
    and exclude `*.manifest.json` from candidate matching in `ResolveChainObject`.
 3. **#186** — restrict the validator's incremental whitelist to postgres, matching the pitr branch.
 4. **#152** — have dry-run invoke the same planner path as run and print the plan status and reason
    code. Do this **after** 1-3, so dry-run starts telling the truth about a system that works.
-5. **#149** — wire a real verification handler in `runtime`, **or** reject `verify_after_restore`
-   (and pitr/incremental modes) at validation time until one exists.
+5. **#149** — wire a real verification handler in `runtime`. Not optional: #148's acceptance test
+   cannot pass without one.
 6. **#185** — probe real server state (`log_bin`, replica-set membership, oplog window) before
    accepting `incremental_backup` config, or remove the dead keys and functions.
 7. **#190** — query `SHOW VARIABLES LIKE 'log_bin_basename'` (or read the binlog index) instead of
    guessing. Independent, can land at any point.
 
-## DECISION REQUIRED
+## Decisions
 
-- **#148: implement PITR, or withdraw it.** It is in the README, the tutorials and the glossary. If
-  the recoverable-window plumbing is more than this PRD can carry, the honest interim is to reject
-  `restore_mode: pitr` at config load with a clear "not implemented" message and to remove the
-  feature from the README. Silence is the one option that is not acceptable.
-- **#149: implement verification, or reject the flag.** Same shape.
-- **#185: probe, or remove the keys.** `wal_summary_check` and `binlog_check` currently read as
-  supported safety features.
+Two resolved, one still open.
+
+- **#148 — RESOLVED 2026-08-06: implement.** PITR is a required feature and is not to be withdrawn
+  under any circumstance. Withdrawing it, rejecting `restore_mode: pitr` at config load, or removing
+  it from the README are all off the table. `Capabilities` must be populated with `"pitr"` and the
+  recoverable-window fields must be set. If the plumbing outgrows this PRD, it gets its own spec —
+  it does not get descoped.
+- **#149 — RESOLVED by consequence: implement.** This was "implement verification, or reject the
+  flag". The reject option is now unavailable: `internal/domain/restore/executor.go:320-323` sets
+  `requiresVerification` for `RestoreMode == "pitr"` as well as for the flag, so **a working PITR
+  restore cannot exist without a verification handler**. A real handler must be wired in
+  `internal/adapters/restore/runtime/`. Sequence it before or with #148's acceptance test, since
+  that test cannot pass otherwise.
+- **#185 — DECISION REQUIRED: probe, or remove the keys.** `wal_summary_check` and `binlog_check`
+  currently read as supported safety features and perform no check. Pairs with #155 in I12 (the same
+  dead prerequisite functions) — decide both together.
 
 ## Definition of done
 

--- a/docs/audit/documentation-batch-defects/I10-command-state-registration.md
+++ b/docs/audit/documentation-batch-defects/I10-command-state-registration.md
@@ -1,0 +1,106 @@
+# PRD I10 — Restore/schedule command state + registration
+
+**Severity:** High (a disabled restore job actually starts executing)
+**Status:** Open
+**Issues:** #136, #137, #138, #139, #140
+**Area:** `internal/cli/{backup,restore,schedule}.go`, `internal/scheduler/restore_integration.go`
+
+All five reproduced against the reference binary. None need a database.
+
+## Confirmed defects
+
+### #139 — `restore run <job>` executes a disabled job
+
+`internal/cli/restore.go:333-374` `handleRestoreRun` never checks `job.Enabled`.
+`internal/config/restore_types.go:220` `ValidateRestoreJob` does not either. Only
+`handleRestoreRunAll` (~line 440) filters on it.
+
+**Reproduction:** config with `restores.myjob.enabled: false`, then `restore run myjob`. The command
+passed validation, **acquired the lock**, and reached the staging step before stopping on
+`lstat /tmp/nonexistent-backups: no such file or directory`. It had begun executing the disabled
+job; only a fake path stopped it. With a real backup source it would have restored.
+
+The check exists. It is simply not called on the single-job branch.
+
+### #136 — chain commands cannot be invoked at all
+
+`internal/cli/backup.go:84,811,836,891` — `chain-status`, `chain-list` and `force-full` read
+`cmd.Flags().GetString("config")`, but only the parent `BackupCmd` registers `--config`, as a
+**local** flag (backup.go:246). The subcommands register nothing and the parent's flag is not
+persistent.
+
+**Reproduction:** `backup chain-status --config x.yaml` → `Error: unknown flag: --config`, exit 1.
+Bare `chain-status` → `Error: required flag(s) "job" not set`, exit 1. No combination works.
+Confirmed for all three subcommands.
+
+### #140 — `schedule status` cannot see restore jobs
+
+`internal/cli/schedule.go:272-283` registers only `cfg.Databases` before calling `s.JobStatus`.
+`scheduleListCmd` (lines 173-194) registers **all three** families — databases, restores and
+`config.IntegrityCheckJobName`.
+
+**Reproduction:** config with one backup job and one restore job, both scheduled. `schedule list`
+shows both. `schedule status myjob` → `Error: job 'myjob' not found`, exit 1.
+`schedule status dummy-backup` → succeeds, exit 0.
+
+### #137 — `restore enable`, `disable`, `pause`, `resume` are no-ops
+
+`internal/cli/restore.go:283-295` logs and prints, persists nothing.
+`internal/scheduler/restore_integration.go:536-548` `PauseRestoreJob` / `ResumeRestoreJob` log and
+`return nil`, with the comment *"requires extending the Scheduler interface"*. **No state store
+exists anywhere in the package.**
+
+### #138 — `schedule stop` always fails
+
+`internal/cli/schedule.go:146-152` `RunE` returns an error unconditionally. Zero conditional paths,
+no PID file, no signal logic.
+
+## Root causes
+
+**(a) Flag registration** — #136 alone: local vs persistent `--config`.
+
+**(b) Incomplete state wiring between the CLI handlers and the job registry** — #137, #139, #140.
+Pattern **D**: the control exists on one path and not the sibling.
+
+#138 is standalone: a deliberately unimplemented command.
+
+## Fix order
+
+1. **#136** — promote `BackupCmd`'s `--config` to `PersistentFlags()`, or register it on each
+   subcommand. Trivial, and it unblocks chain inspection entirely — which several other PRDs need
+   for debugging.
+2. **#140** — mirror `scheduleListCmd`'s registration loop in `scheduleStatusCmd`. Same file.
+3. **#139** — check `job.Enabled` on the single-job branch, as `--all` already does. One line,
+   safety-critical, small blast radius.
+4. **#137** — needs the decision below.
+5. **#138** — needs the decision below.
+
+## DECISION REQUIRED
+
+**#137 and #138 are product decisions, not bugs to be patched.**
+
+- **#137** — implement persistence (write `enabled` back to config, or a sidecar state file, or
+  extend the Scheduler interface as the code comment anticipates), **or remove the four
+  subcommands**. Printing "enabled" and persisting nothing is the only option that must not survive.
+- **#138** — implement real stop semantics (PID file + signal), **or remove the subcommand**.
+
+Recommendation for both: remove now, reintroduce with a design. A command that lies is worse than an
+absent one, and both have a clear removal path.
+
+## Definition of done
+
+- **Code:** items 1-3, plus whatever items 4-5 resolve to.
+- **e2e:**
+  - `backup chain-status --config <valid.yaml> --job <name>` against a seeded history DB — exit 0
+    with the expected chain output.
+  - A restore job with `enabled: false` **and a valid local backup source** — `restore run <job>`
+    refuses with a clear error and a non-zero exit. It must not acquire the lock.
+  - `schedule status <restore-job>` and `schedule status __integrity_check` — both succeed with
+    correct fields.
+  - If #137/#138 are implemented: state survives a process restart. If removed: the subcommand is
+    gone and `--help` does not advertise it.
+- **Docs:** `operations/troubleshooting.md`, `operations/failed-backup-triage.md`,
+  `operations/chain-corruption-recovery.md` (all cite #136);
+  `guides/restore-from-gcs.md`, `guides/parallel-restore.md` (#137, #139);
+  `operations/scheduler-crash-recovery.md`, `guides/index.md` (#138).
+  #140 has no doc page — the `schedule status` reference page currently implies it covers all jobs.

--- a/docs/audit/documentation-batch-defects/I11-storage-schema-drift.md
+++ b/docs/audit/documentation-batch-defects/I11-storage-schema-drift.md
@@ -1,0 +1,124 @@
+# PRD I11 — Storage backends + config schema drift
+
+**Severity:** Medium (Azure reported unreachable when it works; verify can cross backends)
+**Status:** Open
+**Issues:** #161, #184.1, #184.3, #184.4, #145, #144
+**Area:** `internal/cli/{storage_cmd,backup_verify}.go`, `internal/config/{types,loader}.go`,
+`internal/adapters/restore/runtime/staging.go`, `internal/adapters/storage/`
+
+All settled statically. No live infrastructure was needed to confirm any of them.
+
+## Confirmed defects
+
+### #161 — `storage status` reports every Azure named storage as unreachable
+
+`internal/cli/storage_cmd.go:137-141` builds an `azure.Config{AccountName, Container}` by hand —
+**no `Auth`** — then calls `azure.NewAzureBlobBackend`, which dispatches on `cfg.Auth.Type`
+(`azure/auth.go:15-54`). The empty `Type` falls through to the default and errors
+`unsupported auth type ""` (auth.go:54).
+
+The backup path does it correctly: `registry.go:122` calls
+`NewBlobBackendFromKey(account, container, key)`. **Two constructors, one wired right.**
+
+### #184.1 — `storage status` row order is nondeterministic
+
+`storage_cmd.go:56` ranges over `cfg.Storages` (a Go map) with no sort anywhere in the file.
+
+### #184.2 — see I06
+
+Counted there, with the manifest sidecar work.
+
+### #184.3 — `defaults.storage` overwrites a partial job storage
+
+`internal/config/loader.go:97-99`:
+
+```go
+if job.Storage.Name=="" && job.Storage.Type=="" && cfg.Defaults.Storage.Type!="" {
+    job.Storage = cfg.Defaults.Storage
+}
+```
+
+Whole-struct assignment, not a field merge. A job that sets only `storage.local_path` loses it.
+
+**The correct implementation already exists in the same file**: `resolveNamedStorages`
+(loader.go:591-598) field-merges via `overlayStorage`. The defaults path just never calls it.
+
+### #184.4 — `backup verify` combines the recorded backend type with current credentials
+
+`internal/cli/backup_verify.go:198-211` dispatches on `exec.StorageBackend` — the type **recorded at
+backup time** — but fetches connection parameters from `cfg.Databases[exec.BackupName].Storage`, the
+**current** config. `verifyBackendParamsAndObject` (591-643) switches again on the recorded type
+using current credentials.
+
+Change a job's `storage.type` from s3 to gcs and verify will apply GCS credentials against an
+S3-recorded reference. Not in the issue title; the most dangerous item here.
+
+### #145 — `backup_source` accepts only local, s3 and gcs
+
+`runtime/staging.go:233-251` (`listSourceObjects`) and :268-289 (`downloadSourceObject`) switch on
+`source.Type` with cases for `local`/`s3`/`gcs` only; default returns
+`ErrUnsupportedRestoreSource`. Meanwhile `config/restore_types.go:150-158` defines
+`GDriveFolderID`, `GDriveSAFile`, `AzureStorageAccount`, `AzureContainer` on `RestoreBackupSource`,
+and **no validator rejects those types**. The registry already has both backends.
+
+### #144 — `AzureConfig` and `AzureAuthConfig` are unreachable
+
+`config/types.go:178-191` defines both (with an `auth:` sub-block and `tier`). **No field of
+`Configuration` (types.go:194-244) or any nested struct has that type.**
+`grep -rn "AzureConfig\b" --include=*.go .` excluding tests finds only the declaration itself,
+a doc comment in `azure/config.go`, and `validator.go:481` — which does not use the struct, it calls
+`ValidateAzureConfig` with primitive strings.
+
+The reachable Azure schema is the flat `azure_storage_account` / `_key` / `_container` on
+`StorageConfig` (types.go:419-423). Also: `backup --help`'s advertised storage types disagree with
+`storage.ValidateStorageType`, which does accept `azure`.
+
+## Root causes
+
+**(A)** `storage_cmd.go` and the `--help` text were hand-rolled independently of
+`internal/adapters/storage/registry.go` and have drifted from it — #161, #184.1, #184.2, and #144's
+help/validator mismatch.
+
+**(B)** Config schema drift — the YAML advertises fields the runtime never implements (#145) while
+carrying an orphaned dead duplicate of the real schema (#144).
+
+#184.3 and #184.4 are independent of both: separate `loader.go` and `backup_verify.go` bugs.
+
+## Fix order
+
+1. **#144** — delete the dead `AzureConfig`/`AzureAuthConfig` structs; reconcile `backup --help` with
+   `ValidateStorageType`. Cheap, and it clears the Azure story before touching #161.
+2. **#161** — have `storage_cmd.go`'s azure case call `azure.NewBlobBackendFromKey` like
+   `registry.go` does, instead of hand-building a `Config`. Small diff.
+3. **#184.1** — sort entries by name before printing or encoding. Same file as #161, do together.
+4. **#145** — implement the gdrive/azure cases in `staging.go` mirroring s3/gcs, **or** reject those
+   `source.Type` values at config validation. See the decision below.
+5. **#184.3** — replace the whole-struct overwrite with `overlayStorage` semantics.
+6. **#184.4** — persist the full backend params at backup time, **or** refuse/downgrade verify when
+   the current `storage.type` no longer matches `exec.StorageBackend`.
+
+## DECISION REQUIRED
+
+- **#145** — implement gdrive/azure as restore sources, or reject them at validation. The config
+  struct already advertises the fields, so rejecting means removing them. Note this pairs with
+  **#169** in I05: gdrive is half-implemented on both the retention and restore axes.
+- **#184.4** — persisting backend params at backup time is the correct fix but changes the history
+  schema (a migration). Refusing on mismatch is cheap and safe. Pick one.
+
+## Definition of done
+
+- **Code:** the six fixes.
+- **e2e:**
+  - `storage status` against Azurite configured with `azure_storage_key` — `reachable: true` and a
+    correct `backup_count`.
+  - `storage status --output json` run twice against ≥3 named storages — identical key order.
+  - A job setting only `storage.local_path` with `defaults.storage.type` present — the load retains
+    `local_path` merged with the default type.
+  - A restore job with `backup_source.type: azure` — either it works, or it is rejected at config
+    validation. Not `ErrUnsupportedRestoreSource` at run time.
+  - Backup on s3, change the job's `storage.type` to gcs, `backup verify <id>` — does not silently
+    apply GCS credentials against the S3-recorded reference.
+  - `go vet` / dead-code check passes after the #144 deletions.
+- **Docs:** `reference/cli/storage.md`, `guides/check-storage-backend.md`,
+  `guides/migrate-storage-backend.md`, `concepts/storage-backends.md`. **#184 is not indexed in
+  `website/docs/` at all** — add a pointer once it lands.

--- a/docs/audit/documentation-batch-defects/I12-dead-config-notification.md
+++ b/docs/audit/documentation-batch-defects/I12-dead-config-notification.md
@@ -1,0 +1,76 @@
+# PRD I12 — Dead config keys + notification isolation
+
+**Severity:** Medium (keys that read as supported features; one bad secret silences every channel)
+**Status:** Open
+**Issues:** #141, #143, #146, #155, #172, #187
+**Area:** `internal/config/{types,loader,marshal,restore_types}.go`, `internal/cli/schedule.go`,
+`internal/adapters/notifier/converter.go`
+
+A key that parses, validates and does nothing is worse than an absent one: it reads as a supported
+feature. Each item below states explicitly whether the fix is to **implement** or to **remove**.
+
+## Confirmed defects
+
+| # | Defect | Cause | Direction |
+|---|---|---|---|
+| #141 | `scheduler.max_concurrent_backups` is ignored | `internal/cli/schedule.go:64,165,272` — all three `NewScheduler()` calls pass the **top-level** `cfg.MaxConcurrentBackups`, never `cfg.Scheduler.MaxConcurrentBackups`. `loader.go:72-73` copies top-level into nested as a default; nothing ever reads the nested field afterwards | **IMPLEMENT** — pass the nested value; the loader already supplies the right fallback |
+| #143 | `restore_defaults` is parsed but unreachable | `config/restore_types.go:167-183` — `RestoreConfiguration` / `RestoreDefaults` are never constructed; `LoadConfig` builds only `*Configuration`. `grep "RestoreConfiguration\b"` and `"ApplyRestoreDefaults"` outside their own file → zero non-test hits | **REMOVE** — wiring it needs a second config path that does not exist |
+| #155 | `wal_summary_check` is stored but never probes the server | `config/types.go:126` has no reader. The related `ValidatePostgresIncrementalPrerequisites` (`domain/backup/incremental/prerequisites.go:26`) takes a `walSummaryEnabled` param and is called only from `planner_test.go` — and not even fed from the config field | **DECISION** — see below |
+| #146 | `tls.enabled`'s doc comment claims a default of `true`; the loader defaults it to `false` | `config/types.go:9-10` vs `loader.go` `applyTLSDefaults:139-147`, which sets only `Mode` and never touches `Enabled`, so the zero value wins | **DECISION** — see below |
+| #172 | `restore_options.additional_args` is validated at load then silently discarded | `config/marshal.go:294-317` `BuildRestoreAdditionalArgs` iterates `job.RestoreOptions` for known **bool** flags only (`clean`, `if_exists`, `no_owner`, `no_privileges`, `gzip`) and never reads the `additional_args` **string** key that `restore_types.go:271-278` validates via `backup.ParseAdditionalArgs` | **IMPLEMENT** — thread the string through, reusing the already-invoked parser |
+| #187 | One unresolvable notification secret silences every channel on the job | `adapters/notifier/converter.go:14-92` `NewDispatcherFromConfig` returns `(nil, err)` on the **first** channel construction failure, discarding notifiers already built and never processing the rest. The caller (`cli/backup_factory.go:120-129`) then sets `notif = nil` — no notifications at all | **IMPLEMENT** — per-channel isolation |
+
+## On #187
+
+Architecturally distinct from the rest of this PRD: it is an error-handling blast-radius bug, not a
+dead key. It is grouped here only because it is a config-resolution failure.
+
+**Fail-fast at config load is the wrong fix.** Env var presence is a runtime fact resolved at
+dispatch construction; the static validator's `isValidEnvVarName` can only check the *name format*,
+never whether the variable is set at run time. The correct fix is log-and-skip the failing channel
+and keep building the rest — which is what the issue itself proposes.
+
+**Fix this first in this PRD.** It is the only item where current behaviour actively breaks an
+unrelated, correct configuration: a mistyped Slack secret silences a working email channel.
+
+## DECISION REQUIRED
+
+- **#155** — implement (probe the server for `summarize_wal` via `db_probe` and call
+  `ValidatePostgresIncrementalPrerequisites` from the backup planner when the key is true), or
+  remove the key. It currently reads as a safety check on incremental backup prerequisites and
+  performs none. Pairs with **#185** in I09 — the same dead prerequisite functions. **Decide both
+  together.**
+- **#146** — correcting the comment is honest and risk-free. Correcting the loader to default
+  `Enabled: true` means **`tls:` alone silently enables TLS for every existing config** — a
+  behaviour change with security implications the issue does not ask for. Recommendation: fix the
+  comment. Security call, not a technical one.
+
+## Fix order
+
+1. **#187** — per-channel isolation in `converter.go`.
+2. **#172** and **#141** — small mechanical wiring fixes.
+3. **#143** — deletion, no behaviour risk.
+4. **#146** — whichever the decision resolves to.
+5. **#155** — largest surface; needs new probe wiring and live validation.
+
+## Definition of done
+
+- **Code:** the six items.
+- **e2e** (uses `assert_config_key_changes_behavior` from I00 — this PRD is the reason that helper
+  exists):
+  - Two notification channels, one with an unresolvable `*_env` — run a backup, assert the **other**
+    channel still received its notification.
+  - `scheduler.max_concurrent_backups` set differently from the top-level key — the effective
+    concurrency limit matches the **nested** value.
+  - `restore_options.additional_args: "--foo"` — `--foo` appears in the actual restore-tool
+    invocation. Needs a capture or dry-run seam.
+  - `wal_summary_check: true` against postgres:17 with `summarize_wal=off` — the backup fails or
+    warns instead of silently proceeding. **NEEDS_LIVE.** Only if #155 resolves to "implement".
+  - `config load` with a `tls:` block and no `enabled` key — asserts whichever default #146 resolves
+    to.
+  - After the #143 deletion, no config key named `restore_defaults` is accepted.
+- **Docs:** `concepts/backup.md:101`, `concepts/incremental-pitr.md:167,184` already cite #155 by
+  number and document it as broken. #141, #143, #146, #172 and #187 have **no** doc pages —
+  `alerting-setup.md` covers notifications and is tracked separately as #180 (closed). If #187's fix
+  changes behaviour, the notifications page needs it.
+- **Runbooks:** `docs/runbooks/additional-args.md` is wrong per #172; update it with the fix.

--- a/docs/audit/documentation-batch-defects/I13-staging-disk-budget.md
+++ b/docs/audit/documentation-batch-defects/I13-staging-disk-budget.md
@@ -1,0 +1,68 @@
+# PRD I13 — Concurrent staging disk budget + parallel bound
+
+**Severity:** Medium (N parallel restores can exhaust the disk mid-restore)
+**Status:** Open
+**Issues:** #177, #179.6 (duplicate of #177's secondary claim)
+**Area:** `internal/adapters/restore/runtime/staging.go`, `internal/cli/restore.go`
+
+## Problem
+
+### #177 — parallel restores each check disk capacity alone
+
+`runtime/staging.go:327-344` `ensureStagingCapacity(dir, required)` calls `availableStagingBytes(dir)`
+(`statfs`, `diskspace_unix.go:9`), which reports the **full remaining free space on the filesystem**,
+and compares it against that single job's `required` bytes. There is no shared or reserved budget
+across concurrently staging jobs.
+
+Both call sites (`staging.go:86` and `:150`) are per-job, invoked once per job inside the `--all`
+fan-out. Five jobs each needing 30 GB against 100 GB free: all five preflight checks pass, and the
+disk fills mid-restore.
+
+`handleRestoreRunAll` fans out over a `chan struct{}` semaphore reusing `runOneRestoreJob`
+(spec 045 / PRD 31) — the concurrency mechanism exists; the capacity accounting does not
+participate in it.
+
+### #179.6 — `--parallel` has no upper bound
+
+`internal/cli/restore.go:416-422` `effectiveRestoreConcurrency`: `if parallelFlag > 0 { return parallelFlag }`.
+No clamp anywhere in the file. `internal/config/validator.go:53-54` bounds
+`max_concurrent_restores` to [1,100]; the flag that overrides it is unbounded.
+
+Same duplicate confirmed independently by two agents. `restore run --all --parallel 100000` fans out
+without complaint.
+
+## Related, from I04
+
+`restore run --all` reads the **top-level** `MaxConcurrentRestores` (`restore.go:420-421`) while the
+scheduler reads `cfg.Scheduler.MaxConcurrentRestores` (`schedule.go:93`). Two keys for one concept —
+the same shape as #141 in I12. Worth reconciling in this PRD since it is the same function.
+
+## Fix
+
+1. Reserve and decrement a **shared, mutex-guarded capacity budget** for the duration of staging in
+   `handleRestoreRunAll`'s fan-out, **or** serialise the staging step while keeping the apply step
+   parallel. The second is simpler and costs wall-clock; the first is correct and needs care around
+   the release path on error.
+2. Apply the same [1,100] bound to `--parallel` that `max_concurrent_restores` gets in
+   `validator.go:53-54`.
+3. Reconcile the two `MaxConcurrentRestores` keys, or document why `restore run --all` and the
+   scheduler read different ones.
+
+## DECISION REQUIRED
+
+**Shared budget versus serialised staging.** Serialising staging is a few lines and cannot deadlock;
+it makes `--parallel N` mean "N parallel applies" rather than "N parallel everything", which is a
+user-visible semantics change worth a release note. A shared budget preserves the current semantics
+and is the more invasive change. Pick before implementing — they are not compatible designs.
+
+## Definition of done
+
+- **Code:** the three items.
+- **e2e:**
+  - `--all --parallel N` with N jobs whose staged sizes individually fit but collectively exceed
+    free space — a clean **pre-flight** failure, not a mid-restore `ENOSPC`. **NEEDS_LIVE** (needs a
+    constrained filesystem; a small tmpfs mount is enough).
+  - `restore run --all --parallel 100000` — rejected with a bound error, matching
+    `max_concurrent_restores`.
+- **Docs:** `guides/parallel-restore.md`. Neither issue has an admonition today; the parallel-restore
+  page describes the capacity check as a safety net.

--- a/docs/audit/documentation-batch-defects/I14-monitor-query-surface.md
+++ b/docs/audit/documentation-batch-defects/I14-monitor-query-surface.md
@@ -1,0 +1,88 @@
+# PRD I14 — Monitor query surface + reporting polish
+
+**Severity:** Low to Medium (wrong query results presented as correct; several help-vs-behaviour lies)
+**Status:** Open
+**Issues:** #153, #166, #167.1, #167.2, #167.3, #167.5, #179.1, #179.2, #179.4, #181.2, #181.3 (= #179.5)
+**Area:** `internal/cli/{monitor,monitor_doctor,repair}.go`, `internal/adapters/monitor/{export,init}.go`,
+`internal/config/restore_types.go`
+**Blocked by:** I01 (stdout routing must land before touching the CSV/limit logic — adjacent edits in
+the same file), I02 (the read-only monitor open)
+
+## Problem
+
+The monitor surface answers questions wrongly and confidently. Time filters are silently dropped,
+limits are ignored, and the doctor hides the error text that explains what it found.
+
+Most of these are small. They are grouped because they share two files and because several would
+conflict if fixed separately.
+
+## Confirmed defects
+
+| # | Defect | Cause | Evidence |
+|---|---|---|---|
+| #166 | `monitor stats --last 12h` silently means all time | `monitor.go:~278` `parseLastDays` does `int(duration.Hours()/24)` — 12h truncates to 0; `monitorStatsCmd` only bounds when `days > 0` | rows seeded at now and now-40d; `stats --last 12h` → "Period: all time / Executions: 2". `list --last 12h` correctly returned only the recent row |
+| #167.2 | `list --format csv` ignores `--limit` and `--offset` | `adapters/monitor/export.go:17` hardcodes `ListExecutions(ctx, filter, 100000, 0)`; `printCSV` discards the limit it already read | `list --format csv --limit 1 --last 60d` returned both rows |
+| #153 | `monitor stats` documents `--job` as optional and rejects the command without it | `monitor.go:205` help says "optional; omit for all jobs"; `:76-79` returns `--job is required`. `loadStatistics`'s all-jobs branch (`GetAggregateStatistics`, ~219) is **dead code, unreachable through the CLI** | ran it: `Error: --job is required`, exit 1 |
+| #167.5 | `list` and `export` disagree on defaults and on unknown formats | `monitor.go:196` `list` defaults `--last` to `7d`; `:210` `export` defaults to `""` (whole history). `list`'s format switch falls through to table silently; `export`'s `normalizeFormat` errors | `list --format bogus` → exit 0, table. `export --format bogus` → exit 1. `export` without `--last` returned the 40d-old row, `list` did not |
+| #167.3 | `monitor show <id>` takes a positional the help does not document | `monitor.go:117-120` reads `args[0]`; `Use: "show"` and `--help` omit it | `monitor show exec-1` worked; `show --help` lists no positional |
+| #167.1 | `repair --fix` help claims it marks broken chains | `repair.go:1128` flag text; `detectBrokenChains` (355-431) always sets `Action = "manual action required"`, never gated on `mode.doRecoverable()` | source: no branch marks `chain_broken` applied under `--fix` |
+| #179.4 | `monitor doctor` hides the error and hint in table output | `monitor_doctor.go` `renderDoctorTable` (111-142) never prints `r.Error`, and prints `r.Hint` only for `ForwardIncompatible` — never for `StalePending`, which is exactly what a failed repair leaves behind | forced a real migration failure (`duplicate column name: hash_algorithm`); the table showed status/pending/tables and no error text. `--json` on the same run carried both fields |
+| #181.3 (=#179.5) | `monitor doctor` output has no separator between name and count | `monitor_doctor.go:134-138` `tabwriter.NewWriter(w,0,0,2,' ',tabwriter.AlignRight)` — `AlignRight` left-pads narrower cells, so the widest name in the block gets zero separator | reproduced: `backup_executions42 rows`, `schema_migrations5 rows` |
+| #181.2 | An empty integrity sweep records nothing, so "ran and found nothing" is indistinguishable from "never ran" | `adapters/monitor/recorder.go:141-143` `RecordIntegrityCheck` is an explicit, **tested** no-op when `len(run.Results) == 0` (`TestRecordIntegrityCheck_EmptyRunNoOp`). Default `notify_on: failure` also stays silent (`integrity_scheduled.go:104-107`) | source; the doc comment states the behaviour |
+| #179.1 | `schema_migrations.checksum` is declared and never written | `adapters/monitor/init.go:519` `INSERT INTO schema_migrations (version, name)` omits it; `schema.go:114` declares the column | `sqlite3 history.db "SELECT checksum FROM schema_migrations"` → all NULL after 5 real migrations |
+| #179.2 | A restore job cannot be on-demand-only | `config/restore_types.go:265-267` — `enabled && job.Schedule == ""` is a hard error, no opt-out | config with `enabled: true`, no schedule, valid `backup_source` → "restore schedule (cron) is required" |
+
+## Root cause
+
+Two shared, plus a tail of independents.
+
+**(a)** Pattern **B**, already covered in I01: `monitor`, `repair`, `security` and `storage` use
+`cmd.Print*` and `return nil` inconsistently. #167.5's silent format fallback is the same habit.
+
+**(b)** Pattern **C**: a value is read from the flags and then not threaded to the query — `--last`
+(#166), `--limit`/`--offset` (#167.2). The plumbing stops one hop short of the SQL.
+
+**(c)** Independents: #179.1, #179.2, #181.2, #167.1, #167.3.
+
+## DECISION REQUIRED
+
+- **#153 direction.** `GetAggregateStatistics` already exists and is unreachable. Either wire it up
+  (drop the required-check, honour the documented "omit for all jobs") or fix the help string to say
+  the flag is required. Wiring it is more useful and the code is already written.
+- **#181.2 design.** How should "ran, found nothing" be marked? A zero-result run marker row, or a
+  summary surfaced through `monitor doctor`. This changes the `IntegrityRun` shape and the existing
+  test asserts the current no-op, so the test changes with it. Small decision, needs an answer
+  before implementation.
+- **#179.2** — allow an empty schedule for jobs never registered with the scheduler, or add an
+  explicit `on_demand: true`. The explicit flag is clearer and does not weaken validation for
+  scheduled jobs.
+
+## Fix order
+
+1. **#181.3** and **#167.1** — one-liners (`tabwriter` flag; help text). Do first, zero risk.
+2. **#179.4** — print `r.Error` always, and `r.Hint` for `StalePending` too.
+3. **#166** and **#167.2** — thread the time filter and the limit/offset into the queries. Both in
+   `monitor.go`; land after I01's stdout work to avoid conflicting edits.
+4. **#167.3**, **#167.5** — `Use: "show [id]"`, align the `list`/`export` defaults, make `list`
+   reject unknown formats as `export` does.
+5. **#153**, **#181.2**, **#179.2** — after the decisions above.
+6. **#179.1** — compute and store a per-migration checksum, or drop the unused column.
+
+## Definition of done
+
+- **Code:** the items above.
+- **e2e:**
+  - `stats --last 12h` with a row older than 12h present — that row is excluded.
+  - `list --format csv --limit 1` with 2 matching rows — returns 1.
+  - `monitor stats` without `--job` and several jobs present — returns an aggregate, or errors with
+    help text that says the flag is required. Assert whichever the decision picks.
+  - `monitor doctor` against a DB with ≥2 tables of different name lengths — every row matches
+    `\w+\s+\d+ rows` (the separator is present).
+  - `monitor doctor --repair` against a DB that fails migration — the **table** output contains the
+    error string, not just `--json`.
+  - A sweep filter matching zero backups — a queryable run record exists afterwards.
+  - `list --format bogus` — rejected, matching `export`.
+- **Docs:** `guides/inspect-monitor-history.md`, `guides/monitoring-history.md`,
+  `reference/cli/monitor.md`, `guides/first-backup.md`, `guides/restore.md` (all cite #153 or #166).
+  #167, #179 and #181 sub-defects are largely unindexed — add pointers where a page describes the
+  broken behaviour as working.

--- a/docs/audit/documentation-batch-defects/README.md
+++ b/docs/audit/documentation-batch-defects/README.md
@@ -1,0 +1,168 @@
+# Documentation-batch defects — remediation plan
+
+**Origin:** 54 open `bug` issues (#136–#197), all labelled `found-by-docs`, filed while writing the
+documentation site (spec 060). Tracking issue: #176. Root-cause issue for the whole batch: #175.
+
+**Confirmation pass:** 2026-08-06, eleven parallel read-only agents against `develop` @ `b9fd891`,
+using a reference binary built with `go build -o sentinel .` at that commit.
+
+## Headline result
+
+| | |
+|---|---|
+| Issues examined | 54 |
+| Distinct defects after expanding umbrella issues | **77** |
+| Duplicates found between umbrellas | 4 |
+| Net distinct defects | **73** |
+| CONFIRMED | 70 |
+| PARTIAL (symptom real, stated cause wrong or narrower than reality) | 3 |
+| NOT_REPRODUCED | 0 |
+| ALREADY_FIXED by specs 042–059 | 0 |
+
+Nothing in the batch was a false alarm. Three issues named the wrong cause, and correcting them
+changed the fix in each case (see "Corrections to the issue text" below).
+
+Five issues are umbrellas hiding 28 defects between them: #167 (5), #170 (7), #179 (7), #181 (5),
+#184 (4).
+
+## Why the e2e suite reported success
+
+Three independent mechanisms, none of them a one-off oversight. Full analysis in
+[`I00-e2e-harness-foundation.md`](I00-e2e-harness-foundation.md).
+
+1. **Part of the test suite never runs.** `test_unit` in `scripts/e2e.sh` runs `go test ./...`,
+   which silently skips every `//go:build integration` file. Those run only in a separate workflow.
+2. **The incremental coverage is scenery.** Every scenario in `tests/integration/incremental/` is a
+   `t.Skip("...scaffold...")`. A `grep incremental` finds 22 hits and zero executed assertions.
+3. **The one PITR test cannot see the PITR bug.** `postgres_pitr_restore_test.go` hand-writes its
+   manifest via `WritePITRManifest` and exercises only the planner. It never traverses the
+   backup-time manifest-writing path, which is exactly where #148 lives.
+
+On top of that, the harness's default assertion is `assert_exit_ok` (28 uses). A command that
+validates a config key, ignores it, and exits 0 is indistinguishable from success under that helper.
+That is the dominant shape of this entire defect batch.
+
+## Cross-cutting root causes
+
+Six patterns explain most of the 73 defects. They are the reason this plan groups by cause rather
+than by issue number.
+
+| # | Pattern | Defects |
+|---|---|---|
+| A | **Commands bypass `config_resolver.go`** and reinvent their own config path / validation | #160, #171, #173, #179.3, #181.4 |
+| B | **Success and failure are indistinguishable** — exit 0 on failure, output on stderr | #165, #168, #170.1–.4, #179.7, #181.1 |
+| C | **Config plumbing stops one hop short** — parsed, validated, never threaded to a consumer | #141, #142, #143, #154, #155, #157, #172, #194, #196 |
+| D | **Wired on one axis, forgotten on the other** — dump but not restore, `--all` but not single-job, list but not status | #139, #140, #156, #161, #181.1, #184.3, #189 |
+| E | **The validator accepts what the runtime rejects** | #145, #183, #185, #186 |
+| F | **Artifact identity is lost between dump and manifest** | #151, #164, #184.2, #191, #193 |
+
+## Corrections to the issue text
+
+These three would have led to a wrong or wasted fix if taken at face value.
+
+- **#157** — the hardcoded `dryRun=false` is at `internal/cli/backup.go:617`, not at the cited
+  `backup_factory.go:313`. The cited site builds `djob.Retention`, and **that field is read nowhere
+  in the domain**. Fixing the cited line changes nothing.
+- **#164** — "every dump adapter" is wrong for MongoDB. `mongodump` streams to disk via
+  `--archive`/`--out`; only pg, mysql and mariadb buffer the dump in a `bytes.Buffer`. Mongo's real
+  defect is different and is #191.
+- **#195** — the claim that `repair --fix` carries the same hazard is **false**. `repair.go:437-509`
+  does not call `ReconcileStaleExecutions`; it has its own lock-aware reconciliation that checks
+  `ReadLock` + `EvaluateLockState` + hostname. The fix is to make `schedule start` call the logic
+  repair already has, not to change repair.
+
+Two defects were found that no issue covers:
+
+- **#171 extra** — `swapArtifact`'s remote branch (`security_reencrypt.go:503-534`) returns
+  `destObject` (the artifact key) where `RecordSecurityInfo` expects `manifestPath`. The local
+  branch at line 552 is correct. Remote-only.
+- **#151 extra** — the same `Job.OutName` staleness makes `res.ArtifactPath` resolve to `"unknown"`.
+  **The execution history is broken, not just the manifest.**
+
+## Duplicates between umbrella issues
+
+Fix once, close both.
+
+| Duplicate pair | Subject |
+|---|---|
+| #167.4 = #170.3 | `repair --job <unknown>` exits 0 reporting "no drift" |
+| #170.4 = #168 | `retention apply` without `--job` swallows errors and exits 0 |
+| #179.5 = #181.3 | `tabwriter.AlignRight` collapses the separator: `backup_executions42 rows` |
+| #179.6 = #177 (secondary) | `--parallel` has no upper bound, unlike `max_concurrent_restores` |
+
+## Execution order
+
+The ordering is driven by observability first, then by load-bearing structural fixes, then by
+independent work. **I00 and I01 come first because without them no later fix is verifiable** — the
+harness cannot currently tell a fix from a no-op.
+
+```
+I00  e2e harness foundation          ── blocks everything, land the cheap half first
+ │
+I01  CLI honesty (exit codes/stdout) ── makes every later failure visible
+ │
+ ├─ I02  config-loading unification ──┐
+ ├─ I03  secret redaction + Mongo TLS │  (security, land early, independent)
+ ├─ I04  backup locking ──────────────┤  #163 is load-bearing for I05 and I10
+ ├─ I06  artifact identity ───────────┼─→ I07  dump streaming + Mongo artifact
+ ├─ I08  compression + validation order
+ ├─ I09  restore planner (PITR/incremental)
+ ├─ I10  restore/schedule command state
+ ├─ I11  storage backends + schema drift
+ ├─ I12  dead config + notification isolation
+ └─ I13  staging disk budget
+        │
+        └─ I05  retention correctness  (after I01: #168 is what makes the rest visible)
+```
+
+| PRD | Title | Issues | Defects | Blocked by |
+|---|---|---|---|---|
+| [I00](I00-e2e-harness-foundation.md) | e2e harness foundation | #175 | 7 tasks | — |
+| [I01](I01-cli-honesty-exit-codes.md) | CLI honesty: exit codes, stdout, usage noise | #165, #168, #170.1–.6, #179.7, #181.1, #181.5 | 10 | I00 (partial) |
+| [I02](I02-config-loading-unification.md) | Config-loading unification + read-only monitor | #160, #171, #173, #179.3, #181.4 | 5 | — |
+| [I03](I03-secret-redaction-mongo-tls.md) | Secret redaction + MongoDB TLS wiring | #156, #189 | 2 | — |
+| [I04](I04-backup-locking.md) | Backup file locking + lock plumbing + timeouts | #142, #154, #163, #194, #195, #196, #197 | 7 | — |
+| [I05](I05-retention-correctness.md) | Retention correctness | #157, #158, #159, #169, #170.7, #182 | 6 | I01 |
+| [I06](I06-artifact-identity.md) | Artifact identity: output naming, manifest, history | #151, #184.2, #193 | 3 | — |
+| [I07](I07-dump-streaming.md) | Dump streaming + Mongo local artifact | #164, #191 | 2 | I06 |
+| [I08](I08-compression-validation-order.md) | Compression wiring + validation ordering | #183, #188 | 2 | — |
+| [I09](I09-restore-planner.md) | Restore planner: PITR, incremental, dry-run, verify | #148, #149, #150, #152, #185, #186, #190 | 7 | — |
+| [I10](I10-command-state-registration.md) | Restore/schedule command state + registration | #136, #137, #138, #139, #140 | 5 | — |
+| [I11](I11-storage-schema-drift.md) | Storage backends + config schema drift | #144, #145, #161, #184.1, #184.3, #184.4 | 6 | — |
+| [I12](I12-dead-config-notification.md) | Dead config keys + notification isolation | #141, #143, #146, #155, #172, #187 | 6 | — |
+| [I13](I13-staging-disk-budget.md) | Concurrent staging disk budget | #177, #179.6 | 2 | — |
+| [I14](I14-monitor-query-surface.md) | Monitor query surface + reporting polish | #153, #166, #167.1–.3, #167.5, #179.1, #179.2, #179.4, #181.2, #181.3 | 11 | I01, I02 |
+
+**Coverage check.** All 54 open `bug` issues appear in exactly one PRD, verified mechanically. The
+five umbrella issues are split across PRDs by sub-defect, so #167, #170, #179, #181 and #184 each
+appear in more than one row above — every individual sub-defect still has exactly one owner. #175
+and #176 are the e2e root cause and the tracking issue, both owned by I00.
+
+## Standing rules for every PRD in this directory
+
+Each of these is a required task in the PRD's own definition of done, not a nice-to-have.
+
+1. **The e2e assertion ships with the fix.** Every PRD names the assertion that would have caught
+   its defect, and that assertion lands in the same PR. Deferring the coverage to #175 is how this
+   batch happened.
+2. **The documentation site is updated in the same PR.** Every affected page carries a
+   `:::caution` / `:::warning` naming the issue number. `grep -rl "<issue>" website/docs/` finds
+   every page that has to change. Per PRD, the affected pages are listed explicitly.
+3. **Runbook maintenance is a Polish-phase task**, per the standing process rule. `docs/runbooks/`
+   is the preserved corpus; where a runbook and the code disagree after the fix, the runbook is
+   updated, not the site.
+4. **Decisions marked "DECISION REQUIRED" are not the implementer's to make.** They are product or
+   security calls: implement-vs-remove, or a behaviour change with a blast radius on existing
+   configs. Raise them, do not default them.
+
+## Live reproduction status
+
+Every verdict in this plan was settled **statically or against the reference binary, without
+Docker**. The following need live infrastructure to prove the *fix*, not the defect:
+
+#149, #154, #155, #163, #164, #169 (gdrive half), #177, #182, #185, #189 (TLS half), #190, #194,
+#195, #196, #197, #171 (remote half).
+
+Parallel agents cannot share the Docker infra naively: fixed ports, shared DB state, a common
+`lock_dir` and colliding output directories. Live verification must either be serialised or
+namespaced per agent (distinct job names, databases and output paths).

--- a/docs/audit/documentation-batch-defects/README.md
+++ b/docs/audit/documentation-batch-defects/README.md
@@ -155,6 +155,16 @@ Each of these is a required task in the PRD's own definition of done, not a nice
    security calls: implement-vs-remove, or a behaviour change with a blast radius on existing
    configs. Raise them, do not default them.
 
+## Resolved decisions
+
+| Date | Subject | Resolution |
+|---|---|---|
+| 2026-08-06 | **#148 — PITR** | **Implement. PITR is a required feature and is not to be withdrawn.** Rejecting `restore_mode: pitr` at config load, or removing it from the README, are off the table. If the recoverable-window plumbing outgrows I09, it gets its own spec — it does not get descoped. |
+| 2026-08-06 | **#149 — restore verification** | **Implement**, by consequence of the above. `domain/restore/executor.go:320-323` sets `requiresVerification` for `RestoreMode == "pitr"`, so a working PITR restore cannot exist without a real verification handler. The "reject the flag" option is unavailable. |
+| 2026-08-06 | **I00 item 2 — the `t.Skip` scaffolds** | Make them **fail loudly** with a message naming I09, rather than deleting them or implementing them now. Removes the false coverage signal without discarding the skeleton; they convert to real assertions when I09 lands its fixtures. |
+
+Ten decisions remain open. None of them block the first slice (I00 + I01).
+
 ## Live reproduction status
 
 Every verdict in this plan was settled **statically or against the reference binary, without


### PR DESCRIPTION
Adds `docs/audit/documentation-batch-defects/` — the confirmation pass and remediation plan for the 54 open `bug` issues labelled `found-by-docs` (#136–#197). No Go code changes.

## What was done

Every one of the 54 issues was reproduced or refuted against `develop` @ `b9fd891`, using a reference binary built at that commit. Eleven read-only agents, one per root-cause cluster.

| | |
|---|---|
| Issues examined | 54 |
| Distinct defects once the five umbrella issues are expanded | 77 |
| Net after dedup | 73 |
| CONFIRMED | 70 |
| PARTIAL (symptom real, stated cause wrong) | 3 |
| NOT_REPRODUCED | 0 |
| ALREADY_FIXED by specs 042–059 | 0 |

Nothing in the batch was a false alarm.

## Why the e2e suite reported success

Three structural mechanisms, not a coverage shortfall:

1. `test_unit` in `scripts/e2e.sh` runs `go test ./...`, which silently skips every `//go:build integration` file.
2. Every scenario in `tests/integration/incremental/` is a `t.Skip("...scaffold...")`. A grep finds 22 hits and zero executed assertions.
3. `postgres_pitr_restore_test.go` hand-builds its manifest via `WritePITRManifest` and exercises only the planner, so it never traverses the backup-time manifest-writing path where #148 lives.

On top of that the default assertion is `assert_exit_ok` (28 uses). A command that validates a key, ignores it and exits 0 is indistinguishable from success under it — which is the dominant shape of this whole batch.

## Structure

15 units grouped by root cause rather than by issue number, since most defects share a file and a cause. Six cross-cutting patterns account for the bulk; the two largest are commands that bypass `config_resolver.go`, and config plumbing that stops one hop short of its consumer.

I00 (e2e harness) and I01 (exit codes, stdout routing) come first on purpose: until they land, the harness cannot tell a fix from a no-op.

## Corrections to the issue text

Three issues named the wrong cause. Each correction changes the fix:

- **#157** — the hardcoded `dryRun=false` is at `cli/backup.go:617`, not the cited site, whose field is dead.
- **#164** — "every dump adapter" is wrong for MongoDB; `mongodump` streams to disk. Mongo's real defect is #191.
- **#195** — `repair --fix` does **not** carry the same hazard; it already has lock-aware reconciliation. Changing it would damage working code.

Two defects were also found that no issue covers: `swapArtifact`'s remote branch records the artifact key where a manifest path is expected, and the `Job.OutName` staleness behind #151 also breaks the execution history (`ArtifactPath` resolves to `"unknown"`), not just the manifest.

## Decisions

Twelve product and security calls are raised rather than defaulted. Three are already resolved and recorded in the README: PITR is required and will not be withdrawn, restore verification follows from it, and the `t.Skip` scaffolds will fail loudly pointing at I09.

https://claude.ai/code/session_011TGto1Ya4gG45iFNeNM287
